### PR TITLE
Extra arguments for jtreg execution

### DIFF
--- a/sbin/jtreg.sh
+++ b/sbin/jtreg.sh
@@ -68,8 +68,7 @@ export JTREG_HOME=${JTREG_INSTALL}
 export JPRT_JTREG_HOME=${JT_HOME}
 export JPRT_JAVA_HOME=${PRODUCT_HOME}
 export JTREG_TIMEOUT_FACTOR=5
-export CONCURRENCY=2
-export EXTRA_JTREG_OPTIONS='-xml:verify -jcov\/classes:$(ABS_PLATFORM_BUILD_ROOT)\/jdk\/classes\/  -jcov\/source:$(ABS_PLATFORM_BUILD_ROOT)\/..\/..\/jdk\/src\/java\/share\/classes  -jcov\/include:*'
+export EXTRA_JTREG_OPTIONS='-concurrency:2 -xml:verify -jcov\/classes:$(ABS_PLATFORM_BUILD_ROOT)\/jdk\/classes\/  -jcov\/source:$(ABS_PLATFORM_BUILD_ROOT)\/..\/..\/jdk\/src\/java\/share\/classes  -jcov\/include:*'
 
 
 make test jobs=10 LOG=debug

--- a/sbin/jtreg.sh
+++ b/sbin/jtreg.sh
@@ -57,12 +57,6 @@ rm -f jtreg*.tar.gz
 
 echo "Running jtreg via make command"
 
-echo "Apply JCov settings to Makefile..." 
-cd $WORKING_DIR/$OPENJDK_REPO_NAME/jdk/test
-pwd
-
-sed -i 's/-vmoption:-Xmx512m.*/-vmoption:-Xmx512m -xml:verify -jcov\/classes:$(ABS_PLATFORM_BUILD_ROOT)\/jdk\/classes\/  -jcov\/source:$(ABS_PLATFORM_BUILD_ROOT)\/..\/..\/jdk\/src\/java\/share\/classes  -jcov\/include:*/' Makefile
-
 # This is the JDK we'll test
 export PRODUCT_HOME=$WORKING_DIR/$OPENJDK_REPO_NAME/build/$BUILD_FULL_NAME/images/j2sdk-image
 cd $WORKING_DIR/$OPENJDK_REPO_NAME
@@ -74,7 +68,9 @@ export JTREG_HOME=${JTREG_INSTALL}
 export JPRT_JTREG_HOME=${JT_HOME}
 export JPRT_JAVA_HOME=${PRODUCT_HOME}
 export JTREG_TIMEOUT_FACTOR=5
-export CONCURRENCY=8
+export CONCURRENCY=2
+export EXTRA_JTREG_OPTIONS='-xml:verify -jcov\/classes:$(ABS_PLATFORM_BUILD_ROOT)\/jdk\/classes\/  -jcov\/source:$(ABS_PLATFORM_BUILD_ROOT)\/..\/..\/jdk\/src\/java\/share\/classes  -jcov\/include:*'
+
 
 make test jobs=10 LOG=debug
 


### PR DESCRIPTION
The original plan for this branch was to add a series of options onto the jtreg command line.

However, the debug output from an earlier job shows us that these options are all used by default.

In the process of learning this, I discovered that there appears to be a variable defined entirely for the purpose of allowing the user to set jtreg command-line options without having to directly edit the makefile (which is what we used to do, using sed).

So now I'm moving us from sed to this environment variable.