### PR TITLE
Refactoring + some enhancements to build scripts

### DIFF
--- a/makejdk.sh
+++ b/makejdk.sh
@@ -26,8 +26,8 @@
 
 REPOSITORY=AdoptOpenJDK/openjdk-jdk8u
 OPENJDK_REPO_NAME=openjdk
-OS_KERNAL_NAME=$(echo `uname` | awk '{print tolower($0)}')
-OS_MACHINE=`uname -m`
+OS_KERNAL_NAME=$(echo $(uname) | awk '{print tolower($0)}')
+OS_MACHINE=$(uname -m)
 BUILD_TYPE=normal
 JVM_VARIANT=server
 
@@ -38,14 +38,14 @@ fi
 BUILD_FULL_NAME=$OS_KERNAL_NAME-$OS_MACHINE-$BUILD_TYPE-$JVM_VARIANT-release
 
 # Escape code
-esc=`echo -en "\033"`
+esc=$(echo -en "\033")
 
 # Set colors
 error="${esc}[0;31m"
 good="${esc}[0;32m"
 info="${esc}[0;33m"
 git="${esc}[0;34m"
-normal=`echo -en "${esc}[m\017"`
+normal=$(echo -en "${esc}[m\017")
 
 source sbin/signalhandler.sh
 
@@ -154,9 +154,9 @@ fi
 echo $normal
 
 if [ "${USE_DOCKER}" ] ; then
-  PS_DOCKER=`ps -ef | grep "docker" | wc -l`
+  PS_DOCKER=$(ps -ef | grep "docker" | wc -l)
 
-  if [ -z `which docker` ] || [ ${PS_DOCKER} -lt 2 ]; then
+  if [ -z $(which docker) ] || [ ${PS_DOCKER} -lt 2 ]; then
     echo "${error}Error, please install docker and ensure that it is in your path and running!${normal}"
     exit
   fi
@@ -174,7 +174,7 @@ if [ "${USE_DOCKER}" ] ; then
   # Keep is undefined so we'll kill the docker image
 
   if [[ $KEEP == true ]] ; then
-     if [ `docker ps -a | grep openjdk_container | wc -l` == 0 ]; then
+     if [ $(docker ps -a | grep openjdk_container | wc -l) == 0 ]; then
          echo "${info}No docker container found so creating one${normal}"
          docker build -t $CONTAINER docker/jdk8u/x86_64/ubuntu
      fi

--- a/makejdk.sh
+++ b/makejdk.sh
@@ -211,7 +211,7 @@ if [ "${USE_DOCKER}" ] ; then
   fi
 
 else  
-  echo "Calling sbin/build.sh $WORKING_DIR $TARGET_DIR $BUILD_FULL_NAME"
+  echo "Calling sbin/build.sh $WORKING_DIR $TARGET_DIR $BUILD_FULL_NAME $JVM_VARIANT"
   $WORKING_DIR/sbin/build.sh $WORKING_DIR $TARGET_DIR $OPENJDK_REPO_NAME $BUILD_FULL_NAME $JVM_VARIANT
 
   if [[ ! -z $JTREG ]]; then

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -23,14 +23,14 @@ BUILD_FULL_NAME=$4
 JVM_VARIANT=${5:=normal}
 
 # Escape code
-esc=`echo -en "\033"`
+esc=$(echo -en "\033")
 
 # Set colors
 error="${esc}[0;31m"
 good="${esc}[0;32m"
 info="${esc}[0;33m"
 git="${esc}[0;34m"
-normal=`echo -en "${esc}[m\017"`
+normal=$(echo -en "${esc}[m\017")
 
 
 # If on docker
@@ -94,8 +94,8 @@ else
 
   cd freetype-2.4.0
 
-  if [ `uname -m` = "ppc64le" ]; then
-    PARAMS="--build=`rpm --eval %{_host}`"
+  if [ $(uname -m) = "ppc64le" ]; then
+    PARAMS="--build=$(rpm --eval %{_host})"
   fi
    
   # We get the files we need at $WORKING_DIR/installedfreetype
@@ -143,7 +143,7 @@ echo "Boot dir set to $JDK_BOOT_DIR"
 
 CONFIGURE_CMD=" --with-boot-jdk=$JDK_BOOT_DIR"
 
-if [ ! -z `which ccache` ]; then
+if [ ! -z $(which ccache) ]; then
   CONFIGURE_CMD="$CONFIGURE_CMD --enable-ccache"
 fi
 
@@ -191,7 +191,7 @@ fi
 
 ###########################################
 
-if [ `uname -m` == "s390x" ]; then
+if [ $(uname -m) == "s390x" ]; then
   makeCMD='make CONF=$BUILD_FULL_NAME DEBUG_BINARIES=true images'
 else
   makeCMD='make images'

--- a/sbin/jtreg.sh
+++ b/sbin/jtreg.sh
@@ -63,24 +63,6 @@ applyingJConvSettingsToMakefileForTests()
   cd $WORKING_DIR/$OPENJDK_REPO_NAME/
 }
 
-setEnvironmentVariablesForJtreg() 
-{
-  echo "Setting up environment variables for JTREG to run"
-  # This is the JDK we'll test
-  export PRODUCT_HOME=$WORKING_DIR/$OPENJDK_REPO_NAME/build/$BUILD_FULL_NAME/images/j2sdk-image
-  echo $PRODUCT_HOME
-  ls $PRODUCT_HOME
-
-  export JTREG_DIR=$WORKING_DIR/jtreg
-  export JTREG_INSTALL=${JTREG_DIR}
-  export JT_HOME=${JTREG_INSTALL}
-  export JTREG_HOME=${JTREG_INSTALL}
-  export JPRT_JTREG_HOME=${JT_HOME}
-  export JPRT_JAVA_HOME=${PRODUCT_HOME}
-  export JTREG_TIMEOUT_FACTOR=5
-  export CONCURRENCY=8
-}
-
 runJtregViaMakeCommand()
 {
   echo "Running jtreg via make command (debug logs enabled)"
@@ -130,6 +112,21 @@ packageReports()
 checkIfWeAreRunningInTheDockerEnvironment
 downloadJtregAndSetupEnvironment
 applyingJConvSettingsToMakefileForTests
-setEnvironmentVariablesForJtreg
+
+echo "Setting up environment variables for JTREG to run"
+# This is the JDK we'll test
+export PRODUCT_HOME=$WORKING_DIR/$OPENJDK_REPO_NAME/build/$BUILD_FULL_NAME/images/j2sdk-image
+echo $PRODUCT_HOME
+ls $PRODUCT_HOME
+
+export JTREG_DIR=$WORKING_DIR/jtreg
+export JTREG_INSTALL=${JTREG_DIR}
+export JT_HOME=${JTREG_INSTALL}
+export JTREG_HOME=${JTREG_INSTALL}
+export JPRT_JTREG_HOME=${JT_HOME}
+export JPRT_JAVA_HOME=${PRODUCT_HOME}
+export JTREG_TIMEOUT_FACTOR=5
+export CONCURRENCY=8
+
 runJtregViaMakeCommand
 packageReports

--- a/sbin/jtreg.sh
+++ b/sbin/jtreg.sh
@@ -33,7 +33,7 @@ downloadJtregAndSetupEnvironment()
 {
   # Download then add jtreg to our path
   echo "Downloading Jtreg binary"
-  wget https://ci.adoptopenjdk.net/view/jdk%20tools/job/jtreg/lastSuccessfulBuild/artifact/jtreg-4.2.0-tip.tar.gz
+    wget https://ci.adoptopenjdk.net/view/OpenJDK%20code-tools/job/jtreg/lastSuccessfulBuild/artifact/jtreg-4.2.0-tip.tar.gz
 
   if [ $? -ne 0 ]; then
     echo "Failed to retrieve the jtreg binary, exiting"
@@ -84,7 +84,7 @@ setEnvironmentVariablesForJtreg()
 
 runJtregViaMakeCommand()
 {
-  echo "Running jtreg via make command"
+  echo "Running jtreg via make command (debug logs enabled)"
   make test jobs=10 LOG=debug  
 }
 

--- a/sbin/jtreg.sh
+++ b/sbin/jtreg.sh
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+  
 WORKING_DIR=$1
 OPENJDK_REPO_NAME=$2
 BUILD_FULL_NAME=$3
@@ -31,28 +31,31 @@ checkIfWeAreRunningInTheDockerEnvironment()
 downloadJtregAndSetupEnvironment() 
 {
   # Download then add jtreg to our path
-  echo "Downloading Jtreg binary"
+
+  JTREG_BINARY_FILE=jtreg-4.2.0-tip.tar.gz
+  JTREG_TARGET_FOLDER=jtreg
+
   if [[ ! -d $WORKING_DIR/jtreg ]]; then
-    wget https://ci.adoptopenjdk.net/job/jtreg/lastSuccessfulBuild/artifact/jtreg-4.2.0-tip.tar.gz
+   echo "Downloading Jtreg binary"
+   wget https://ci.adoptopenjdk.net/job/jtreg/lastSuccessfulBuild/artifact/$JTREG_BINARY_FILE
 
-    if [ $? -ne 0 ]; then
-      echo "Failed to retrieve the jtreg binary, exiting"
-      exit
-    fi
+   if [ $? -ne 0 ]; then
+     echo "Failed to retrieve the jtreg binary, exiting"
+     exit
+   fi
 
-    tar xvf *.tar.gz
-
-    mv jtreg* $WORKING_DIR
+   tar xvf $JTREG_BINARY_FILE
   fi
 
-  ls $WORKING_DIR/jtreg*
+  echo "List contents of jtreg"
+  ls $WORKING_DIR/$JTREG_TARGET_FOLDER/*
 
-  export PATH=$WORKING_DIR/jtreg/bin:$PATH
+  export PATH=$WORKING_DIR/$JTREG_TARGET_FOLDER/bin:$PATH
 
-  export JT_HOME=$WORKING_DIR/jtreg
+  export JT_HOME=$WORKING_DIR/$JTREG_TARGET_FOLDER
 
   # Clean up after ourselves by removing jtreg tgz
-  rm -f jtreg*.tar.gz
+  rm -f $JTREG_BINARY_FILE
 }
 
 applyingJConvSettingsToMakefileForTests()


### PR DESCRIPTION
- replaced legacy ways of running a command using backticks with the `$()`
- `jtreg.sh`: extracted blocks of code into functions of its own (also includes work from @Bluevisitor)
- Added the missing JVM_VARIANT variable to debug message
- Refactored jtreg.sh, each code block is a bash function - easier to s...
- Fixed the url to jtreg binary - now corrected to the one on ci.adopto...
- Refactored blocks of bash code into functions of its own, replaced old...
- Moved setting of environment variables from the function to the main...
- Merged changes from another change to fix bug with s390x builds
- Put a check around jtreg binary download to see if it exists otherwise do not download (is this desirable, let me know otherwise - im now doubtful of it)
- Changed the way jtreg is downloaded, removed some checks, added a couple
 