### PR TITLE
Specify freetype dir for the FreeType Font library to build script

### DIFF
--- a/makejdk.1
+++ b/makejdk.1
@@ -29,6 +29,9 @@ run jtreg after building
 .BR \-js ", " \-\-jtreg-subsets
 select one or more jtreg tests to run
 .TP
+.BR \-ftd ", " \-\-freetype-dir
+specify the location of an existing FreeType library that can be used for the OpenJDK build process
+.TP
 .BR \-S ", " \-\-ssh
 use ssh when cloning git
 .TP

--- a/makejdk.sh
+++ b/makejdk.sh
@@ -35,7 +35,7 @@ SHALLOW_CLONE_OPTION="--depth=1"
 
 DOCKER_SOURCE_VOLUME_NAME="openjdk-source-volume"
 CONTAINER=openjdk_container
-TMP_CONTAINTER_NAME=openjdk-copy-src
+TMP_CONTAINER_NAME=openjdk-copy-src
   
 USE_DOCKER=false
 WORKING_DIR=""
@@ -98,6 +98,9 @@ parseCommandLineArgs()
 
       "--disable-shallow-git-clone" | "-dsgc" )
       SHALLOW_CLONE_OPTION=""; shift;;
+
+      "--freetype-dir" | "-ftd" )
+      export FREETYPE_DIRECTORY="$1"; shift;;
 
       *) echo >&2 "${error}Invalid option: ${opt}${normal}"; man ./makejdk.1; exit 1;;
      esac
@@ -246,20 +249,20 @@ createPersistentDockerDataVolume()
   if [[ "$CLEAN_DOCKER_BUILD" == "true" || "$DATA_VOLUME_EXISTS" != "0" ]]; then
   
     echo "${info}Removing old volumes and containers${normal}"
-    docker rm -f $TMP_CONTAINTER_NAME || true
+    docker rm -f $TMP_CONTAINER_NAME || true
     docker rm -f "$(docker ps -a | grep $CONTAINER | cut -d' ' -f1)" || true
     docker volume rm "${DOCKER_SOURCE_VOLUME_NAME}" || true
     
     echo "${info}Creating volume${normal}"
     docker volume create --name "${DOCKER_SOURCE_VOLUME_NAME}"
-    docker run -v "${DOCKER_SOURCE_VOLUME_NAME}":/openjdk/build --name $TMP_CONTAINTER_NAME ubuntu:14.04 /bin/bash
-    docker cp openjdk $TMP_CONTAINTER_NAME:/openjdk/build/
+    docker run -v "${DOCKER_SOURCE_VOLUME_NAME}":/openjdk/build --name $TMP_CONTAINER_NAME ubuntu:14.04 /bin/bash
+    docker cp openjdk $TMP_CONTAINER_NAME:/openjdk/build/
     
     echo "${info}Updating source${normal}"
-    docker exec $TMP_CONTAINTER_NAME "cd /openjdk/build/openjdk && sh get_source.sh"
+    docker exec $TMP_CONTAINER_NAME "cd /openjdk/build/openjdk && sh get_source.sh"
     
     echo "${info}Shutting down${normal}"
-    docker rm -f $TMP_CONTAINTER_NAME
+    docker rm -f $TMP_CONTAINER_NAME
   fi
 }
 

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -122,7 +122,9 @@ buildingTheRestOfTheConfigParameters()
   CONFIGURE_ARGS="${CONFIGURE_ARGS} --with-jvm-variants=${JVM_VARIANT}"
   CONFIGURE_ARGS="${CONFIGURE_ARGS} --with-cacerts-file=${WORKING_DIR}/cacerts_area/security/cacerts"
   CONFIGURE_ARGS="${CONFIGURE_ARGS} --with-alsa=${WORKING_DIR}/alsa-lib-${ALSA_LIB_VERSION}"
-  CONFIGURE_ARGS="${CONFIGURE_ARGS} --with-freetype=${WORKING_DIR}/${OPENJDK_REPO_NAME}/installedfreetype"
+
+  FREETYPE_DIRECTORY=${FREETYPE_DIRECTORY:-"${WORKING_DIR}/${OPENJDK_REPO_NAME}/installedfreetype"}
+  CONFIGURE_ARGS="${CONFIGURE_ARGS} --with-freetype=$FREETYPE_DIRECTORY"
 
   # These will have been installed by the package manager (see our Dockerfile)
   CONFIGURE_ARGS="${CONFIGURE_ARGS} --with-x=/usr/include/X11"

--- a/sbin/common-functions.sh
+++ b/sbin/common-functions.sh
@@ -117,6 +117,10 @@ downloadingRequiredDependencies()
           echo "Checking and download FreeType Font dependency"
           checkingAndDownloadingFreeType
         )
+     else
+         echo ""
+         echo "---> Skipping the process of checking and downloading the FreeType Font dependency, a pre-built version provided at $FREETYPE_DIRECTORY <---"
+         echo ""
      fi
      time (
         echo "Checking and download CaCerts dependency"

--- a/sbin/common-functions.sh
+++ b/sbin/common-functions.sh
@@ -107,10 +107,20 @@ downloadingRequiredDependencies()
      echo "Windows or Windows-like environment detected, skipping downloading of dependencies...: Alsa, Freetype, and CaCerts."
   else
      echo "Downloading required dependencies...: Alsa, Freetype, and CaCerts."
-     checkingAndDownloadingAlsa
+     time (
+        echo "Checking and download Alsa dependency"
+        checkingAndDownloadingAlsa
+     )
+
      if [[ -z "$FREETYPE_DIRECTORY" ]]; then
-        checkingAndDownloadingFreeType
+        time (
+          echo "Checking and download FreeType Font dependency"
+          checkingAndDownloadingFreeType
+        )
      fi
-     checkingAndDownloadCaCerts
+     time (
+        echo "Checking and download CaCerts dependency"
+        checkingAndDownloadCaCerts
+     )
   fi
 }

--- a/sbin/common-functions.sh
+++ b/sbin/common-functions.sh
@@ -108,7 +108,9 @@ downloadingRequiredDependencies()
   else
      echo "Downloading required dependencies...: Alsa, Freetype, and CaCerts."
      checkingAndDownloadingAlsa
-     checkingAndDownloadingFreeType
+     if [[ -z "$FREETYPE_DIRECTORY" ]]; then
+        checkingAndDownloadingFreeType
+     fi
      checkingAndDownloadCaCerts
   fi
 }


### PR DESCRIPTION
- Corrected spelling of a variable name
- Accept a new command-line param to specify the location of the pre-built FreeType Font directory, instead of building one each time, for e.g,

```
./makejdk-any-platform.sh [other params] --freetype-dir=/path/to/new/installfreetype/
```

Look for the below message on the console or build.log:
```
---> Skipping the process of checking and downloading the FreeType Font dependency, a pre-built version provided at /path/to/new/installfreetype/ <---
```

Note: The way this is written, if an environment variable by the name 
`FREETYPE_DIRECTORY` is created with the correct location, the build scripts will pick it up and use it.

Also added some performance checks around the dependency downloads for future references, metrics will be written to both console and build log file. Look out for these:

```
real	1m9.623s
user	0m14.213s
sys	0m2.752s
```