### PR TITLE
Refactoring jtreg prep script and dependent scripts

### DIFF
--- a/makejdk.1
+++ b/makejdk.1
@@ -26,6 +26,9 @@ reuse docker container (prevents deleting)
 .BR \-j ", " \-\-jtreg
 run jtreg after building
 .TP
+.BR \-js ", " \-\-jtreg-subsets
+select one or more jtreg tests to run
+.TP
 .BR \-S ", " \-\-ssh
 use ssh when cloning git
 .TP

--- a/makejdk.sh
+++ b/makejdk.sh
@@ -95,7 +95,7 @@ parseCommandLineArgs()
       "--jtreg" | "-j" )
       JTREG=true; shift;;
 
-    "--jtreg_subsets" )
+      "--jtreg-subsets" | "-js" )
     JTREG=true; JTREG_TEST_SUBSETS="$1"; shift;;
 
       *) echo >&2 "${error}Invalid option: ${opt}${normal}"; man ./makejdk.1; exit 1;;

--- a/makejdk.sh
+++ b/makejdk.sh
@@ -38,7 +38,7 @@ fi
 
 BUILD_TYPE=normal
 
-BUILD_FULL_NAME=$OS_KERNAL_NAME-$OS_MACHINE-$BUILD_TYPE-$JVM_VARIANT-release
+BUILD_FULL_NAME=${OS_KERNAL_NAME}-${OS_MACHINE}-${BUILD_TYPE}-${JVM_VARIANT}-release
 
 USE_DOCKER=false
 WORKING_DIR=""
@@ -106,17 +106,17 @@ parseCommandLineArgs()
 checkIfDockerIsUsedForBuildingOrNot()
 {
   # Both a working directory and a target directory provided
-  if [ ! -z "${WORKING_DIR}" ] && [ ! -z "${TARGET_DIR}" ] ; then
+  if [ ! -z "$WORKING_DIR" ] && [ ! -z "$TARGET_DIR" ] ; then
     # This uses sbin/build.sh directly
     echo "${info} Not using Docker, working area will be ${WORKING_DIR}, target for the JDK will be ${TARGET_DIR} ${normal}"
   fi
 
   # No working directory and no target directory provided
-  if [ -z "${WORKING_DIR}" ] && [ -z "${TARGET_DIR}" ] ; then
+  if [ -z "$WORKING_DIR" ] && [ -z "$TARGET_DIR" ] ; then
     echo "${info}No parameters provided, using Docker ${normal}"
     USE_DOCKER=true
-  elif [ ! -z "${TARGET_DIR}" ] && [ -z "${WORKING_DIR}" ] ; then
-    # Target dir is defined but the working dir isn't
+  elif [ ! -z "$TARGET_DIR" ] && [ -z "$WORKING_DIR" ] ; then
+    # Target directory is defined but the working directory isn't
     # Calls sbin/build.sh inside of Docker followed by a docker cp command
     echo "${info}Using Docker, target directory for the tgz on the host: ${TARGET_DIR}"
     USE_DOCKER=true
@@ -126,17 +126,17 @@ checkIfDockerIsUsedForBuildingOrNot()
 checkInCaseOfDockerShouldTheContainerBePreserved()
 {
   echo ${info}
-  if [ "${KEEP}" == "true" ] ; then
+  if [ "$KEEP" == "true" ] ; then
     echo "We'll keep the built Docker container if you're using Docker"
   else
     echo "We'll remove the built Docker container if you're using Docker"
   fi
-  echo $normal
+  echo ${normal}
 }
 
 setDefaultIfBranchIsNotProvided()
 {
-  if [ -z "${BRANCH}" ] ; then
+  if [ -z "$BRANCH" ] ; then
     echo "${info}BRANCH is undefined so checking out dev${normal}"
     BRANCH="dev"
   fi
@@ -144,24 +144,24 @@ setDefaultIfBranchIsNotProvided()
 
 setWorkingDirectoryIfProvided()
 {
-  if [ -z "${WORKING_DIR}" ] ; then
+  if [ -z "$WORKING_DIR" ] ; then
     echo "${info}WORKING_DIR is undefined so setting to $PWD${normal}"
     WORKING_DIR=$PWD
   else
-    echo "${info}Working dir is $WORKING_DIR${normal}"
+    echo "${info}Working directory is ${WORKING_DIR}${normal}"
   fi
 }
 
 setTargetDirectoryIfProvided()
 {
   echo $info
-  if [ -z "${TARGET_DIR}" ] ; then
-    echo "${info}TARGET_DIR is undefined so setting to $PWD"
+  if [ -z "$TARGET_DIR" ] ; then
+    echo "${info}TARGET_DIR is undefined so setting to ${PWD}"
     TARGET_DIR=$PWD
     # Only makes a difference if we're in Docker
     echo "If you're using Docker The build artifact will not be copied to the host"
   else
-    echo "${info}Target directory is $TARGET_DIR${normal}"
+    echo "${info}Target directory is ${TARGET_DIR}${normal}"
     COPY_TO_HOST=true
     echo "If you're using Docker we'll copy the build artifact to the host"
   fi
@@ -172,18 +172,18 @@ cloneOpenJDKGitRepo()
   echo $git
   if [ -d "${WORKING_DIR}/${OPENJDK_REPO_NAME}/.git" ] && [ "$REPOSITORY" == "AdoptOpenJDK/openjdk-jdk8u" ] ; then
     # It does exist and it's a repo other than the AdoptOpenJDK one
-    cd $WORKING_DIR/$OPENJDK_REPO_NAME
-    echo "${info}Will reset the repository at $PWD in 10 seconds...${git}"
+    cd ${WORKING_DIR}/${OPENJDK_REPO_NAME}
+    echo "${info}Will reset the repository at ${PWD} in 10 seconds...${git}"
     sleep 10
     echo "${git}Pulling latest changes from git repo"
     git fetch --all
-    git reset --hard origin/$BRANCH
-    echo $normal
+    git reset --hard origin/${BRANCH}
+    echo ${normal}
     cd $WORKING_DIR
   elif [ ! -d "${WORKING_DIR}/${OPENJDK_REPO_NAME}/.git" ] ; then
     # If it doesn't exixt, clone it
     echo "${info}Didn't find any existing openjdk repository at WORKING_DIR (set to ${WORKING_DIR}) so cloning the source to openjdk"
-    if [[ "${USE_SSH}" == "true" ]] ; then
+    if [[ "$USE_SSH" == "true" ]] ; then
       echo "git clone -b ${BRANCH} git@github.com:${REPOSITORY}.git ${WORKING_DIR}/${OPENJDK_REPO_NAME}"
       git clone -b ${BRANCH} git@github.com:${REPOSITORY}.git $WORKING_DIR/$OPENJDK_REPO_NAME
     else
@@ -196,8 +196,8 @@ cloneOpenJDKGitRepo()
 
 testOpenJDKViaDocker()
 {
-  if [[ ! -z $JTREG ]]; then
-    docker run --privileged -t -v $WORKING_DIR/$OPENJDK_REPO_NAME:/openjdk/jdk8u/openjdk --entrypoint jtreg.sh $CONTAINER
+  if [[ ! -z "$JTREG" ]]; then
+    docker run --privileged -t -v ${WORKING_DIR}/${OPENJDK_REPO_NAME}:/openjdk/jdk8u/openjdk --entrypoint jtreg.sh ${CONTAINER}
   fi
 }
 
@@ -205,7 +205,7 @@ buildAndTestOpenJDKViaDocker()
 {
   PS_DOCKER=$(ps -ef | grep "docker" | wc -l)
 
-  if [ -z $(which docker) ] || [ ${PS_DOCKER} -lt 2 ]; then
+  if [ -z $(which docker) ] || [ "$PS_DOCKER" -lt 2 ]; then
     echo "${error}Error, please install docker and ensure that it is in your path and running!${normal}"
     exit
   fi
@@ -232,28 +232,28 @@ buildAndTestOpenJDKViaDocker()
      echo $good
      docker ps -a | awk '{ print $1,$2 }' | grep $CONTAINER | awk '{print $1 }' | xargs -I {} docker rm -f {}
      docker build -t $CONTAINER docker/jdk8u/x86_64/ubuntu
-     echo $normal
+     echo ${normal}
   fi
 
-  docker run --privileged -t -v $WORKING_DIR/$OPENJDK_REPO_NAME:/openjdk/jdk8u/openjdk --entrypoint build.sh $CONTAINER
+  docker run --privileged -t -v ${WORKING_DIR}/${OPENJDK_REPO_NAME}:/openjdk/jdk8u/openjdk --entrypoint build.sh $CONTAINER
 
   testOpenJDKViaDocker
 
   CONTAINER_ID=$(docker ps -a | awk '{ print $1,$2 }' | grep openjdk_container | awk '{print $1 }'| head -1)
 
-  if [[ "${COPY_TO_HOST}" == "true" ]] ; then
-    echo "Copying to the host with docker cp $id:/openjdk/jdk8u/OpenJDK.tar.gz $TARGET_DIR"
-    docker cp $CONTAINER_ID:/openjdk/jdk8u/OpenJDK.tar.gz $TARGET_DIR
+  if [[ "$COPY_TO_HOST" == "true" ]] ; then
+    echo "Copying to the host with docker cp ${id}:/openjdk/jdk8u/OpenJDK.tar.gz ${TARGET_DIR}"
+    docker cp ${CONTAINER_ID}:/openjdk/jdk8u/OpenJDK.tar.gz $TARGET_DIR
   fi
 
-  if [[ "${JTREG}" == "true" ]] ; then
+  if [[ "$JTREG" == "true" ]] ; then
     echo "Copying jtreg reports from docker"
-    docker cp $CONTAINER_ID:/openjdk/jdk8u/jtreport.zip $TARGET_DIR
-    docker cp $CONTAINER_ID:/openjdk/jdk8u/jtwork.zip $TARGET_DIR
+    docker cp ${CONTAINER_ID}:/openjdk/jdk8u/jtreport.zip $TARGET_DIR
+    docker cp ${CONTAINER_ID}:/openjdk/jdk8u/jtwork.zip $TARGET_DIR
   fi
 
   # Didn't specify to keep
-  if [[ -z ${KEEP} ]] ; then
+  if [[ -z "$KEEP" ]] ; then
     docker ps -a | awk '{ print $1,$2 }' | grep $CONTAINER | awk '{print $1 }' | xargs -I {} docker rm {}
   fi
 }
@@ -268,7 +268,7 @@ testOpenJDKInNativeEnvironmentIfExpected()
 
 buildAndTestOpenJDKInNativeEnvironment()
 {
-  echo "Calling sbin/build.sh $WORKING_DIR $TARGET_DIR $OPENJDK_REPO_NAME $BUILD_FULL_NAME $JVM_VARIANT"
+  echo "Calling sbin/build.sh ${WORKING_DIR} ${TARGET_DIR} ${OPENJDK_REPO_NAME} ${BUILD_FULL_NAME} ${JVM_VARIANT}"
   $WORKING_DIR/sbin/build.sh $WORKING_DIR $TARGET_DIR $OPENJDK_REPO_NAME $BUILD_FULL_NAME $JVM_VARIANT
 
   testOpenJDKInNativeEnvironmentIfExpected
@@ -276,7 +276,7 @@ buildAndTestOpenJDKInNativeEnvironment()
 
 buildAndTestOpenJDK()
 {
-  if [ "${USE_DOCKER}" == "true" ] ; then
+  if [ "$USE_DOCKER" == "true" ] ; then
     buildAndTestOpenJDKViaDocker
   else
     buildAndTestOpenJDKInNativeEnvironment
@@ -287,7 +287,7 @@ buildAndTestOpenJDK()
 
 initialiseEscapeCodes
 sourceSignalHandler
-parseCommandLineArgs $@
+parseCommandLineArgs "$@"
 checkIfDockerIsUsedForBuildingOrNot
 checkInCaseOfDockerShouldTheContainerBePreserved
 setDefaultIfBranchIsNotProvided

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -237,7 +237,7 @@ runTheOpenJDKConfigureCommandAndUseThePrebuildConfigParams()
 
 buildOpenJDK()
 {
-  #If the user has specified nobuild, we do everything short of building Java, and then we stop.
+  #If the user has specified nobuild, we do everything short of building the JDK, and then we stop.
   if [ "${NOBUILD}" == "--nobuild" ]; then
     rm -rf cacerts_area
     echo "Nobuild option was set. Prep complete. Java not built."

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -22,10 +22,10 @@ OPENJDK_REPO_NAME=$3
 BUILD_FULL_NAME=$4
 
 JVM_VARIANT=${5:=normal}
-NOBUILD=$6
+RUN_JTREG_TESTS_ONLY=$6
 
-if [ "$JVM_VARIANT" == "--nobuild" ]; then
-  NOBUILD="--nobuild"
+if [ "$JVM_VARIANT" == "--run-jtreg-tests-only" ]; then
+  RUN_JTREG_TESTS_ONLY="--run-jtreg-tests-only"
   JVM_VARIANT="normal"
 fi
 
@@ -238,7 +238,7 @@ runTheOpenJDKConfigureCommandAndUseThePrebuildConfigParams()
 buildOpenJDK()
 {
   #If the user has specified nobuild, we do everything short of building the JDK, and then we stop.
-  if [ "${NOBUILD}" == "--nobuild" ]; then
+  if [ "${RUN_JTREG_TESTS_ONLY}" == "--run-jtreg-tests-only" ]; then
     rm -rf cacerts_area
     echo "Nobuild option was set. Prep complete. Java not built."
     exit 0

--- a/sbin/jtreg.sh
+++ b/sbin/jtreg.sh
@@ -38,7 +38,7 @@ downloadJtregAndSetupEnvironment()
   if [[ ! -d "${WORKING_DIR}/${JTREG_TARGET_FOLDER}" ]]; then
    echo "Downloading Jtreg binary"
    JTREG_BINARY_FILE="jtreg-${JTREG_VERSION}.tar.gz"
-   wget https://ci.adoptopenjdk.net/job/jtreg/lastSuccessfulBuild/artifact/$JTREG_BINARY_FILE
+   wget https://ci.adoptopenjdk.net/job/jtreg/lastSuccessfulBuild/artifact/${JTREG_BINARY_FILE}
 
    if [ $? -ne 0 ]; then
      echo "Failed to retrieve the jtreg binary, exiting"
@@ -48,12 +48,13 @@ downloadJtregAndSetupEnvironment()
    tar xvf $JTREG_BINARY_FILE
   fi
 
-  echo "List contents of jtreg"
-  ls $WORKING_DIR/$JTREG_TARGET_FOLDER/*
+  echo "List contents of the jtreg folder"
+  export JT_HOME=${WORKING_DIR}/${JTREG_TARGET_FOLDER}
 
-  export PATH=$WORKING_DIR/$JTREG_TARGET_FOLDER/bin:$PATH
+  export PATH=${JT_HOME}/bin:$PATH
 
-  export JT_HOME=$WORKING_DIR/$JTREG_TARGET_FOLDER
+    ls $JT_HOME/*
+
 
   # Clean up after ourselves by removing jtreg tgz
   rm -f $JTREG_BINARY_FILE
@@ -62,12 +63,12 @@ downloadJtregAndSetupEnvironment()
 applyingJCovSettingsToMakefileForTests()
 {
   echo "Apply JCov settings to Makefile..." 
-  cd $WORKING_DIR/$OPENJDK_REPO_NAME/jdk/test
+  cd ${WORKING_DIR}/${OPENJDK_REPO_NAME}/jdk/test
   pwd
 
   sed -i 's/-vmoption:-Xmx512m.*/-vmoption:-Xmx512m -xml:verify -jcov\/classes:$(ABS_PLATFORM_BUILD_ROOT)\/jdk\/classes\/  -jcov\/source:$(ABS_PLATFORM_BUILD_ROOT)\/..\/..\/jdk\/src\/java\/share\/classes  -jcov\/include:*/' Makefile
 
-  cd $WORKING_DIR/$OPENJDK_REPO_NAME/
+  cd ${WORKING_DIR}/${OPENJDK_REPO_NAME}/
 }
 
 settingUpEnvironmentVariablesForJTREG()
@@ -75,7 +76,7 @@ settingUpEnvironmentVariablesForJTREG()
   echo "Setting up environment variables for JTREG to run"
 
   # This is the JDK we'll test
-  export PRODUCT_HOME=$WORKING_DIR/$OPENJDK_REPO_NAME/build/$BUILD_FULL_NAME/images/j2sdk-image
+  export PRODUCT_HOME=${WORKING_DIR}/${OPENJDK_REPO_NAME}/build/${BUILD_FULL_NAME}/images/j2sdk-image
   echo $PRODUCT_HOME
   ls $PRODUCT_HOME
 
@@ -104,16 +105,16 @@ packageTestResultsWithJCovReports()
   echo "Package test output into archives..." 
   pwd
 
-  cd $WORKING_DIR/$OPENJDK_REPO_NAME/build/$BUILD_FULL_NAME/
+  cd ${WORKING_DIR}/${OPENJDK_REPO_NAME}/build/${BUILD_FULL_NAME}/
  
   artifact=${JOB_NAME}-testoutput-with-jcov-reports
   echo "Tarring and zipping the 'testoutput' folder into artefact: $artifact.tar.gz" 
-  tar -cvzf $WORKING_DIR/$artifact.tar.gz   testoutput/
+  tar -cvzf ${WORKING_DIR}/${artifact}.tar.gz   testoutput/
 
   if [ -d testoutput  ]; then  
-     rm -fr $WORKING_DIR/$OPENJDK_REPO_NAME/testoutput
+     rm -fr ${WORKING_DIR}/${OPENJDK_REPO_NAME}/testoutput
   fi
-  cp -fr testoutput/ $WORKING_DIR/testoutput/
+  cp -fr testoutput/ ${WORKING_DIR}/testoutput/
   
   cd $WORKING_DIR
 }
@@ -123,11 +124,11 @@ packageOnlyJCovReports()
   echo "Package jcov reports into archives..." 
   pwd
 
-  cd $WORKING_DIR/$OPENJDK_REPO_NAME/build/$BUILD_FULL_NAME/
+  cd ${WORKING_DIR}/${OPENJDK_REPO_NAME}/build/${BUILD_FULL_NAME}/
  
   artifact=${JOB_NAME}-jcov-results-only
   echo "Tarring and zipping the 'testoutput/../jcov' folder into artefact: $artifact.tar.gz" 
-  tar -cvzf $WORKING_DIR/$artifact.tar.gz   testoutput/*/JTreport/jcov/
+  tar -cvzf ${WORKING_DIR}/${artifact}.tar.gz   testoutput/*/JTreport/jcov/
 
   cd $WORKING_DIR
 }

--- a/sbin/jtreg_prep.sh
+++ b/sbin/jtreg_prep.sh
@@ -149,7 +149,7 @@ printFinishedMessage()
 
 ##################################################################
 
-parseCommandLineArgs $@
+parseCommandLineArgs "$@"
 cloneOpenJDKRepo
 downloadJDKArtifact
 unpackJDKTarArtifact

--- a/sbin/jtreg_prep.sh
+++ b/sbin/jtreg_prep.sh
@@ -81,7 +81,7 @@ parseCommandLineArgs()
 # Step 1: Fetch OpenJDK, as that's where the tests live.
 cloneOpenJDKRepo()
 {
-    if [ -d "$WORKING_DIR"/$OPENJDK_REPO_NAME/.git ] && [ $REPOSITORY == "AdoptOpenJDK/openjdk-jdk8u" ] ; then
+    if [ -d "$WORKING_DIR/$OPENJDK_REPO_NAME/.git" ] && [ $REPOSITORY == "AdoptOpenJDK/openjdk-jdk8u" ] ; then
       # It does exist and it's a repo other than the AdoptOpenJDK one
       cd $WORKING_DIR/$OPENJDK_REPO_NAME
       echo "Will reset the repository at $PWD in 10 seconds..."
@@ -90,10 +90,10 @@ cloneOpenJDKRepo()
       git fetch --all
       git reset --hard origin/$BRANCH
       cd $WORKING_DIR
-    elif [ ! -d "${WORKING_DIR}"/$OPENJDK_REPO_NAME/.git ] ; then
+    elif [ ! -d "${WORKING_DIR}/${OPENJDK_REPO_NAME}/.git" ] ; then
       # If it doesn't exist, clone it
       echo "Didn't find any existing openjdk repository at WORKING_DIR (set to ${WORKING_DIR}) so cloning the source to openjdk"
-      if [[ "${USE_SSH}" == true ]] ; then
+      if [[ ${USE_SSH} == true ]] ; then
         echo "git clone -b ${BRANCH} git@github.com:${REPOSITORY}.git $WORKING_DIR/$OPENJDK_REPO_NAME"
         git clone -b ${BRANCH} git@github.com:${REPOSITORY}.git $WORKING_DIR/$OPENJDK_REPO_NAME
       else
@@ -107,20 +107,20 @@ cloneOpenJDKRepo()
 downloadJDKArtifact()
 {
     if [ ! -d "${JAVA_DESTINATION}" ]; then
-      mkdir -p "${JAVA_DESTINATION}"
+      mkdir -p ${JAVA_DESTINATION}
     fi
-    cd "${JAVA_DESTINATION}"
+    cd ${JAVA_DESTINATION}
 
     #If it's a http location, use wget.
     if [[ "${JAVA_SOURCE}" == http* ]]; then
-      wget "${JAVA_SOURCE}"
+      wget ${JAVA_SOURCE}
       if [ $? -ne 0 ]; then
         echo "Failed to retrieve the JDK binary from ${JAVA_SOURCE}, exiting"
         exit 1
       fi
     else #Assume it's local or on a mounted drive.
       if [ -f "${JAVA_SOURCE}" ] || [ -d "${JAVA_SOURCE}" ]; then
-        cp -r "${JAVA_SOURCE}" .
+        cp -r ${JAVA_SOURCE} .
       else
         echo "The JDK artifact could not be found at the source location: ${JAVA_SOURCE}."
         exit 1
@@ -132,10 +132,10 @@ downloadJDKArtifact()
 unpackJDKTarArtifact()
 {
     if [[ "$JAVA_SOURCE" == *\.tar\.gz ]]; then #If it's a tar file, unpack it.
-      cd "${JAVA_DESTINATION}"
+      cd ${JAVA_DESTINATION}
       tar xf *.tar.gz
       echo "The JDK artifact has been untarred at ${JAVA_DESTINATION}."
-      cd "${WORKING_DIR}"
+      cd ${WORKING_DIR}
     elif [ ! -d "${JAVA_SOURCE}" ]; then #If it's not a directory, then we don't know how to unpack it.
       echo "The Java file you specified as source was copied to the destination, but this script doesn't know how to unpack it. Please add this logic to this script, or unpack it manually before running jtreg.";
     fi
@@ -144,7 +144,7 @@ unpackJDKTarArtifact()
 # Step 4: Finish
 printFinishedMessage()
 {
-    echo "jtreg_prep.sh has finished successfully."
+    echo "$0 has finished successfully."
 }
 
 ##################################################################

--- a/sbin/jtreg_prep.sh
+++ b/sbin/jtreg_prep.sh
@@ -115,14 +115,14 @@ downloadJDKArtifact()
     if [[ "${JAVA_SOURCE}" == http* ]]; then
       wget "${JAVA_SOURCE}"
       if [ $? -ne 0 ]; then
-        echo "Failed to retrieve the jtreg binary from ${JAVA_SOURCE}, exiting"
+        echo "Failed to retrieve the JDK binary from ${JAVA_SOURCE}, exiting"
         exit 1
       fi
     else #Assume it's local or on a mounted drive.
       if [ -f "${JAVA_SOURCE}" ] || [ -d "${JAVA_SOURCE}" ]; then
         cp -r "${JAVA_SOURCE}" .
       else
-        echo "Java could not be found at the java_source location: ${JAVA_SOURCE}."
+        echo "The JDK artifact could not be found at the source location: ${JAVA_SOURCE}."
         exit 1
       fi
     fi
@@ -134,7 +134,7 @@ unpackJDKTarArtifact()
     if [[ "$JAVA_SOURCE" == *\.tar\.gz ]]; then #If it's a tar file, unpack it.
       cd "${JAVA_DESTINATION}"
       tar xf *.tar.gz
-      echo "Java has been untarred at ${JAVA_DESTINATION}."
+      echo "The JDK artifact has been untarred at ${JAVA_DESTINATION}."
       cd "${WORKING_DIR}"
     elif [ ! -d "${JAVA_SOURCE}" ]; then #If it's not a directory, then we don't know how to unpack it.
       echo "The Java file you specified as source was copied to the destination, but this script doesn't know how to unpack it. Please add this logic to this script, or unpack it manually before running jtreg.";

--- a/sbin/jtreg_prep.sh
+++ b/sbin/jtreg_prep.sh
@@ -16,114 +16,141 @@
 # Purpose: This script was designed to do any+all setup required by the jtreg.sh script in order to run it.
 # Tasks: Retrieve Java, unpack it if need-be, and store it locally in a specific location. If the location is blank, we put it in 
 
+set -eu
+
 REPOSITORY=AdoptOpenJDK/openjdk-jdk8u
 OPENJDK_REPO_NAME=openjdk
 
-while [[ $# -gt 0 ]] && [[ ."$1" == .-* ]] ; do
-  opt="$1";
-  shift;
-  case "$opt" in
-    "--" ) break 2;;
+JAVA_SOURCE=""
+JAVA_DESTINATION=""
+WORKING_DIR=""
+USE_SSH=false
+BRANCH=""
 
-    "--source" )
-    JAVA_SOURCE="$1"; shift;;
+parseCommandLineArgs()
+{
+    while [[ $# -gt 0 ]] && [[ ."$1" == .-* ]] ; do
+      opt="$1";
+      shift;
+      case "$opt" in
+        "--" ) break 2;;
 
-    "--destination" )
-    JAVA_DESTINATION="$1"; shift;;
+        "--source" )
+        JAVA_SOURCE="$1"; shift;;
 
-    "--ssh" | "-S" )
-    USE_SSH=true; shift;;
+        "--destination" )
+        JAVA_DESTINATION="$1"; shift;;
 
-    "--repository" | "-r" )
-    REPOSITORY="$1"; shift;;
+        "--ssh" | "-S" )
+        USE_SSH=true; shift;;
 
-    "--branch" | "-b" )
-    BRANCH="$1"; shift;;
+        "--repository" | "-r" )
+        REPOSITORY="$1"; shift;;
 
-    "--working_dir" )
-    WORKING_DIR="$1"; shift;;
+        "--branch" | "-b" )
+        BRANCH="$1"; shift;;
 
-    *) echo >&2 "Invalid option: ${opt}"; echo "This option was unrecognised. See the script jtreg_prep.sh for a full list."; exit 1;;
-   esac
-done
+        "--working_dir" )
+        WORKING_DIR="$1"; shift;;
 
-if [ -z "${JAVA_SOURCE}" ]; then
-  echo >&2 "jtreg_prep.sh failed: --source must be specified"; exit 1
-fi
+        *) echo >&2 "Invalid option: ${opt}"; echo "This option was unrecognised. See the script jtreg_prep.sh for a full list."; exit 1;;
+       esac
+    done
 
-if [ -z "${WORKING_DIR}" ] ; then
-  echo "WORKING_DIR is undefined so setting to $PWD"
-  WORKING_DIR=$PWD
-else
-  echo "Working dir is $WORKING_DIR"
-fi
+    if [ -z "${JAVA_SOURCE}" ]; then
+      echo >&2 "jtreg_prep.sh failed: --source must be specified"; exit 1
+    fi
 
-if [ -z "${JAVA_DESTINATION}" ]; then
-  JAVA_DESTINATION="$WORKING_DIR/$OPENJDK_REPO_NAME/build/java_home/images"
-fi
+    if [ -z "${WORKING_DIR}" ] ; then
+      echo "WORKING_DIR is undefined so setting to $PWD"
+      WORKING_DIR=$PWD
+    else
+      echo "Working dir is $WORKING_DIR"
+    fi
 
-if [ -z "${BRANCH}" ] ; then
-  echo "BRANCH is undefined so checking out dev"
-  BRANCH="dev"
-fi
+    if [ -z "${JAVA_DESTINATION}" ]; then
+      JAVA_DESTINATION="$WORKING_DIR/$OPENJDK_REPO_NAME/build/java_home/images"
+    fi
+
+    if [ -z "${BRANCH}" ] ; then
+      echo "BRANCH is undefined so checking out dev"
+      BRANCH="dev"
+    fi
+}
 
 # Step 1: Fetch OpenJDK, as that's where the tests live.
-
-if [ -d "$WORKING_DIR"/$OPENJDK_REPO_NAME/.git ] && [ $REPOSITORY == "AdoptOpenJDK/openjdk-jdk8u" ] ; then
-  # It does exist and it's a repo other than the AdoptOpenJDK one
-  cd $WORKING_DIR/$OPENJDK_REPO_NAME
-  echo "Will reset the repository at $PWD in 10 seconds..."
-  sleep 10
-  echo "Pulling latest changes from git repo"
-  git fetch --all
-  git reset --hard origin/$BRANCH
-  cd $WORKING_DIR
-elif [ ! -d "${WORKING_DIR}"/$OPENJDK_REPO_NAME/.git ] ; then
-  # If it doesn't exist, clone it
-  echo "Didn't find any existing openjdk repository at WORKING_DIR (set to ${WORKING_DIR}) so cloning the source to openjdk"
-  if [[ "${USE_SSH}" == true ]] ; then
-    echo "git clone -b ${BRANCH} git@github.com:${REPOSITORY}.git $WORKING_DIR/$OPENJDK_REPO_NAME"
-    git clone -b ${BRANCH} git@github.com:${REPOSITORY}.git $WORKING_DIR/$OPENJDK_REPO_NAME
-  else
-    echo "git clone -b ${BRANCH} https://github.com/${REPOSITORY}.git $WORKING_DIR/$OPENJDK_REPO_NAME"
-    git clone -b ${BRANCH} https://github.com/${REPOSITORY}.git $WORKING_DIR/$OPENJDK_REPO_NAME
-  fi
-fi
+cloneOpenJDKRepo()
+{
+    if [ -d "$WORKING_DIR"/$OPENJDK_REPO_NAME/.git ] && [ $REPOSITORY == "AdoptOpenJDK/openjdk-jdk8u" ] ; then
+      # It does exist and it's a repo other than the AdoptOpenJDK one
+      cd $WORKING_DIR/$OPENJDK_REPO_NAME
+      echo "Will reset the repository at $PWD in 10 seconds..."
+      sleep 10
+      echo "Pulling latest changes from git repo"
+      git fetch --all
+      git reset --hard origin/$BRANCH
+      cd $WORKING_DIR
+    elif [ ! -d "${WORKING_DIR}"/$OPENJDK_REPO_NAME/.git ] ; then
+      # If it doesn't exist, clone it
+      echo "Didn't find any existing openjdk repository at WORKING_DIR (set to ${WORKING_DIR}) so cloning the source to openjdk"
+      if [[ "${USE_SSH}" == true ]] ; then
+        echo "git clone -b ${BRANCH} git@github.com:${REPOSITORY}.git $WORKING_DIR/$OPENJDK_REPO_NAME"
+        git clone -b ${BRANCH} git@github.com:${REPOSITORY}.git $WORKING_DIR/$OPENJDK_REPO_NAME
+      else
+        echo "git clone -b ${BRANCH} https://github.com/${REPOSITORY}.git $WORKING_DIR/$OPENJDK_REPO_NAME"
+        git clone -b ${BRANCH} https://github.com/${REPOSITORY}.git $WORKING_DIR/$OPENJDK_REPO_NAME
+      fi
+    fi
+}
 
 # Step 2: Retrieve Java
+downloadJDKArtifact()
+{
+    if [ ! -d "${JAVA_DESTINATION}" ]; then
+      mkdir -p "${JAVA_DESTINATION}"
+    fi
+    cd "${JAVA_DESTINATION}"
 
-if [ ! -d "${JAVA_DESTINATION}" ]; then
-  mkdir -p "${JAVA_DESTINATION}"
-fi
-cd "${JAVA_DESTINATION}"
-
-#If it's a http location, use wget.
-if [[ "${JAVA_SOURCE}" == http* ]]; then 
-  wget "${JAVA_SOURCE}"
-  if [ $? -ne 0 ]; then
-    echo "Failed to retrieve the jtreg binary, exiting"
-    exit 1
-  fi
-else #Assume it's local or on a mounted drive.
-  if [ -f "${JAVA_SOURCE}" ] || [ -d "${JAVA_SOURCE}" ]; then
-    cp -r "${JAVA_SOURCE}" .
-  else
-    echo "Java could not be found at the java_source location."
-    exit 1
-  fi
-fi
+    #If it's a http location, use wget.
+    if [[ "${JAVA_SOURCE}" == http* ]]; then
+      wget "${JAVA_SOURCE}"
+      if [ $? -ne 0 ]; then
+        echo "Failed to retrieve the jtreg binary from ${JAVA_SOURCE}, exiting"
+        exit 1
+      fi
+    else #Assume it's local or on a mounted drive.
+      if [ -f "${JAVA_SOURCE}" ] || [ -d "${JAVA_SOURCE}" ]; then
+        cp -r "${JAVA_SOURCE}" .
+      else
+        echo "Java could not be found at the java_source location: ${JAVA_SOURCE}."
+        exit 1
+      fi
+    fi
+}
 
 # Step 3: Unpack Java if we need to.
-
-if [[ "$JAVA_SOURCE" == *\.tar\.gz ]]; then #If it's a tar file, unpack it.
-  cd "${JAVA_DESTINATION}"
-  tar xf *.tar.gz
-  echo "Java has been untarred."
-  cd "${WORKING_DIR}"
-elif [ ! -d "${JAVA_SOURCE}" ]; then #If it's not a directory, then we don't know how to unpack it. 
-  echo "The Java file you specified as source was copied to the destination, but this script doesn't know how to unpack it. Please add this logic to this script, or unpack it manually before running jtreg.";
-fi
+unpackJDKTarArtifact()
+{
+    if [[ "$JAVA_SOURCE" == *\.tar\.gz ]]; then #If it's a tar file, unpack it.
+      cd "${JAVA_DESTINATION}"
+      tar xf *.tar.gz
+      echo "Java has been untarred at ${JAVA_DESTINATION}."
+      cd "${WORKING_DIR}"
+    elif [ ! -d "${JAVA_SOURCE}" ]; then #If it's not a directory, then we don't know how to unpack it.
+      echo "The Java file you specified as source was copied to the destination, but this script doesn't know how to unpack it. Please add this logic to this script, or unpack it manually before running jtreg.";
+    fi
+}
 
 # Step 4: Finish
-echo "jtreg_prep.sh has finished successfully."
-exit 0
+printFinishedMessage()
+{
+    echo "jtreg_prep.sh has finished successfully."
+}
+
+##################################################################
+
+parseCommandLineArgs $@
+cloneOpenJDKRepo
+downloadJDKArtifact
+unpackJDKTarArtifact
+printFinishedMessage


### PR DESCRIPTION
Fully resolves issue #53. Amends all .sh scripts in the repo that has to do with jenkins or local builds. 

Beware there are plenty of small changes, mainly due to the replacement of the existing use of $VAR, ${VAR} and "${VAR}" with the respective versions depending on where the VAR was placed:

- use "$VAR" in if conditions
- use ${VAR} if it was part of another string/variable i.e. "The source is ${VAR}"
- use $VAR in all other circumstances

See the [ref guide](https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html)

- Added documentation and updated both short and long param flags