### PR TITLE
Fix #89

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -16,8 +16,8 @@ The Dockerfiles and associated scripts found in this project are licensed under 
 	`docker build -t dockeropenjdk .`
 
  - Run:
-	`docker run -it -v <path to source>:/openjdk/jdk8u dockeropenjdk`
+	`docker run -it -v <path to source>:/openjdk/build dockeropenjdk`
 
  - Debug (to shell):
-	`docker run -it -v <path to source>:/openjdk/jdk8u --entrypoint /bin/bash dockeropenjdk`
+	`docker run -it -v <path to source>:/openjdk/build --entrypoint /bin/bash dockeropenjdk`
 

--- a/docker/jdk8u/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk8u/x86_64/ubuntu/Dockerfile
@@ -41,18 +41,15 @@ RUN apt-get update \
 && rm -rf /var/lib/apt/lists/*
 
 # Pick up build instructions
-RUN mkdir -p /openjdk/jdk8u
+RUN mkdir -p /openjdk/target
 
-COPY build.sh /bin/
-COPY jtreg.sh /bin/
-COPY common-functions.sh /bin/
-COPY colour-codes.sh /bin
+ADD sbin /openjdk/sbin
 
-WORKDIR /openjdk/jdk8u/
+WORKDIR /openjdk/build/
 
 ENV JDK_BOOT_DIR=/usr/lib/jvm/java-1.7.0-openjdk-amd64
 
 # Default actions
-ENTRYPOINT ["build.sh"]
+ENTRYPOINT ["/openjdk/sbin/build.sh"]
 
 CMD ["images"]

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -49,13 +49,13 @@ checkIfDockerIsUsedForBuildingOrNot()
 
   if [[ -f /.dockerenv ]] ; then
     echo "Detected we're in docker"
-    WORKING_DIR=/openjdk/jdk8u
+    WORKING_DIR=/openjdk/build
     TARGET_DIR=/openjdk/target
     OPENJDK_REPO_NAME=/openjdk
     OPENJDK_DIR="$WORKING_DIR/$OPENJDK_REPO_NAME"
   fi
 
-  # E.g. /openjdk/jdk8u if you're building in a Docker container
+  # E.g. /openjdk/build if you're building in a Docker container
   # otherwise ensure it's a writable area e.g. /home/youruser/myopenjdkarea
 
   if [ -z "$WORKING_DIR" ] || [ -z "$TARGET_DIR" ] ; then

--- a/sbin/jtreg.sh
+++ b/sbin/jtreg.sh
@@ -36,7 +36,7 @@ checkIfDockerIsUsedForBuildingOrNot()
 {
   if [[ -f /.dockerenv ]] ; then
     echo "Detected we're in docker"
-    WORKING_DIR=/openjdk/jdk8u/
+    WORKING_DIR=/openjdk/build/
     OPENJDK_REPO_NAME=openjdk/
     OPENJDK_DIR="$WORKING_DIR/$OPENJDK_REPO_NAME"
     TARGET_DIR=/openjdk/target/


### PR DESCRIPTION
- Copy scripts into docker at build time, resolves #89.

- Convert docker to use a persistent volume to store and build the docker source, should resolve #88.

A data volume will be created called `openjdk-source-volume`. This has a checkout of the jdk, and the downloaded libraries needed to build. This data volume is persistent over restarts so can be used to build and test separately. This is an improvement over the current state as the build does not depend on the state of the local directory.

- Change /openjdk/jdk8u to /openjdk/build inside docker.