### PR TITLE
Remove hard-coding of cores and using NUM_PROCESSORS instead

### DIFF
--- a/makejdk-any-platform.sh
+++ b/makejdk-any-platform.sh
@@ -38,7 +38,7 @@ fi
 if [[ "$OS_MACHINE_NAME" == "armv7l" ]] ; then
    export JVM_VARIANT=${JVM_VARIANT:-zero}
    export MAKE_ARGS_FOR_ANY_PLATFORM=${MAKE_ARGS_FOR_ANY_PLATFORM:-"DEBUG_BINARIES=true images"}
-   export CONFIGURE_ARGS_FOR_ANY_PLATFORM=${CONFIGURE_ARGS_FOR_ANY_PLATFORM:-"--with-jobs=4"}
+   export CONFIGURE_ARGS_FOR_ANY_PLATFORM=${CONFIGURE_ARGS_FOR_ANY_PLATFORM:-"--with-jobs=${NUM_PROCESSORS}}"}
 fi
 
 ./makejdk.sh "$@"


### PR DESCRIPTION
Replaced hard-coded number of processors flag passed to --with-jobs, to environment variable NUM_PROCESSORS. Fixes issue #76.