### PR TITLE
Remove hint about jdk boot dir when configure fails

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -171,9 +171,6 @@ runTheOpenJDKConfigureCommandAndUseThePrebuildConfigParams()
     if [ $? -ne 0 ]; then
       echo "${error}"
       echo "Failed to configure the JDK, exiting"
-      echo "Did you set the JDK boot directory correctly? Override by exporting JDK_BOOT_DIR"
-      echo "For example, on RHEL you would do export JDK_BOOT_DIR=/usr/lib/jvm/java-1.7.0-openjdk-1.7.0.131-2.6.9.0.el7_3.x86_64"
-      echo "Current JDK_BOOT_DIR value: ${JDK_BOOT_DIR}"
       exit;
     else
       echo "${good}Configured the JDK"


### PR DESCRIPTION
When configure fails it'd give us the cause anyway which may include the JDK_BOOT_DIR not being properly set

By always providing this hint this may falsely lead people to check their JDK_BOOT_DIR when there is a different problem