### PR TITLE
Minor fixes while building openjdk in native env (without docker)

### DIFF
--- a/makejdk.sh
+++ b/makejdk.sh
@@ -202,5 +202,5 @@ if [ "${USE_DOCKER}" ] ; then
 
 else
   echo "Calling sbin/build.sh $WORKING_DIR $TARGET_DIR"
-  $WORKING_DIR/sbin/build.sh $WORKING_DIR $TARGET_DIR
+  $WORKING_DIR/sbin/build.sh $WORKING_DIR $TARGET_DIR $OPENJDK_REPO_NAME
 fi

--- a/makejdk.sh
+++ b/makejdk.sh
@@ -25,6 +25,7 @@
 # You can set the JDK boot directory with the JDK_BOOT_DIR environment variable
 
 REPOSITORY=AdoptOpenJDK/openjdk-jdk8u
+OPENJDK_REPO_NAME=openjdk
 
 # Escape code
 esc=`echo -en "\033"`
@@ -119,9 +120,9 @@ else
 fi
 
 echo $git
-if [ -d "$WORKING_DIR"/openjdk/.git ] && [ $REPOSITORY == "AdoptOpenJDK/openjdk-jdk8u" ] ; then
+if [ -d "$WORKING_DIR"/$OPENJDK_REPO_NAME/.git ] && [ $REPOSITORY == "AdoptOpenJDK/openjdk-jdk8u" ] ; then
   # It does exist and it's a repo other than the AdoptOpenJDK one
-  cd $WORKING_DIR/openjdk
+  cd $WORKING_DIR/$OPENJDK_REPO_NAME
   echo "${info}Will reset the repository at $PWD in 10 seconds...${git}"
   sleep 10
   echo "${git}Pulling latest changes from git repo"
@@ -129,15 +130,15 @@ if [ -d "$WORKING_DIR"/openjdk/.git ] && [ $REPOSITORY == "AdoptOpenJDK/openjdk-
   git reset --hard origin/$BRANCH
   echo $normal
   cd $WORKING_DIR
-elif [ ! -d "${WORKING_DIR}"/openjdk/.git ] ; then
+elif [ ! -d "${WORKING_DIR}"/$OPENJDK_REPO_NAME/.git ] ; then
   # If it doesn't exixt, clone it
   echo "${info}Didn't find any existing openjdk repository at WORKING_DIR (set to ${WORKING_DIR}) so cloning the source to openjdk"
   if [[ "${USE_SSH}" == true ]] ; then
-    echo "git clone -b ${BRANCH} git@github.com:${REPOSITORY}.git $WORKING_DIR/openjdk"
-    git clone -b ${BRANCH} git@github.com:${REPOSITORY}.git $WORKING_DIR/openjdk
+    echo "git clone -b ${BRANCH} git@github.com:${REPOSITORY}.git $WORKING_DIR/$OPENJDK_REPO_NAME"
+    git clone -b ${BRANCH} git@github.com:${REPOSITORY}.git $WORKING_DIR/$OPENJDK_REPO_NAME
   else
-    echo "git clone -b ${BRANCH} https://github.com/${REPOSITORY}.git $WORKING_DIR/openjdk"
-    git clone -b ${BRANCH} https://github.com/${REPOSITORY}.git $WORKING_DIR/openjdk
+    echo "git clone -b ${BRANCH} https://github.com/${REPOSITORY}.git $WORKING_DIR/$OPENJDK_REPO_NAME"
+    git clone -b ${BRANCH} https://github.com/${REPOSITORY}.git $WORKING_DIR/$OPENJDK_REPO_NAME
   fi
 fi
 echo $normal
@@ -175,10 +176,10 @@ if [ "${USE_DOCKER}" ] ; then
      echo $normal
   fi
 
-  docker run --privileged -t -v $WORKING_DIR/openjdk:/openjdk/jdk8u/openjdk --entrypoint build.sh $CONTAINER
+  docker run --privileged -t -v $WORKING_DIR/$OPENJDK_REPO_NAME:/openjdk/jdk8u/openjdk --entrypoint build.sh $CONTAINER
 
   if [[ ! -z $JTREG ]]; then
-    docker run --privileged -t -v $WORKING_DIR/openjdk:/openjdk/jdk8u/openjdk --entrypoint jtreg.sh $CONTAINER
+    docker run --privileged -t -v $WORKING_DIR/$OPENJDK_REPO_NAME:/openjdk/jdk8u/openjdk --entrypoint jtreg.sh $CONTAINER
   fi
 
   CONTAINER_ID=$(docker ps -a | awk '{ print $1,$2 }' | grep openjdk_container | awk '{print $1 }'| head -1)
@@ -201,5 +202,5 @@ if [ "${USE_DOCKER}" ] ; then
 
 else
   echo "Calling sbin/build.sh $WORKING_DIR $TARGET_DIR"
-  ./sbin/build.sh $WORKING_DIR $TARGET_DIR
+  $WORKING_DIR/sbin/build.sh $WORKING_DIR $TARGET_DIR
 fi

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -85,7 +85,8 @@ if [[ ! -z $FOUND_FREETYPE ]] ; then
   echo "Skipping FreeType download"
 else
   # Then FreeType for fonts: make it and use
-  wget -nc http://download.savannah.gnu.org/releases/freetype/freetype-2.4.0.tar.gz
+  
+  wget -nc http://ftp.acc.umu.se/mirror/gnu.org/savannah/freetype/freetype-2.4.0.tar.gz
   tar xvf freetype-2.4.0.tar.gz
   rm freetype-2.4.0.tar.gz
 

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -96,7 +96,7 @@ else
   fi
    
   # We get the files we need at $WORKING_DIR/installedfreetype
-  ./configure --prefix=$WORKING_DIR/openjdk/installedfreetype $PARAMS && make all && make install
+  ./configure --prefix=$WORKING_DIR/$OPENJDK_REPO_NAME/installedfreetype $PARAMS && make all && make install
 
   if [ $? -ne 0 ]; then
     echo "${error}Failed to configure and build libfreetype, exiting"
@@ -165,7 +165,7 @@ CONFIGURE_CMD="$CONFIGURE_CMD --with-debug-level=release"
 
 # Make sure we're in the source directory for OpenJDK now
 
-cd $WORKING_DIR/openjdk
+cd $WORKING_DIR/$OPENJDK_REPO_NAME
 
 echo "Should have the source, I'm at $PWD"
 

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -18,6 +18,7 @@
 
 WORKING_DIR=$1
 TARGET_DIR=$2
+OPENJDK_REPO_NAME=$3
 
 # Escape code
 esc=`echo -en "\033"`
@@ -78,7 +79,7 @@ fi
 
 echo "Checking for freetype"
 
-FOUND_FREETYPE=$(find "$WORKING_DIR/installedfreetype/lib" -name "libfreetype.so.6.5.0")
+FOUND_FREETYPE=$(find "$WORKING_DIR/$OPENJDK_REPO_NAME/installedfreetype/lib" -name "libfreetype.so.6.5.0")
 
 if [[ ! -z $FOUND_FREETYPE ]] ; then
   echo "Skipping FreeType download"
@@ -95,7 +96,7 @@ else
   fi
    
   # We get the files we need at $WORKING_DIR/installedfreetype
-  ./configure --prefix=$WORKING_DIR/installedfreetype $PARAMS && make all && make install
+  ./configure --prefix=$WORKING_DIR/openjdk/installedfreetype $PARAMS && make all && make install
 
   if [ $? -ne 0 ]; then
     echo "${error}Failed to configure and build libfreetype, exiting"
@@ -149,7 +150,7 @@ fi
 
 CONFIGURE_CMD="$CONFIGURE_CMD --with-cacerts-file=$WORKING_DIR/cacerts_area/security/cacerts"
 CONFIGURE_CMD="$CONFIGURE_CMD --with-alsa=$WORKING_DIR/alsa-lib-1.0.27.2"
-CONFIGURE_CMD="$CONFIGURE_CMD --with-freetype=$WORKING_DIR/installedfreetype"
+CONFIGURE_CMD="$CONFIGURE_CMD --with-freetype=$WORKING_DIR/$OPENJDK_REPO_NAME/installedfreetype"
 
 # These will have been installed by the package manager (see our Dockerfile)
 CONFIGURE_CMD="$CONFIGURE_CMD --with-x=/usr/include/X11"
@@ -158,7 +159,7 @@ CONFIGURE_CMD="$CONFIGURE_CMD --with-x=/usr/include/X11"
 # other options include fastdebug and slowdebug
 CONFIGURE_CMD="$CONFIGURE_CMD --with-debug-level=release"
 
-#CONFIGURE_CMD="$CONFIGURE_CMD --with-adds-and-overrides=$WORKING_DIR/openjdk/addsandoverrides"
+#CONFIGURE_CMD="$CONFIGURE_CMD --with-adds-and-overrides=$WORKING_DIR/$OPENJDK_REPO_NAME/addsandoverrides"
 
 ###########################################
 


### PR DESCRIPTION
Fixed a abs/relative path issue, also replaced hard-coded references to openjdk repo folder name with a variable