### PR TITLE
Allow user to specify tests we want jtreg to run

### DIFF
--- a/makejdk.sh
+++ b/makejdk.sh
@@ -76,8 +76,8 @@ while [[ $# -gt 0 ]] && [[ ."$1" = .-* ]] ; do
     "--jtreg" | "-j" )
     JTREG=true; shift;;
     
-    "--jdk_subsets" )
-    JTREG=true; JTREG_JDK_SUBSETS="$1" shift;;
+    "--jtreg_subsets" )
+    JTREG=true; JTREG_TEST_SUBSETS="$1" shift;;
 
     *) echo >&2 "${error}Invalid option: ${opt}${normal}"; man ./makejdk.1; exit 1;;
    esac
@@ -218,8 +218,8 @@ else
   $WORKING_DIR/sbin/build.sh $WORKING_DIR $TARGET_DIR $OPENJDK_REPO_NAME $BUILD_FULL_NAME $JVM_VARIANT
 
   if [[ ! -z $JTREG ]]; then
-    if [[ ! -z $JTREG_JDK_SUBSETS ]]; then
-      $WORKING_DIR/sbin/jtreg.sh $WORKING_DIR $OPENJDK_REPO_NAME $BUILD_FULL_NAME $JTREG_JDK_SUBSETS
+    if [[ ! -z $JTREG_TEST_SUBSETS ]]; then
+      $WORKING_DIR/sbin/jtreg.sh $WORKING_DIR $OPENJDK_REPO_NAME $BUILD_FULL_NAME $JTREG_TEST_SUBSETS
     else
       $WORKING_DIR/sbin/jtreg.sh $WORKING_DIR $OPENJDK_REPO_NAME $BUILD_FULL_NAME
     fi

--- a/makejdk.sh
+++ b/makejdk.sh
@@ -77,7 +77,7 @@ while [[ $# -gt 0 ]] && [[ ."$1" = .-* ]] ; do
     JTREG=true; shift;;
     
     "--jtreg_subsets" )
-    JTREG=true; JTREG_TEST_SUBSETS="$1" shift;;
+    JTREG=true; JTREG_TEST_SUBSETS="$1"; shift;;
 
     *) echo >&2 "${error}Invalid option: ${opt}${normal}"; man ./makejdk.1; exit 1;;
    esac

--- a/makejdk.sh
+++ b/makejdk.sh
@@ -75,6 +75,9 @@ while [[ $# -gt 0 ]] && [[ ."$1" = .-* ]] ; do
 
     "--jtreg" | "-j" )
     JTREG=true; shift;;
+    
+    "--jdk_subsets" )
+    JTREG=true; JTREG_JDK_SUBSETS="$1" shift;;
 
     *) echo >&2 "${error}Invalid option: ${opt}${normal}"; man ./makejdk.1; exit 1;;
    esac
@@ -215,6 +218,10 @@ else
   $WORKING_DIR/sbin/build.sh $WORKING_DIR $TARGET_DIR $OPENJDK_REPO_NAME $BUILD_FULL_NAME $JVM_VARIANT
 
   if [[ ! -z $JTREG ]]; then
-    $WORKING_DIR/sbin/jtreg.sh $WORKING_DIR $OPENJDK_REPO_NAME $BUILD_FULL_NAME
+    if [[ ! -z $JTREG_JDK_SUBSETS ]]; then
+      $WORKING_DIR/sbin/jtreg.sh $WORKING_DIR $OPENJDK_REPO_NAME $BUILD_FULL_NAME $JTREG_JDK_SUBSETS
+    else
+      $WORKING_DIR/sbin/jtreg.sh $WORKING_DIR $OPENJDK_REPO_NAME $BUILD_FULL_NAME
+    fi
   fi
 fi

--- a/sbin/jtreg.sh
+++ b/sbin/jtreg.sh
@@ -16,6 +16,7 @@
 WORKING_DIR=$1
 OPENJDK_REPO_NAME=$2
 BUILD_FULL_NAME=$3
+JTREG_TEST_SUBSETS=$(echo "$4" | sed 's/:/ /')
 
 checkIfWeAreRunningInTheDockerEnvironment()
 {
@@ -91,7 +92,11 @@ settingUpEnvironmentVariablesForJTREG()
 runJtregViaMakeCommand()
 {
   echo "Running jtreg via make command (debug logs enabled)"
-  make test jobs=10 LOG=debug  
+  if [ -z $JTREG_TEST_SUBSETS }; then
+    make test jobs=10 LOG=debug
+  else
+    make test jobs=10 LOG=debug TEST="$JTREG_TEST_SUBSETS"
+  fi 
 }
 
 packageTestResultsWithJCovReports()

--- a/sbin/jtreg.sh
+++ b/sbin/jtreg.sh
@@ -127,7 +127,7 @@ packageOnlyJCovReports()
  
   artifact=${JOB_NAME}-jcov-results-only
   echo "Tarring and zipping the 'testoutput/../jcov' folder into artefact: $artifact.tar.gz" 
-  tar -cvzf $WORKING_DIR/$artifact.tar.gz   testoutput/jdk_core/JTreport/jcov/
+  tar -cvzf $WORKING_DIR/$artifact.tar.gz   testoutput/*/JTreport/jcov/
 
   cd $WORKING_DIR
 }


### PR DESCRIPTION
Currently we allow the user to say "run the default jtreg tests after the build is complete", but we don't allow the user to specify a subset.

If we want to run less tests than the default, or more, or if we want to run focused testing (in the event that a specific module has been changed recently), we'll need this option or something like it.