### PR TITLE
Fixes the failing issue on Jenkins - cannot find file ../colour-codes.sh

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -38,9 +38,12 @@ OS_MACHINE_NAME=$(uname -m)
 
 sourceFileWithColourCodes()
 {
+  CURRENT_SCRIPT=$(realpath "$0")
+  CURRENT_SCRIPTPATH=$(dirname "$CURRENT_SCRIPT")
+
   # shellcheck disable=SC1090
   # shellcheck disable=SC1091
-  source "$WORKING_DIR"/colour-codes.sh
+  source "$CURRENT_SCRIPTPATH"/../colour-codes.sh
 }
 
 checkIfDockerIsUsedForBuildingOrNot()

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -38,8 +38,9 @@ OS_MACHINE_NAME=$(uname -m)
 
 sourceFileWithColourCodes()
 {
+  # shellcheck disable=SC1090
   # shellcheck disable=SC1091
-  source "$WORKING_DIR/colour-codes.sh"
+  source "$WORKING_DIR"/colour-codes.sh
 }
 
 checkIfDockerIsUsedForBuildingOrNot()

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -39,7 +39,7 @@ OS_MACHINE_NAME=$(uname -m)
 sourceFileWithColourCodes()
 {
   # shellcheck disable=SC1091
-  source ../colour-codes.sh
+  source ${WORKING_DIR}/colour-codes.sh
 }
 
 checkIfDockerIsUsedForBuildingOrNot()

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -39,7 +39,7 @@ OS_MACHINE_NAME=$(uname -m)
 sourceFileWithColourCodes()
 {
   # shellcheck disable=SC1091
-  source ${WORKING_DIR}/colour-codes.sh
+  source "$WORKING_DIR/colour-codes.sh"
 }
 
 checkIfDockerIsUsedForBuildingOrNot()


### PR DESCRIPTION
Noticed in the Jenkins jobs - build logs, colour codes weren't being picked up due to this