### PR TITLE
Make Changes to Allow Jenkins to Parse Jtreg Test Results

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Repository for useful files to build OpenJDK
- 
+
 AdoptOpenJDK makes use of these scripts to provide a build farm at http://ci.adoptopenjdk.net which produces OpenJDK binaries for consumption via http://www.adoptopenjdk.net
 
 ## This repository contains three folders and one script you should be calling to build OpenJDK

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Repository for useful files to build OpenJDK
-
+ 
 AdoptOpenJDK makes use of these scripts to provide a build farm at http://ci.adoptopenjdk.net which produces OpenJDK binaries for consumption via http://www.adoptopenjdk.net
 
 ## This repository contains three folders and one script you should be calling to build OpenJDK

--- a/sbin/jtreg.sh
+++ b/sbin/jtreg.sh
@@ -36,7 +36,7 @@ echo $PRODUCT_HOME
 ls $PRODUCT_HOME
 
 # Download then add jtreg to our path
-wget https://adopt-openjdk.ci.cloudbees.com/job/jtreg/lastSuccessfulBuild/artifact/jtreg-4.2.0-tip.tar.gz
+wget https://ci.adoptopenjdk.net/job/jtreg/lastSuccessfulBuild/artifact/jtreg-4.2.0-tip.tar.gz
 
 if [ $? -ne 0 ]; then
   echo "Failed to retrieve the jtreg binary, exiting"

--- a/sbin/jtreg.sh
+++ b/sbin/jtreg.sh
@@ -61,7 +61,7 @@ echo "Apply JCov settings to Makefile..."
 cd $WORKING_DIR/$OPENJDK_REPO_NAME/jdk/test
 pwd
 
-sed -i 's/-vmoption:-Xmx512m.*/-vmoption:-Xmx512m -jcov\/classes:$(ABS_PLATFORM_BUILD_ROOT)\/jdk\/classes\/  -jcov\/source:$(ABS_PLATFORM_BUILD_ROOT)\/..\/..\/jdk\/src\/java\/share\/classes  -jcov\/include:*/' Makefile
+sed -i 's/-vmoption:-Xmx512m.*/-vmoption:-Xmx512m -xml:verify -jcov\/classes:$(ABS_PLATFORM_BUILD_ROOT)\/jdk\/classes\/  -jcov\/source:$(ABS_PLATFORM_BUILD_ROOT)\/..\/..\/jdk\/src\/java\/share\/classes  -jcov\/include:*/' Makefile
 
 # This is the JDK we'll test
 export PRODUCT_HOME=$WORKING_DIR/$OPENJDK_REPO_NAME/build/$BUILD_FULL_NAME/images/j2sdk-image


### PR DESCRIPTION
Right now the plan seems to be:

- Make the xml results (from the jtreg run) visible.
- Get Jenkins to parse it.
- Make sure Jenkins lists the job as "failed" when the tests fail.