### PR TITLE
Travis file for lint checking script files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: bash
+
+# Use container-based infrastructure for quicker build start-up
+sudo: false
+
+addons:
+  apt:
+    sources:
+    - debian-sid    # Grab shellcheck from the Debian repo (o_O)
+    packages:
+    - shellcheck
+
+script:
+ - bash -c 'shopt -s globstar; shellcheck **/*.sh'
+
+matrix:
+  fast_finish: true


### PR DESCRIPTION
This will run shellcheck on all files ending with '.sh' and report any static issues found.