### PR TITLE
Run jtreg without building java

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -21,6 +21,7 @@ TARGET_DIR=$2
 OPENJDK_REPO_NAME=$3
 BUILD_FULL_NAME=$4
 JVM_VARIANT=${5:=normal}
+NOBUILD=$6
 
 # Escape code
 esc=$(echo -en "\033")
@@ -187,6 +188,16 @@ else
     echo "${good}Configured the JDK"
   fi
   echo ${normal}
+fi
+
+
+###########################################
+
+#If the user has specified nobuild, we do everything short of building Java, and then we stop.
+if [ "${NOBUILD}" == "--nobuild"]; then
+  rm -rf cacerts_area
+  echo "Nobuild option was set. Prep complete. Java not built."
+  exit 0
 fi
 
 ###########################################

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -194,7 +194,7 @@ fi
 ###########################################
 
 #If the user has specified nobuild, we do everything short of building Java, and then we stop.
-if [ "${NOBUILD}" == "--nobuild"]; then
+if [ "${NOBUILD}" == "--nobuild" ]; then
   rm -rf cacerts_area
   echo "Nobuild option was set. Prep complete. Java not built."
   exit 0

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -23,6 +23,11 @@ BUILD_FULL_NAME=$4
 JVM_VARIANT=${5:=normal}
 NOBUILD=$6
 
+if [ "${JVM_VARIANT}" == "--nobuild" ]; then
+  NOBUILD="--nobuild"
+  JVM_VARIANT="normal"
+fi
+
 # Escape code
 esc=$(echo -en "\033")
 

--- a/sbin/jtreg.sh
+++ b/sbin/jtreg.sh
@@ -92,7 +92,7 @@ settingUpEnvironmentVariablesForJTREG()
 runJtregViaMakeCommand()
 {
   echo "Running jtreg via make command (debug logs enabled)"
-  if [ -z $JTREG_TEST_SUBSETS ]; then
+  if [ -z "$JTREG_TEST_SUBSETS" ]; then
     make test jobs=10 LOG=debug
   else
     make test jobs=10 LOG=debug TEST="$JTREG_TEST_SUBSETS"

--- a/sbin/jtreg.sh
+++ b/sbin/jtreg.sh
@@ -92,7 +92,7 @@ settingUpEnvironmentVariablesForJTREG()
 runJtregViaMakeCommand()
 {
   echo "Running jtreg via make command (debug logs enabled)"
-  if [ -z $JTREG_TEST_SUBSETS }; then
+  if [ -z $JTREG_TEST_SUBSETS ]; then
     make test jobs=10 LOG=debug
   else
     make test jobs=10 LOG=debug TEST="$JTREG_TEST_SUBSETS"

--- a/sbin/jtreg_prep.sh
+++ b/sbin/jtreg_prep.sh
@@ -19,7 +19,7 @@
 REPOSITORY=AdoptOpenJDK/openjdk-jdk8u
 OPENJDK_REPO_NAME=openjdk
 
-while [[ $# -gt 0 ]] && [[ ."$1" = .-* ]] ; do
+while [[ $# -gt 0 ]] && [[ ."$1" == .-* ]] ; do
   opt="$1";
   shift;
   case "$opt" in

--- a/sbin/jtreg_prep.sh
+++ b/sbin/jtreg_prep.sh
@@ -43,7 +43,7 @@ while [[ $# -gt 0 ]] && [[ ."$1" = .-* ]] ; do
     "--working_dir" )
     WORKING_DIR="$1"; shift;;
 
-    *) echo >&2 "Invalid option: ${opt}"; man ./makejdk.1; exit 1;;
+    *) echo >&2 "Invalid option: ${opt}"; echo "This option was unrecognised. See the script jtreg_prep.sh for a full list."; exit 1;;
    esac
 done
 

--- a/sbin/jtreg_prep.sh
+++ b/sbin/jtreg_prep.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Purpose: This script was designed to do any+all setup required by the jtreg.sh script in order to run it.
+# Tasks: Retrieve Java, unpack it if need-be, and store it locally in a specific location. If the location is blank, we put it in 
+
+REPOSITORY=AdoptOpenJDK/openjdk-jdk8u
+OPENJDK_REPO_NAME=openjdk
+
+while [[ $# -gt 0 ]] && [[ ."$1" = .-* ]] ; do
+  opt="$1";
+  shift;
+  case "$opt" in
+    "--" ) break 2;;
+
+    "--java_source" )
+    JAVA_SOURCE="$1"; shift;;
+
+    "--java_destination" )
+    JAVA_DESTINATION="$1"; shift;;
+
+    "--ssh" | "-S" )
+    USE_SSH=true; shift;;
+
+    "--repository" | "-r" )
+    REPOSITORY="$1"; shift;;
+
+    "--branch" | "-b" )
+    BRANCH="$1"; shift;;
+
+    "--working_dir" )
+    WORKING_DIR="$1"; shift;;
+
+    *) echo >&2 "Invalid option: ${opt}"; man ./makejdk.1; exit 1;;
+   esac
+done
+
+if [ -z "${JAVA_SOURCE}" ]; then
+  echo >&2 "jtreg_prep.sh failed: --java_source must be specified"; exit 1
+fi
+
+if [ -z "${WORKING_DIR}" ] ; then
+  echo "WORKING_DIR is undefined so setting to $PWD"
+  WORKING_DIR=$PWD
+else
+  echo "Working dir is $WORKING_DIR"
+fi
+
+if [ -z "${JAVA_DESTINATION}" ]; then
+  JAVA_DESTINATION="$WORKING_DIR/$OPENJDK_REPO_NAME/build/java_home/images"
+fi
+
+if [ -z "${BRANCH}" ] ; then
+  echo "BRANCH is undefined so checking out dev"
+  BRANCH="dev"
+fi
+
+# Step 1: Retrieve Java
+
+if [ ! -d "${JAVA_DESTINATION}" ]; then
+  mkdir -p "${JAVA_DESTINATION}"
+fi
+cd "${JAVA_DESTINATION}"
+
+#If it's a http location, use wget.
+if [[ "${JAVA_SOURCE}" == http* ]]; then 
+  wget "${JAVA_SOURCE}"
+  if [ $? -ne 0 ]; then
+    echo "Failed to retrieve the jtreg binary, exiting"
+    exit 1
+  fi
+else #Assume it's local or on a mounted drive.
+  if [ -f "${JAVA_SOURCE}" ] || [ -d "${JAVA_SOURCE}" ]; then
+    cp -r "${JAVA_SOURCE}" .
+  else
+    echo "Java could not be found at the java_source location."
+    exit 1
+  fi
+fi
+
+# Step 2: Unpack Java if we need to.
+
+if [[ "$JAVA_SOURCE" == *\.tar\.gz ]]; then #If it's a tar file, unpack it.
+  cd "${JAVA_DESTINATION}"
+  tar xvf *.tar.gz
+  echo "Java has been untarred."
+  cd "${WORKING_DIR}"
+elif [ ! -d "${JAVA_SOURCE}" ]; then #If it's not a directory, then we don't know how to unpack it. 
+  echo "The Java file you specified as source was copied to the destination, but this script doesn't know how to unpack it. Please add this logic to this script, or unpack it manually before running jtreg.";
+fi
+
+# Step 3: Fetch OpenJDK, as that's where the tests live.
+
+if [ -d "$WORKING_DIR"/$OPENJDK_REPO_NAME/.git ] && [ $REPOSITORY == "AdoptOpenJDK/openjdk-jdk8u" ] ; then
+  # It does exist and it's a repo other than the AdoptOpenJDK one
+  cd $WORKING_DIR/$OPENJDK_REPO_NAME
+  echo "Will reset the repository at $PWD in 10 seconds..."
+  sleep 10
+  echo "Pulling latest changes from git repo"
+  git fetch --all
+  git reset --hard origin/$BRANCH
+  cd $WORKING_DIR
+elif [ ! -d "${WORKING_DIR}"/$OPENJDK_REPO_NAME/.git ] ; then
+  # If it doesn't exixt, clone it
+  echo "Didn't find any existing openjdk repository at WORKING_DIR (set to ${WORKING_DIR}) so cloning the source to openjdk"
+  if [[ "${USE_SSH}" == true ]] ; then
+    echo "git clone -b ${BRANCH} git@github.com:${REPOSITORY}.git $WORKING_DIR/$OPENJDK_REPO_NAME"
+    git clone -b ${BRANCH} git@github.com:${REPOSITORY}.git $WORKING_DIR/$OPENJDK_REPO_NAME
+  else
+    echo "git clone -b ${BRANCH} https://github.com/${REPOSITORY}.git $WORKING_DIR/$OPENJDK_REPO_NAME"
+    git clone -b ${BRANCH} https://github.com/${REPOSITORY}.git $WORKING_DIR/$OPENJDK_REPO_NAME
+  fi
+fi
+
+# Step 4: Finish
+echo "jtreg_prep.sh has finished successfully."
+exit 0

--- a/sbin/jtreg_prep.sh
+++ b/sbin/jtreg_prep.sh
@@ -79,7 +79,7 @@ if [ -d "$WORKING_DIR"/$OPENJDK_REPO_NAME/.git ] && [ $REPOSITORY == "AdoptOpenJ
   git reset --hard origin/$BRANCH
   cd $WORKING_DIR
 elif [ ! -d "${WORKING_DIR}"/$OPENJDK_REPO_NAME/.git ] ; then
-  # If it doesn't exixt, clone it
+  # If it doesn't exist, clone it
   echo "Didn't find any existing openjdk repository at WORKING_DIR (set to ${WORKING_DIR}) so cloning the source to openjdk"
   if [[ "${USE_SSH}" == true ]] ; then
     echo "git clone -b ${BRANCH} git@github.com:${REPOSITORY}.git $WORKING_DIR/$OPENJDK_REPO_NAME"

--- a/sbin/jtreg_prep.sh
+++ b/sbin/jtreg_prep.sh
@@ -67,7 +67,30 @@ if [ -z "${BRANCH}" ] ; then
   BRANCH="dev"
 fi
 
-# Step 1: Retrieve Java
+# Step 1: Fetch OpenJDK, as that's where the tests live.
+
+if [ -d "$WORKING_DIR"/$OPENJDK_REPO_NAME/.git ] && [ $REPOSITORY == "AdoptOpenJDK/openjdk-jdk8u" ] ; then
+  # It does exist and it's a repo other than the AdoptOpenJDK one
+  cd $WORKING_DIR/$OPENJDK_REPO_NAME
+  echo "Will reset the repository at $PWD in 10 seconds..."
+  sleep 10
+  echo "Pulling latest changes from git repo"
+  git fetch --all
+  git reset --hard origin/$BRANCH
+  cd $WORKING_DIR
+elif [ ! -d "${WORKING_DIR}"/$OPENJDK_REPO_NAME/.git ] ; then
+  # If it doesn't exixt, clone it
+  echo "Didn't find any existing openjdk repository at WORKING_DIR (set to ${WORKING_DIR}) so cloning the source to openjdk"
+  if [[ "${USE_SSH}" == true ]] ; then
+    echo "git clone -b ${BRANCH} git@github.com:${REPOSITORY}.git $WORKING_DIR/$OPENJDK_REPO_NAME"
+    git clone -b ${BRANCH} git@github.com:${REPOSITORY}.git $WORKING_DIR/$OPENJDK_REPO_NAME
+  else
+    echo "git clone -b ${BRANCH} https://github.com/${REPOSITORY}.git $WORKING_DIR/$OPENJDK_REPO_NAME"
+    git clone -b ${BRANCH} https://github.com/${REPOSITORY}.git $WORKING_DIR/$OPENJDK_REPO_NAME
+  fi
+fi
+
+# Step 2: Retrieve Java
 
 if [ ! -d "${JAVA_DESTINATION}" ]; then
   mkdir -p "${JAVA_DESTINATION}"
@@ -90,7 +113,7 @@ else #Assume it's local or on a mounted drive.
   fi
 fi
 
-# Step 2: Unpack Java if we need to.
+# Step 3: Unpack Java if we need to.
 
 if [[ "$JAVA_SOURCE" == *\.tar\.gz ]]; then #If it's a tar file, unpack it.
   cd "${JAVA_DESTINATION}"
@@ -99,29 +122,6 @@ if [[ "$JAVA_SOURCE" == *\.tar\.gz ]]; then #If it's a tar file, unpack it.
   cd "${WORKING_DIR}"
 elif [ ! -d "${JAVA_SOURCE}" ]; then #If it's not a directory, then we don't know how to unpack it. 
   echo "The Java file you specified as source was copied to the destination, but this script doesn't know how to unpack it. Please add this logic to this script, or unpack it manually before running jtreg.";
-fi
-
-# Step 3: Fetch OpenJDK, as that's where the tests live.
-
-if [ -d "$WORKING_DIR"/$OPENJDK_REPO_NAME/.git ] && [ $REPOSITORY == "AdoptOpenJDK/openjdk-jdk8u" ] ; then
-  # It does exist and it's a repo other than the AdoptOpenJDK one
-  cd $WORKING_DIR/$OPENJDK_REPO_NAME
-  echo "Will reset the repository at $PWD in 10 seconds..."
-  sleep 10
-  echo "Pulling latest changes from git repo"
-  git fetch --all
-  git reset --hard origin/$BRANCH
-  cd $WORKING_DIR
-elif [ ! -d "${WORKING_DIR}"/$OPENJDK_REPO_NAME/.git ] ; then
-  # If it doesn't exixt, clone it
-  echo "Didn't find any existing openjdk repository at WORKING_DIR (set to ${WORKING_DIR}) so cloning the source to openjdk"
-  if [[ "${USE_SSH}" == true ]] ; then
-    echo "git clone -b ${BRANCH} git@github.com:${REPOSITORY}.git $WORKING_DIR/$OPENJDK_REPO_NAME"
-    git clone -b ${BRANCH} git@github.com:${REPOSITORY}.git $WORKING_DIR/$OPENJDK_REPO_NAME
-  else
-    echo "git clone -b ${BRANCH} https://github.com/${REPOSITORY}.git $WORKING_DIR/$OPENJDK_REPO_NAME"
-    git clone -b ${BRANCH} https://github.com/${REPOSITORY}.git $WORKING_DIR/$OPENJDK_REPO_NAME
-  fi
 fi
 
 # Step 4: Finish

--- a/sbin/jtreg_prep.sh
+++ b/sbin/jtreg_prep.sh
@@ -25,10 +25,10 @@ while [[ $# -gt 0 ]] && [[ ."$1" == .-* ]] ; do
   case "$opt" in
     "--" ) break 2;;
 
-    "--java_source" )
+    "--source" )
     JAVA_SOURCE="$1"; shift;;
 
-    "--java_destination" )
+    "--destination" )
     JAVA_DESTINATION="$1"; shift;;
 
     "--ssh" | "-S" )
@@ -48,7 +48,7 @@ while [[ $# -gt 0 ]] && [[ ."$1" == .-* ]] ; do
 done
 
 if [ -z "${JAVA_SOURCE}" ]; then
-  echo >&2 "jtreg_prep.sh failed: --java_source must be specified"; exit 1
+  echo >&2 "jtreg_prep.sh failed: --source must be specified"; exit 1
 fi
 
 if [ -z "${WORKING_DIR}" ] ; then

--- a/sbin/jtreg_prep.sh
+++ b/sbin/jtreg_prep.sh
@@ -117,7 +117,7 @@ fi
 
 if [[ "$JAVA_SOURCE" == *\.tar\.gz ]]; then #If it's a tar file, unpack it.
   cd "${JAVA_DESTINATION}"
-  tar xvf *.tar.gz
+  tar xf *.tar.gz
   echo "Java has been untarred."
   cd "${WORKING_DIR}"
 elif [ ! -d "${JAVA_SOURCE}" ]; then #If it's not a directory, then we don't know how to unpack it. 


### PR DESCRIPTION
This new script allows us to specify an existing Java and run jtreg against it, rather than building a new Java from scratch.