### PR TITLE
Stop calling shift when an argument has no parameters

### DIFF
--- a/makejdk.sh
+++ b/makejdk.sh
@@ -67,7 +67,7 @@ parseCommandLineArgs()
       WORKING_DIR="$1"; shift;;
 
       "--ssh" | "-S" )
-      USE_SSH=true; shift;;
+      USE_SSH=true;;
 
       "--destination" | "-d" )
       TARGET_DIR="$1"; shift;;
@@ -79,10 +79,10 @@ parseCommandLineArgs()
       BRANCH="$1"; shift;;
 
       "--keep" | "-k" )
-      KEEP=true; shift;;
+      KEEP=true;;
 
       "--jtreg" | "-j" )
-      JTREG=true; shift;;
+      JTREG=true;;
 
       "--jtreg-subsets" | "-js" )
       JTREG=true; JTREG_TEST_SUBSETS="$1"; shift;;

--- a/sbin/jtreg_prep.sh
+++ b/sbin/jtreg_prep.sh
@@ -42,7 +42,7 @@ parseCommandLineArgs()
         JAVA_DESTINATION="$1"; shift;;
 
         "--ssh" | "-S" )
-        USE_SSH=true; shift;;
+        USE_SSH=true;;
 
         "--repository" | "-r" )
         REPOSITORY="$1"; shift;;


### PR DESCRIPTION
Calling shift causes the next argument to be ignored