### PR TITLE
Adding the -q flag to the zip command to run the command in silent mode

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -237,7 +237,7 @@ createOpenJDKTarArchive()
 {
   case "${OS_MACHINE_NAME}" in
     *cygwin*)
-      zip -r OpenJDK.zip ./j2sdk-image
+      zip -r -q OpenJDK.zip ./j2sdk-image
       EXT=".zip" ;;
     *)
       GZIP=-9 tar -czf OpenJDK.tar.gz ./j2sdk-image


### PR DESCRIPTION
Adding the -q flag to the zip command to run the command in silent mode - this prevents unnecessary log messages in the log file and other text are visible and not become hidden when viewing the bottom of the log file in the browser or local machine editor