### PR TITLE
Make JVM_VARIANT overrideable

### DIFF
--- a/makejdk-any-platform.sh
+++ b/makejdk-any-platform.sh
@@ -33,7 +33,7 @@ if [[ "$OS_MACHINE_NAME" == "s390x" ]] ; then
 fi
 
 if [[ "$OS_MACHINE_NAME" == "armv7l" ]] ; then
-   export JVM_VARIANT=zero
+   export JVM_VARIANT=${JVM_VARIANT:-zero}
    export MAKE_ARGS_FOR_ANY_PLATFORM=${MAKE_ARGS_FOR_ANY_PLATFORM:-"DEBUG_BINARIES=true images"}
    export CONFIGURE_ARGS_FOR_ANY_PLATFORM=${CONFIGURE_ARGS_FOR_ANY_PLATFORM:-"--with-num-cores=4"}
 fi


### PR DESCRIPTION
Change config for the ARM such that JVM_VARIANT can be overriden via makejdk-any-platform