### PR TITLE
Fix shell script lint check errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: bash
+
+# Use container-based infrastructure for quicker build start-up
+sudo: false
+
+addons:
+  apt:
+    sources:
+    - debian-sid    # Grab shellcheck from the Debian repo (o_O)
+    packages:
+    - shellcheck
+
+script:
+ - bash -c 'shopt -s globstar; shellcheck **/*.sh'
+
+matrix:
+  fast_finish: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Repository for useful files to build OpenJDK
 
+[![Build Status](https://travis-ci.org/AdoptOpenJDK/openjdk-build.svg?branch=master)](https://travis-ci.org/AdoptOpenJDK/openjdk-build)
+
 AdoptOpenJDK makes use of these scripts to provide a build farm at http://ci.adoptopenjdk.net which produces OpenJDK binaries for consumption via http://www.adoptopenjdk.net
 
 ## This repository contains three folders and one script you should be calling to build OpenJDK

--- a/git-hg/git-hg.sh
+++ b/git-hg/git-hg.sh
@@ -18,7 +18,7 @@ hg clone http://hg.openjdk.java.net/jdk8u/jdk8u/ openjdk_hg
 
 cd openjdk_hg || exit
 # get latest mercurial tag
-hgTag=`hg log -r "." --template "{latesttag}\n"`
+#hgTag=`hg log -r "." --template "{latesttag}\n"`
 
 bash ./get_source.sh
 for i in corba jaxp jaxws langtools jdk hotspot nashorn; do
@@ -50,7 +50,7 @@ git commit -m "merge sources"
 git remote add releases git@github.com:AdoptOpenJDK/openjdk-jdk8u.git
 git fetch --all
 # check if git diff is the same
-if [ `git diff releases/master | wc -l` -gt 0 ]; then
+if [ $(git diff releases/master | wc -l) -gt 0 ]; then
 	git checkout -b staging
 	git checkout master
 	git reset --hard releases/master

--- a/git-hg/git-hg.sh
+++ b/git-hg/git-hg.sh
@@ -50,7 +50,7 @@ git commit -m "merge sources"
 git remote add releases git@github.com:AdoptOpenJDK/openjdk-jdk8u.git
 git fetch --all
 # check if git diff is the same
-if [ $(git diff releases/master | wc -l) -gt 0 ]; then
+if [ "$(git diff releases/master | wc -l)" -gt 0 ]; then
 	git checkout -b staging
 	git checkout master
 	git reset --hard releases/master

--- a/git-hg/git-hg.sh
+++ b/git-hg/git-hg.sh
@@ -37,13 +37,13 @@ git init
 "$WORKSPACE"/fast-export/hg-fast-export.sh -r "$WORKSPACE"/openjdk_hg
 for i in corba jaxp jaxws langtools jdk hotspot nashorn; do
 	# copy the additional repos in
-	cp -r "$WORKSPACE"/openjdk_hg/$i $i
+	cp -r "${WORKSPACE}"/openjdk_hg/$i $i
 done
 git checkout
 # remove remaining mercurial stuff
 rm -rf .hg .hgignore .hgtags README-builds.html README get_source.sh
 # create new README
-cp "$WORKSPACE"/openjdk-build/git-hg/README.md .
+cp "${WORKSPACE}"/openjdk-build/git-hg/README.md .
 echo ".hg/" > .gitignore
 git add .
 git commit -m "merge sources"

--- a/git-hg/git-hg.sh
+++ b/git-hg/git-hg.sh
@@ -16,7 +16,7 @@
 git clone https://github.com/frej/fast-export.git
 hg clone http://hg.openjdk.java.net/jdk8u/jdk8u/ openjdk_hg
 
-cd openjdk_hg
+cd openjdk_hg || exit
 # get latest mercurial tag
 hgTag=`hg log -r "." --template "{latesttag}\n"`
 
@@ -24,26 +24,26 @@ bash ./get_source.sh
 for i in corba jaxp jaxws langtools jdk hotspot nashorn; do
    echo "cleaning up $i"
    # removes the mercurial stuff from the additional repos
-   cd $i
+   cd $i || exit
    rm -rf .hg .hgignore .hgtags
-   cd -
+   cd - || exit
 done
-cd $WORKSPACE
+cd "$WORKSPACE" || exit
 
 mkdir openjdk_git
-cd openjdk_git
+cd openjdk_git || exit
 git init
 # convert mercurial to github
-$WORKSPACE/fast-export/hg-fast-export.sh -r $WORKSPACE/openjdk_hg
+"$WORKSPACE"/fast-export/hg-fast-export.sh -r "$WORKSPACE"/openjdk_hg
 for i in corba jaxp jaxws langtools jdk hotspot nashorn; do
 	# copy the additional repos in
-	cp -r $WORKSPACE/openjdk_hg/$i $i
+	cp -r "$WORKSPACE"/openjdk_hg/$i $i
 done
 git checkout
 # remove remaining mercurial stuff
 rm -rf .hg .hgignore .hgtags README-builds.html README get_source.sh
 # create new README
-cp $WORKSPACE/openjdk-build/git-hg/README.md .
+cp "$WORKSPACE"/openjdk-build/git-hg/README.md .
 echo ".hg/" > .gitignore
 git add .
 git commit -m "merge sources"

--- a/makejdk.sh
+++ b/makejdk.sh
@@ -27,18 +27,17 @@
 REPOSITORY=AdoptOpenJDK/openjdk-jdk8u
 OPENJDK_REPO_NAME=openjdk
 
-OS_KERNEL_NAME=$(uname) | awk '{print tolower($0)}'
-
-OS_MACHINE=$(uname -m)
+OS_KERNEL_NAME=$(uname | awk '{print tolower($0)}')
+OS_CPU_NAME=$(uname -m)
 
 JVM_VARIANT=server
-if [[ "$OS_MACHINE" == "s390x" ]] || [[ "$OS_MACHINE" == "armv7l" ]] ; then
+if [[ "$OS_CPU_NAME" == "s390x" ]] || [[ "$OS_CPU_NAME" == "armv7l" ]] ; then
  JVM_VARIANT=zero
 fi 
 
 BUILD_TYPE=normal
 
-BUILD_FULL_NAME=$OS_KERNEL_NAME-$OS_MACHINE-$BUILD_TYPE-$JVM_VARIANT-release
+BUILD_FULL_NAME=$OS_KERNEL_NAME-$OS_CPU_NAME-$BUILD_TYPE-$JVM_VARIANT-release
 
 USE_DOCKER=false
 WORKING_DIR=""
@@ -187,7 +186,7 @@ cloneOpenJDKGitRepo()
       echo "git clone -b ${BRANCH} git@github.com:${REPOSITORY}.git ${WORKING_DIR}/${OPENJDK_REPO_NAME}"
       git clone -b ${BRANCH} git@github.com:"${REPOSITORY}".git "${WORKING_DIR}/${OPENJDK_REPO_NAME}"
     else
-      echo "git clone -b ${BRANCH} https://github.com/"${REPOSITORY}".git "${WORKING_DIR}/${OPENJDK_REPO_NAME}""
+      echo "git clone -b ${BRANCH} https://github.com/${REPOSITORY}.git ${WORKING_DIR}/${OPENJDK_REPO_NAME}"
       git clone -b ${BRANCH} https://github.com/"${REPOSITORY}".git "$WORKING_DIR/$OPENJDK_REPO_NAME"
     fi
   fi
@@ -240,14 +239,14 @@ buildAndTestOpenJDKViaDocker()
   CONTAINER_ID=$(docker ps -a | awk '{ print $1,$2 }' | grep openjdk_container | awk '{print $1 }'| head -1)
 
   if [[ "${COPY_TO_HOST}" == "true" ]] ; then
-    echo "Copying to the host with docker cp "$CONTAINER_ID":/openjdk/jdk8u/OpenJDK.tar.gz $TARGET_DIR"
+    echo "Copying to the host with docker cp $CONTAINER_ID:/openjdk/jdk8u/OpenJDK.tar.gz $TARGET_DIR"
     docker cp "$CONTAINER_ID":/openjdk/jdk8u/OpenJDK.tar.gz "$TARGET_DIR"
   fi
 
   if [[ "${JTREG}" == "true" ]] ; then
     echo "Copying jtreg reports from docker"
-    docker cp $CONTAINER_ID:/openjdk/jdk8u/jtreport.zip $TARGET_DIR
-    docker cp $CONTAINER_ID:/openjdk/jdk8u/jtwork.zip $TARGET_DIR
+    docker cp "$CONTAINER_ID":/openjdk/jdk8u/jtreport.zip "$TARGET_DIR"
+    docker cp "$CONTAINER_ID":/openjdk/jdk8u/jtwork.zip "$TARGET_DIR"
   fi
 
   # Didn't specify to keep

--- a/makejdk.sh
+++ b/makejdk.sh
@@ -287,7 +287,7 @@ buildAndTestOpenJDK()
 
 initialiseEscapeCodes
 sourceSignalHandler
-parseCommandLineArgs $@
+parseCommandLineArgs "$@"
 checkIfDockerIsUsedForBuildingOrNot
 checkInCaseOfDockerShouldTheContainerBePreserved
 setDefaultIfBranchIsNotProvided

--- a/makejdk.sh
+++ b/makejdk.sh
@@ -28,15 +28,15 @@ REPOSITORY=AdoptOpenJDK/openjdk-jdk8u
 OPENJDK_REPO_NAME=openjdk
 
 OS_KERNEL_NAME=$(uname | awk '{print tolower($0)}')
-OS_CPU_NAME=$(uname -m)
+OS_MACHINE_NAME=$(uname -m)
 
 JVM_VARIANT=server
-if [[ "$OS_CPU_NAME" == "s390x" ]] || [[ "$OS_CPU_NAME" == "armv7l" ]] ; then
+if [[ "$OS_MACHINE_NAME" == "s390x" ]] || [[ "$OS_MACHINE_NAME" == "armv7l" ]] ; then
  JVM_VARIANT=zero
 fi 
 
 BUILD_TYPE=normal
-BUILD_FULL_NAME=$OS_KERNEL_NAME-$OS_CPU_NAME-$BUILD_TYPE-$JVM_VARIANT-release
+BUILD_FULL_NAME=${OS_KERNEL_NAME}-${OS_MACHINE_NAME}-${BUILD_TYPE}-${JVM_VARIANT}-release
 USE_DOCKER=false
 WORKING_DIR=""
 USE_SSH=false
@@ -142,10 +142,10 @@ setDefaultIfBranchIsNotProvided()
 setWorkingDirectoryIfProvided()
 {
   if [ -z "${WORKING_DIR}" ] ; then
-    echo "${info}WORKING_DIR is undefined so setting to $PWD${normal}."
+    echo "${info}WORKING_DIR is undefined so setting to ${PWD}${normal}."
     WORKING_DIR=$PWD
   else
-    echo "${info}Working dir is $WORKING_DIR${normal}."
+    echo "${info}Working dir is ${WORKING_DIR}${normal}."
   fi
 }
 
@@ -185,7 +185,7 @@ cloneOpenJDKGitRepo()
       git clone -b ${BRANCH} git@github.com:"${REPOSITORY}".git "${WORKING_DIR}/${OPENJDK_REPO_NAME}"
     else
       echo "git clone -b ${BRANCH} https://github.com/${REPOSITORY}.git ${WORKING_DIR}/${OPENJDK_REPO_NAME}"
-      git clone -b ${BRANCH} https://github.com/"${REPOSITORY}".git "$WORKING_DIR/$OPENJDK_REPO_NAME"
+      git clone -b ${BRANCH} https://github.com/"${REPOSITORY}".git "${WORKING_DIR}/${OPENJDK_REPO_NAME}"
     fi
   fi
   echo "${normal}"
@@ -230,7 +230,7 @@ buildAndTestOpenJDKViaDocker()
      echo "$normal"
   fi
 
-  docker run --privileged -t -v "$WORKING_DIR/$OPENJDK_REPO_NAME:/openjdk/jdk8u/openjdk" --entrypoint build.sh "$CONTAINER"
+  docker run --privileged -t -v "${WORKING_DIR}/${OPENJDK_REPO_NAME}:/openjdk/jdk8u/openjdk" --entrypoint build.sh "${CONTAINER}"
 
   testOpenJDKViaDocker
 
@@ -238,18 +238,18 @@ buildAndTestOpenJDKViaDocker()
 
   if [[ "${COPY_TO_HOST}" == "true" ]] ; then
     echo "Copying to the host with docker cp $CONTAINER_ID:/openjdk/jdk8u/OpenJDK.tar.gz $TARGET_DIR"
-    docker cp "$CONTAINER_ID":/openjdk/jdk8u/OpenJDK.tar.gz "$TARGET_DIR"
+    docker cp "${CONTAINER_ID}":/openjdk/jdk8u/OpenJDK.tar.gz "${TARGET_DIR}"
   fi
 
   if [[ "${JTREG}" == "true" ]] ; then
     echo "Copying jtreg reports from docker"
-    docker cp "$CONTAINER_ID":/openjdk/jdk8u/jtreport.zip "$TARGET_DIR"
-    docker cp "$CONTAINER_ID":/openjdk/jdk8u/jtwork.zip "$TARGET_DIR"
+    docker cp "${CONTAINER_ID}":/openjdk/jdk8u/jtreport.zip "${TARGET_DIR}"
+    docker cp "${CONTAINER_ID}":/openjdk/jdk8u/jtwork.zip "${TARGET_DIR}"
   fi
 
   # Didn't specify to keep
   if [[ -z ${KEEP} ]] ; then
-    docker ps -a | awk '{ print $1,$2 }' | grep $CONTAINER | awk '{print $1 }' | xargs -I {} docker rm {}
+    docker ps -a | awk '{ print $1,$2 }' | grep "${CONTAINER}" | awk '{print $1 }' | xargs -I {} docker rm {}
   fi
 }
 
@@ -257,14 +257,14 @@ testOpenJDKInNativeEnvironmentIfExpected()
 {
   if [[ "$JTREG" == "true" ]];
   then
-      "$WORKING_DIR"/sbin/jtreg.sh "$WORKING_DIR" "$OPENJDK_REPO_NAME" "$BUILD_FULL_NAME" "$JTREG_TEST_SUBSETS"
+      "${WORKING_DIR}"/sbin/jtreg.sh "${WORKING_DIR}" "${OPENJDK_REPO_NAME}" "${BUILD_FULL_NAME}" "${JTREG_TEST_SUBSETS}"
   fi
 }
 
 buildAndTestOpenJDKInNativeEnvironment()
 {
   echo "Calling sbin/build.sh $WORKING_DIR $TARGET_DIR $OPENJDK_REPO_NAME $BUILD_FULL_NAME $JVM_VARIANT"
-  "$WORKING_DIR"/sbin/build.sh "$WORKING_DIR" "$TARGET_DIR" "$OPENJDK_REPO_NAME" "$BUILD_FULL_NAME" "$JVM_VARIANT"
+  "${WORKING_DIR}"/sbin/build.sh "${WORKING_DIR}" "${TARGET_DIR}" "${OPENJDK_REPO_NAME}" "${BUILD_FULL_NAME}" "${JVM_VARIANT}"
 
   testOpenJDKInNativeEnvironmentIfExpected
 }

--- a/makejdk.sh
+++ b/makejdk.sh
@@ -125,13 +125,13 @@ checkIfDockerIsUsedForBuildingOrNot()
 
 checkInCaseOfDockerShouldTheContainerBePreserved()
 {
-  echo ${info}
+  echo "${info}"
   if [ "${KEEP}" == "true" ] ; then
     echo "We'll keep the built Docker container if you're using Docker"
   else
     echo "We'll remove the built Docker container if you're using Docker"
   fi
-  echo $normal
+  echo "${normal}"
 }
 
 setDefaultIfBranchIsNotProvided()
@@ -154,7 +154,7 @@ setWorkingDirectoryIfProvided()
 
 setTargetDirectoryIfProvided()
 {
-  echo $info
+  echo "${info}"
   if [ -z "${TARGET_DIR}" ] ; then
     echo "${info}TARGET_DIR is undefined so setting to $PWD"
     TARGET_DIR=$PWD
@@ -169,35 +169,35 @@ setTargetDirectoryIfProvided()
 
 cloneOpenJDKGitRepo()
 {
-  echo $git
+  echo "${git}"
   if [ -d "${WORKING_DIR}/${OPENJDK_REPO_NAME}/.git" ] && [ "$REPOSITORY" == "AdoptOpenJDK/openjdk-jdk8u" ] ; then
     # It does exist and it's a repo other than the AdoptOpenJDK one
-    cd $WORKING_DIR/$OPENJDK_REPO_NAME
+    cd "${WORKING_DIR}/${OPENJDK_REPO_NAME}" || return
     echo "${info}Will reset the repository at $PWD in 10 seconds...${git}"
     sleep 10
     echo "${git}Pulling latest changes from git repo"
     git fetch --all
     git reset --hard origin/$BRANCH
-    echo $normal
-    cd $WORKING_DIR
+    echo "${normal}"
+    cd "${WORKING_DIR}" || return
   elif [ ! -d "${WORKING_DIR}/${OPENJDK_REPO_NAME}/.git" ] ; then
     # If it doesn't exixt, clone it
     echo "${info}Didn't find any existing openjdk repository at WORKING_DIR (set to ${WORKING_DIR}) so cloning the source to openjdk"
     if [[ "${USE_SSH}" == "true" ]] ; then
       echo "git clone -b ${BRANCH} git@github.com:${REPOSITORY}.git ${WORKING_DIR}/${OPENJDK_REPO_NAME}"
-      git clone -b ${BRANCH} git@github.com:${REPOSITORY}.git $WORKING_DIR/$OPENJDK_REPO_NAME
+      git clone -b ${BRANCH} git@github.com:"${REPOSITORY}".git "${WORKING_DIR}/${OPENJDK_REPO_NAME}"
     else
       echo "git clone -b ${BRANCH} https://github.com/${REPOSITORY}.git ${WORKING_DIR}/${OPENJDK_REPO_NAME}"
       git clone -b ${BRANCH} https://github.com/${REPOSITORY}.git $WORKING_DIR/$OPENJDK_REPO_NAME
     fi
   fi
-  echo $normal
+  echo "${normal}"
 }
 
 testOpenJDKViaDocker()
 {
   if [[ ! -z $JTREG ]]; then
-    docker run --privileged -t -v $WORKING_DIR/$OPENJDK_REPO_NAME:/openjdk/jdk8u/openjdk --entrypoint jtreg.sh $CONTAINER
+    docker run --privileged -t -v "${WORKING_DIR}/${OPENJDK_REPO_NAME}":/openjdk/jdk8u/openjdk --entrypoint jtreg.sh "${CONTAINER}"
   fi
 }
 

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -212,7 +212,7 @@ configureCommandParameters()
 stepIntoTheWorkingDirectory()
 {
   # Make sure we're in the source directory for OpenJDK now
-  cd $WORKING_DIR/$OPENJDK_REPO_NAME
+  cd "$WORKING_DIR/$OPENJDK_REPO_NAME"  || exit
   echo "Should have the source, I'm at $PWD"
 }
 
@@ -258,7 +258,7 @@ buildOpenJDK()
   $makeCMD
 
   if [ $? -ne 0 ]; then
-     echo "${fail}Failed to make the JDK, exiting"
+     echo "${error}Failed to make the JDK, exiting"
     exit;
   else
     echo "${good}Built the JDK!"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -93,9 +93,9 @@ checkingAndDownloadingAlsa()
   if [[ ! -z "${FOUND_ALSA}" ]] ; then
     echo "Skipping ALSA download"
   else
-    wget -nc ftp://ftp.alsa-project.org/pub/lib/alsa-lib-"$ALSA_LIB_VERSION".tar.bz2
-    tar xvf alsa-lib-"$ALSA_LIB_VERSION".tar.bz2
-    rm alsa-lib-"$ALSA_LIB_VERSION".tar.bz2
+    wget -nc ftp://ftp.alsa-project.org/pub/lib/alsa-lib-"${ALSA_LIB_VERSION}".tar.bz2
+    tar xvf alsa-lib-"${ALSA_LIB_VERSION}".tar.bz2
+    rm alsa-lib-"${ALSA_LIB_VERSION}".tar.bz2
   fi
 }
 
@@ -122,7 +122,7 @@ checkingAndDownloadingFreetype()
     fi
 
     # We get the files we need at $WORKING_DIR/installedfreetype
-    bash ./configure --prefix="$WORKING_DIR"/"$OPENJDK_REPO_NAME"/installedfreetype "$PARAMS" && make all && make install
+    bash ./configure --prefix="${WORKING_DIR}"/"${OPENJDK_REPO_NAME}"/installedfreetype "${PARAMS}" && make all && make install
 
     if [ $? -ne 0 ]; then
       echo "${error}Failed to configure and build libfreetype, exiting"
@@ -292,7 +292,7 @@ createOpenJDKTarArchive()
 
 stepIntoTargetDirectoryAndShowCompletionMessage()
 {
-  cd $TARGET_DIR  || return
+  cd "${TARGET_DIR}"  || return
   ls
   echo "All done!"
 }

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -118,6 +118,7 @@ checkingAndDownloadingFreetype()
     cd freetype-"$FREETYPE_FONT_VERSION" || exit
 
     if [ "$OS_CPU_NAME" = "ppc64le" ]; then
+      # shellcheck disable=SC1083
       PARAMS="--build=$(rpm --eval %{_host})"
     fi
 

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -35,6 +35,8 @@ FREETYPE_FONT_VERSION=${FREETYPE_FONT_VERSION:-2.4.0}
 MAKE_ARGS_FOR_ALL_PLATFORMS=${MAKE_ARGS_FOR_ALL_PLATFORMS:-"images"}
 MAKE_ARGS_FOR_SPECIAL_PLATFORMS=${MAKE_ARGS_FOR_SPECIAL_PLATFORMS:-"CONF=${BUILD_FULL_NAME} DEBUG_BINARIES=true images"}
 
+OS_CPU_NAME=$(uname -m)
+
 initialiseEscapeCodes()
 {
   # Escape code
@@ -43,7 +45,9 @@ initialiseEscapeCodes()
   # Set colors
   error="${esc}[0;31m"
   good="${esc}[0;32m"
+  # shellcheck disable=SC2034
   info="${esc}[0;33m"
+  # shellcheck disable=SC2034
   git="${esc}[0;34m"
   normal=$(echo -en "${esc}[m\017")
 }
@@ -76,7 +80,7 @@ checkIfDockerIsUsedForBuildingOrNot()
 
   mkdir -p $WORKING_DIR
 
-  cd $WORKING_DIR
+  cd $WORKING_DIR || exit
 }
 
 checkingAndDownloadingAlsa()
@@ -90,9 +94,9 @@ checkingAndDownloadingAlsa()
   if [[ ! -z "${FOUND_ALSA}" ]] ; then
     echo "Skipping ALSA download"
   else
-    wget -nc ftp://ftp.alsa-project.org/pub/lib/alsa-lib-$ALSA_LIB_VERSION.tar.bz2
-    tar xvf alsa-lib-$ALSA_LIB_VERSION.tar.bz2
-    rm alsa-lib-$ALSA_LIB_VERSION.tar.bz2
+    wget -nc ftp://ftp.alsa-project.org/pub/lib/alsa-lib-"$ALSA_LIB_VERSION".tar.bz2
+    tar xvf alsa-lib-"$ALSA_LIB_VERSION".tar.bz2
+    rm alsa-lib-"$ALSA_LIB_VERSION".tar.bz2
   fi
 }
 
@@ -106,19 +110,19 @@ checkingAndDownloadingFreetype()
     echo "Skipping FreeType download"
   else
     # Then FreeType for fonts: make it and use
-    wget -nc http://ftp.acc.umu.se/mirror/gnu.org/savannah/freetype/freetype-$FREETYPE_FONT_VERSION.tar.gz
+    wget -nc http://ftp.acc.umu.se/mirror/gnu.org/savannah/freetype/freetype-"$FREETYPE_FONT_VERSION".tar.gz
      
-    tar xvf freetype-$FREETYPE_FONT_VERSION.tar.gz
-    rm freetype-$FREETYPE_FONT_VERSION.tar.gz
+    tar xvf freetype-"$FREETYPE_FONT_VERSION".tar.gz
+    rm freetype-"$FREETYPE_FONT_VERSION".tar.gz
 
-    cd freetype-$FREETYPE_FONT_VERSION
+    cd freetype-"$FREETYPE_FONT_VERSION" || exit
 
-    if [ $(uname -m) = "ppc64le" ]; then
+    if [ "$OS_CPU_NAME" = "ppc64le" ]; then
       PARAMS="--build=$(rpm --eval %{_host})"
     fi
 
     # We get the files we need at $WORKING_DIR/installedfreetype
-    bash ./configure --prefix=$WORKING_DIR/$OPENJDK_REPO_NAME/installedfreetype $PARAMS && make all && make install
+    bash ./configure --prefix="$WORKING_DIR"/"$OPENJDK_REPO_NAME"/installedfreetype "$PARAMS" && make all && make install
 
     if [ $? -ne 0 ]; then
       echo "${error}Failed to configure and build libfreetype, exiting"
@@ -132,7 +136,7 @@ checkingAndDownloadingFreetype()
 
 checkingAndDownloadCaCerts()
 {
-  cd $WORKING_DIR
+  cd "$WORKING_DIR" || exit
 
   echo "Retrieving cacerts file"
 
@@ -176,11 +180,11 @@ configuringBootJDKConfigureParameter()
 
 buildingTheRestOfTheConfigParameters()
 {
-  if [ ! -z $(which ccache) ]; then
+  if [ ! -z "$(which ccache)" ]; then
     CONFIGURE_CMD="$CONFIGURE_CMD --enable-ccache"
   fi
   
-  if [[ `uname -m` == "armv7l" ]] ; then
+  if [[ "$OS_CPU_NAME" == "armv7l" ]] ; then
     CONFIGURE_CMD="$CONFIGURE_CMD --with-num-cores=4"
   fi
 
@@ -220,9 +224,9 @@ runTheOpenJDKConfigureCommandAndUseThePrebuildConfigParams()
     echo "Not reconfiguring due to the presence of config.status in $WORKING_DIR"
   else
     echo "Running ./configure with $CONFIGURE_CMD"
-    bash ./configure $CONFIGURE_CMD
+    bash ./configure "$CONFIGURE_CMD"
     if [ $? -ne 0 ]; then
-      echo ${fail}
+      echo "${error}"
       echo "Failed to configure the JDK, exiting"
       echo "Did you set the JDK boot directory correctly? Override by exporting JDK_BOOT_DIR"
       echo "For example, on RHEL you would do export JDK_BOOT_DIR=/usr/lib/jvm/java-1.7.0-openjdk-1.7.0.131-2.6.9.0.el7_3.x86_64"
@@ -244,7 +248,7 @@ buildOpenJDK()
     exit 0
   fi
 
-  if [ $(uname -m) == "s390x" ]; then
+  if [ "$OS_CPU_NAME" == "s390x" ]; then
     makeCMD="make ${MAKE_ARGS_FOR_SPECIAL_PLATFORMS}"
   else
     makeCMD="make ${MAKE_ARGS_FOR_ALL_PLATFORMS}"
@@ -268,7 +272,7 @@ removingUnnecessaryFiles()
 
   rm -rf cacerts_area
 
-  cd build/*/images
+  cd build/*/images  || return
 
   # Remove files we don't need
   rm -rf j2sdk-image/demo/applets
@@ -288,7 +292,7 @@ createOpenJDKTarArchive()
 
 stepIntoTargetDirectoryAndShowCompletionMessage()
 {
-  cd $TARGET_DIR
+  cd $TARGET_DIR  || return
   ls
   echo "All done!"
 }

--- a/sbin/jtreg.sh
+++ b/sbin/jtreg.sh
@@ -16,7 +16,7 @@
 WORKING_DIR=$1
 OPENJDK_REPO_NAME=$2
 BUILD_FULL_NAME=$3
-JTREG_TEST_SUBSETS=$(echo "$4" | sed 's/:/ /')
+JTREG_TEST_SUBSETS=$($4//:/ ) # Replace all ':' with ' '
 JTREG_VERSION=${JTREG_VERSION:-4.2.0-tip}
 JTREG_TARGET_FOLDER=${JTREG_TARGET_FOLDER:-jtreg}
 JOB_NAME=${JOB_NAME:-OpenJDK}
@@ -39,36 +39,36 @@ downloadJtregAndSetupEnvironment()
   if [[ ! -d "${WORKING_DIR}/${JTREG_TARGET_FOLDER}" ]]; then
    echo "Downloading Jtreg binary"
    JTREG_BINARY_FILE="jtreg-${JTREG_VERSION}.tar.gz"
-   wget https://ci.adoptopenjdk.net/job/jtreg/lastSuccessfulBuild/artifact/$JTREG_BINARY_FILE
+   wget https://ci.adoptopenjdk.net/job/jtreg/lastSuccessfulBuild/artifact/"$JTREG_BINARY_FILE"
 
    if [ $? -ne 0 ]; then
      echo "Failed to retrieve the jtreg binary, exiting"
      exit
    fi
 
-   tar xvf $JTREG_BINARY_FILE
+   tar xvf "$JTREG_BINARY_FILE"
   fi
 
   echo "List contents of jtreg"
-  ls $WORKING_DIR/$JTREG_TARGET_FOLDER/*
+  ls "$WORKING_DIR/$JTREG_TARGET_FOLDER/*"
 
   export PATH=$WORKING_DIR/$JTREG_TARGET_FOLDER/bin:$PATH
 
   export JT_HOME=$WORKING_DIR/$JTREG_TARGET_FOLDER
 
   # Clean up after ourselves by removing jtreg tgz
-  rm -f $JTREG_BINARY_FILE
+  rm -f "$JTREG_BINARY_FILE"
 }
 
 applyingJCovSettingsToMakefileForTests()
 {
   echo "Apply JCov settings to Makefile..." 
-  cd $WORKING_DIR/$OPENJDK_REPO_NAME/jdk/test
+  cd "$WORKING_DIR/$OPENJDK_REPO_NAME/jdk/test" || exit
   pwd
 
-  sed -i 's/-vmoption:-Xmx512m.*/-vmoption:-Xmx512m -xml:verify -jcov\/classes:$(ABS_PLATFORM_BUILD_ROOT)\/jdk\/classes\/  -jcov\/source:$(ABS_PLATFORM_BUILD_ROOT)\/..\/..\/jdk\/src\/java\/share\/classes  -jcov\/include:*/' Makefile
+  sed -i "s/-vmoption:-Xmx512m.*/-vmoption:-Xmx512m -xml:verify -jcov\/classes:$(ABS_PLATFORM_BUILD_ROOT)\/jdk\/classes\/  -jcov\/source:$(ABS_PLATFORM_BUILD_ROOT)\/..\/..\/jdk\/src\/java\/share\/classes  -jcov\/include:*/" Makefile
 
-  cd $WORKING_DIR/$OPENJDK_REPO_NAME/
+  cd "$WORKING_DIR/$OPENJDK_REPO_NAME/" || exit
 }
 
 settingUpEnvironmentVariablesForJTREG()
@@ -77,8 +77,8 @@ settingUpEnvironmentVariablesForJTREG()
 
   # This is the JDK we'll test
   export PRODUCT_HOME=$WORKING_DIR/$OPENJDK_REPO_NAME/build/$BUILD_FULL_NAME/images/j2sdk-image
-  echo $PRODUCT_HOME
-  ls $PRODUCT_HOME
+  echo "$PRODUCT_HOME"
+  ls "$PRODUCT_HOME"
 
   export JTREG_DIR=$WORKING_DIR/jtreg
   export JTREG_INSTALL=${JTREG_DIR}
@@ -105,18 +105,18 @@ packageTestResultsWithJCovReports()
   echo "Package test output into archives..." 
   pwd
 
-  cd $WORKING_DIR/$OPENJDK_REPO_NAME/build/$BUILD_FULL_NAME/
+  cd "$WORKING_DIR/$OPENJDK_REPO_NAME/build/$BUILD_FULL_NAME/" || exit
  
-  artifact=${JOB_NAME}-testoutput-with-jcov-reports
+  artifact="${JOB_NAME}-testoutput-with-jcov-reports"
   echo "Tarring and zipping the 'testoutput' folder into artefact: $artifact.tar.gz" 
-  tar -cvzf $WORKING_DIR/$artifact.tar.gz   testoutput/
+  tar -cvzf "$WORKING_DIR/$artifact.tar.gz"   testoutput/
 
   if [ -d testoutput  ]; then  
-     rm -fr $WORKING_DIR/$OPENJDK_REPO_NAME/testoutput
+     rm -fr "$WORKING_DIR/$OPENJDK_REPO_NAME/testoutput"
   fi
-  cp -fr testoutput/ $WORKING_DIR/testoutput/
+  cp -fr testoutput/ "$WORKING_DIR/testoutput/"
   
-  cd $WORKING_DIR
+  cd "$WORKING_DIR" || exit
 }
 
 packageOnlyJCovReports()
@@ -124,13 +124,13 @@ packageOnlyJCovReports()
   echo "Package jcov reports into archives..." 
   pwd
 
-  cd $WORKING_DIR/$OPENJDK_REPO_NAME/build/$BUILD_FULL_NAME/
+  cd "$WORKING_DIR/$OPENJDK_REPO_NAME/build/$BUILD_FULL_NAME/"
  
-  artifact=${JOB_NAME}-jcov-results-only
+  artifact="${JOB_NAME}-jcov-results-only"
   echo "Tarring and zipping the 'testoutput/../jcov' folder into artefact: $artifact.tar.gz" 
-  tar -cvzf $WORKING_DIR/$artifact.tar.gz   testoutput/*/JTreport/jcov/
+  tar -cvzf "$WORKING_DIR/$artifact.tar.gz"   testoutput/*/JTreport/jcov/
 
-  cd $WORKING_DIR
+  cd "$WORKING_DIR" || exit
 }
 
 packageReports()

--- a/sbin/jtreg.sh
+++ b/sbin/jtreg.sh
@@ -16,7 +16,7 @@
 WORKING_DIR=$1
 OPENJDK_REPO_NAME=$2
 BUILD_FULL_NAME=$3
-JTREG_TEST_SUBSETS=$($4//:/ ) # Replace all ':' with ' '
+JTREG_TEST_SUBSETS=$("$4"//:/ ) # Replace all ':' with ' '
 JTREG_VERSION=${JTREG_VERSION:-4.2.0-tip}
 JTREG_TARGET_FOLDER=${JTREG_TARGET_FOLDER:-jtreg}
 JOB_NAME=${JOB_NAME:-OpenJDK}
@@ -29,6 +29,7 @@ checkIfDockerIsUsedForBuildingOrNot()
     WORKING_DIR=/openjdk/jdk8u/openjdk
     # Keep as a variable for potential use later
     # if we wish to copy the results to the host
+    # shellcheck disable=SC2034
     IN_DOCKER=true
   fi
 }
@@ -124,7 +125,7 @@ packageOnlyJCovReports()
   echo "Package jcov reports into archives..." 
   pwd
 
-  cd "$WORKING_DIR/$OPENJDK_REPO_NAME/build/$BUILD_FULL_NAME/"
+  cd "$WORKING_DIR/$OPENJDK_REPO_NAME/build/$BUILD_FULL_NAME/" || exit
  
   artifact="${JOB_NAME}-jcov-results-only"
   echo "Tarring and zipping the 'testoutput/../jcov' folder into artefact: $artifact.tar.gz" 

--- a/sbin/jtreg_prep.sh
+++ b/sbin/jtreg_prep.sh
@@ -82,11 +82,11 @@ elif [ ! -d "${WORKING_DIR}"/$OPENJDK_REPO_NAME/.git ] ; then
   # If it doesn't exist, clone it
   echo "Didn't find any existing openjdk repository at WORKING_DIR (set to ${WORKING_DIR}) so cloning the source to openjdk"
   if [[ "${USE_SSH}" == true ]] ; then
-    echo "git clone -b ${BRANCH} git@github.com:${REPOSITORY}.git $WORKING_DIR/$OPENJDK_REPO_NAME"
-    git clone -b ${BRANCH} git@github.com:"${REPOSITORY}".git "$WORKING_DIR/$OPENJDK_REPO_NAME"
+    echo "git clone -b ${BRANCH} git@github.com:${REPOSITORY}.git ${WORKING_DIR}/${OPENJDK_REPO_NAME}"
+    git clone -b ${BRANCH} git@github.com:"${REPOSITORY}".git "${WORKING_DIR}/${OPENJDK_REPO_NAME}"
   else
-    echo "git clone -b ${BRANCH} https://github.com/${REPOSITORY}.git $WORKING_DIR/$OPENJDK_REPO_NAME"
-    git clone -b ${BRANCH} https://github.com/"${REPOSITORY}".git "$WORKING_DIR/$OPENJDK_REPO_NAME"
+    echo "git clone -b ${BRANCH} https://github.com/${REPOSITORY}.git ${WORKING_DIR}/${OPENJDK_REPO_NAME}"
+    git clone -b ${BRANCH} https://github.com/"${REPOSITORY}".git "${WORKING_DIR}/${OPENJDK_REPO_NAME}"
   fi
 fi
 

--- a/sbin/jtreg_prep.sh
+++ b/sbin/jtreg_prep.sh
@@ -69,24 +69,24 @@ fi
 
 # Step 1: Fetch OpenJDK, as that's where the tests live.
 
-if [ -d "$WORKING_DIR"/$OPENJDK_REPO_NAME/.git ] && [ $REPOSITORY == "AdoptOpenJDK/openjdk-jdk8u" ] ; then
+if [ -d "$WORKING_DIR"/$OPENJDK_REPO_NAME/.git ] && [ "$REPOSITORY" == "AdoptOpenJDK/openjdk-jdk8u" ] ; then
   # It does exist and it's a repo other than the AdoptOpenJDK one
-  cd $WORKING_DIR/$OPENJDK_REPO_NAME
+  cd "$WORKING_DIR/$OPENJDK_REPO_NAME"  || exit
   echo "Will reset the repository at $PWD in 10 seconds..."
   sleep 10
   echo "Pulling latest changes from git repo"
   git fetch --all
   git reset --hard origin/$BRANCH
-  cd $WORKING_DIR
+  cd "$WORKING_DIR" || exit
 elif [ ! -d "${WORKING_DIR}"/$OPENJDK_REPO_NAME/.git ] ; then
   # If it doesn't exist, clone it
   echo "Didn't find any existing openjdk repository at WORKING_DIR (set to ${WORKING_DIR}) so cloning the source to openjdk"
   if [[ "${USE_SSH}" == true ]] ; then
     echo "git clone -b ${BRANCH} git@github.com:${REPOSITORY}.git $WORKING_DIR/$OPENJDK_REPO_NAME"
-    git clone -b ${BRANCH} git@github.com:${REPOSITORY}.git $WORKING_DIR/$OPENJDK_REPO_NAME
+    git clone -b ${BRANCH} git@github.com:"${REPOSITORY}".git "$WORKING_DIR/$OPENJDK_REPO_NAME"
   else
     echo "git clone -b ${BRANCH} https://github.com/${REPOSITORY}.git $WORKING_DIR/$OPENJDK_REPO_NAME"
-    git clone -b ${BRANCH} https://github.com/${REPOSITORY}.git $WORKING_DIR/$OPENJDK_REPO_NAME
+    git clone -b ${BRANCH} https://github.com/"${REPOSITORY}".git "$WORKING_DIR/$OPENJDK_REPO_NAME"
   fi
 fi
 
@@ -95,7 +95,7 @@ fi
 if [ ! -d "${JAVA_DESTINATION}" ]; then
   mkdir -p "${JAVA_DESTINATION}"
 fi
-cd "${JAVA_DESTINATION}"
+cd "${JAVA_DESTINATION}"  || exit
 
 #If it's a http location, use wget.
 if [[ "${JAVA_SOURCE}" == http* ]]; then 
@@ -116,10 +116,10 @@ fi
 # Step 3: Unpack Java if we need to.
 
 if [[ "$JAVA_SOURCE" == *\.tar\.gz ]]; then #If it's a tar file, unpack it.
-  cd "${JAVA_DESTINATION}"
-  tar xf *.tar.gz
+  cd "${JAVA_DESTINATION}" || exit
+  tar xf ./*.tar.gz
   echo "Java has been untarred."
-  cd "${WORKING_DIR}"
+  cd "${WORKING_DIR}" || exit
 elif [ ! -d "${JAVA_SOURCE}" ]; then #If it's not a directory, then we don't know how to unpack it. 
   echo "The Java file you specified as source was copied to the destination, but this script doesn't know how to unpack it. Please add this logic to this script, or unpack it manually before running jtreg.";
 fi

--- a/sbin/signalhandler.sh
+++ b/sbin/signalhandler.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 exit_script() {
     if [[ -z ${KEEP} ]] ; then
       docker ps -a | awk '{ print $1,$2 }' | grep $CONTAINER | awk '{print $1 }' | xargs -I {} docker rm -f {}

--- a/sbin/signalhandler.sh
+++ b/sbin/signalhandler.sh
@@ -1,8 +1,26 @@
 #!/bin/bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# For terminal colors
+esc=$(echo -en "\033")
+error="${esc}[0;31m"
+
 
 exit_script() {
     if [[ -z ${KEEP} ]] ; then
-      docker ps -a | awk '{ print $1,$2 }' | grep $CONTAINER | awk '{print $1 }' | xargs -I {} docker rm -f {}
+      docker ps -a | awk '{ print $1,$2 }' | grep "$CONTAINER" | awk '{print $1 }' | xargs -I {} docker rm -f {}
     fi
     echo "${error}Process exited${normal}"
     trap - SIGINT SIGTERM # clear the trap

--- a/sbin/signalhandler.sh
+++ b/sbin/signalhandler.sh
@@ -16,6 +16,7 @@
 # For terminal colors
 esc=$(echo -en "\033")
 error="${esc}[0;31m"
+normal=$(echo -en "${esc}[m\017")
 
 
 exit_script() {


### PR DESCRIPTION
This fixes a number of warnings and errors from running the shell lint checker.
There are some real bugs (e.g. use of undefined vars), but most are safety features; notably 
1. using quotes around var expansion to avoid word splitting and globbing by the shell,
1. fail safe when `cd`'ing to a directory, especially where we `cd` then `rf -f`

Special bonus addition is the image in our README.md to show the testing status.