### PR TITLE
Do not run tests if not specified

### DIFF
--- a/makejdk.sh
+++ b/makejdk.sh
@@ -260,8 +260,10 @@ buildAndTestOpenJDKViaDocker()
 
 testOpenJDKInNativeEnvironmentIfExpected()
 {
-  if [[ ! -z $JTREG ]]; then
-    if [[ ! -z $JTREG_TEST_SUBSETS ]]; then
+  if [[ "$JTREG" == "true" ]];
+  then
+    if [[ ! -z $JTREG_TEST_SUBSETS ]];
+    then
       $WORKING_DIR/sbin/jtreg.sh $WORKING_DIR $OPENJDK_REPO_NAME $BUILD_FULL_NAME $JTREG_TEST_SUBSETS
     else
       $WORKING_DIR/sbin/jtreg.sh $WORKING_DIR $OPENJDK_REPO_NAME $BUILD_FULL_NAME

--- a/makejdk.sh
+++ b/makejdk.sh
@@ -260,7 +260,7 @@ buildAndTestOpenJDKViaDocker()
 
 testOpenJDKInNativeEnvironmentIfExpected()
 {
-  if [[ "${JTREG}" == "true" ]];
+  if [[ "$JTREG" == "true" ]];
   then
       $WORKING_DIR/sbin/jtreg.sh $WORKING_DIR $OPENJDK_REPO_NAME $BUILD_FULL_NAME $JTREG_TEST_SUBSETS
   fi

--- a/makejdk.sh
+++ b/makejdk.sh
@@ -260,7 +260,7 @@ buildAndTestOpenJDKViaDocker()
 
 testOpenJDKInNativeEnvironmentIfExpected()
 {
-  if [[ "$JTREG" == "true" ]];
+  if [[ "${JTREG}" == "true" ]];
   then
       $WORKING_DIR/sbin/jtreg.sh $WORKING_DIR $OPENJDK_REPO_NAME $BUILD_FULL_NAME $JTREG_TEST_SUBSETS
   fi

--- a/makejdk.sh
+++ b/makejdk.sh
@@ -262,12 +262,7 @@ testOpenJDKInNativeEnvironmentIfExpected()
 {
   if [[ "$JTREG" == "true" ]];
   then
-    if [[ ! -z $JTREG_TEST_SUBSETS ]];
-    then
       $WORKING_DIR/sbin/jtreg.sh $WORKING_DIR $OPENJDK_REPO_NAME $BUILD_FULL_NAME $JTREG_TEST_SUBSETS
-    else
-      $WORKING_DIR/sbin/jtreg.sh $WORKING_DIR $OPENJDK_REPO_NAME $BUILD_FULL_NAME
-    fi
   fi
 }
 


### PR DESCRIPTION
Fix to change made in the same area as changed by PR https://github.com/Bluevisitor/openjdk-build/commit/be63d41343d235dcb7a2c82472643157e82a85f8

Strangely this line was causing the issue:
```if [[ ! -z $JTREG ]]; then```

`If` block was executed irrespective of passing `--jtreg` or not

We couldn't have spotted this via pull requests, maybe we should discourage such constructs (as the above) reducing the chances of bugs slipping thru - @karianna @gdams any thoughts?