### PR TITLE
Update to docker runtime image creation to enable pushing to docker hub

### DIFF
--- a/installer/docker/README.md
+++ b/installer/docker/README.md
@@ -1,0 +1,8 @@
+## Build scripts for creating Docker Images from AdoptOpenJDK binaries
+
+This directory is the root for scripts and Dockerfiles that are used to create Docker Images for publishing
+to docker hub at https://hub.docker.com/u/adoptopenjdk/
+
+Scripts are organised by OS and then by type of binary
+
+Build scripts are designed to be executed by Jenkins.

--- a/installer/docker/ubuntu/jdk/Dockerfile
+++ b/installer/docker/ubuntu/jdk/Dockerfile
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 # Dockerfile to create an image with AdoptOpenJDK jdk binary installed
-# Note that the installation process removes demos manual and samples directories
+# Note that the calling build process removes demos manual and samples directories before
+# the image is created
+
 # Build info is emitted to stderr
 #
 # Build example:  docker build --build-arg RELEASE=jdk8u162-b00 -t adoptopenjdk:jdk8u162 .
@@ -23,30 +25,21 @@ FROM ubuntu:16.10
 
 MAINTAINER Steve Poole <spoole167@googlemail.com>
 
-# default release / architecture to install (override with --build-arg RELEASE=?  option etc)
-
-ARG RELEASE=latest
-ARG ARCH=x64_linux
+# Java release is required to be specified. Use --build-arg RELEASE=?  on call to docker to set
+ARG RELEASE
 
 # envs
-ENV JAVA_LOC=/opt/java/openjdk-$RELEASE
-ENV API_URL=https://api.adoptopenjdk.net/releases/$ARCH/$RELEASE/binary
+ENV JAVA_LOC=/opt/java/openjdk/$RELEASE
 
-RUN ( >&2 echo "RELEASE=$RELEASE" ) && \
-    ( >&2 echo "ARCH   =$ARCH"    ) && \
-    ( >&2 echo "API URL=$API_URL" )
+RUN ( >&2 echo "RELEASE=$RELEASE" )
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
   	bash curl ca-certificates \
  	  && rm -rf /var/lib/apt/lists/*
 
+RUN mkdir -p $JAVA_LOC
 
-RUN curl -LJ -s -o java.tar.gz  -H 'accept-version: 1.1.0' $API_URL \
-    && mkdir -p /opt/java \
-    && cd /opt/java && gunzip -c /java.tar.gz | tar xf - \
-  	&& mv /opt/java/j2sdk-image $JAVA_LOC \
-    && rm -rf $JAVA_LOC/demo  $JAVA_LOC/man  $JAVA_LOC/sample  \
-		&& rm /java.tar.gz
+COPY $RELEASE/  $JAVA_LOC
 
 ENV JAVA_HOME=$JAVA_LOC/jre \
     PATH=$JAVA_LOC/bin:$PATH

--- a/installer/docker/ubuntu/jdk/build.sh
+++ b/installer/docker/ubuntu/jdk/build.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Script to create a Docker image using Ubuntu and latest AdoptOpenJDK  linux binary
+# This script works in conjunction with jenkins plugins
+# The script assumes that Jenkins has placesd the tar.gz of the binary
+# in the root of the workspace. (WORKSPACE envar is set by jenkins)
+#
+# REPO defines the target docker repository for tagging images with
+# ARCH defines the computer architecture tag to be used for docker image tags
+# that are machine specific.
+#
+# This script builds the docker image but does not push to docker hub.
+# The docker plugin could build the image but is not dynamically configurable
+# so is only used to push the created image.
+#
+
+: "${WORKSPACE:=$PWD}"
+: "${REPO:=adoptopenjdk/openjdk8}"
+: "${ARCH:=x86_64}"
+
+# remove any locally built images before building
+
+images=$(docker images | grep "^$REPO"  | awk '{print $3}' | uniq)
+
+for i in $images
+do
+   docker rmi -f "$i"
+done
+
+# create place to hold image to be dockerized
+rm -rf docker_image
+mkdir -p docker_image
+
+# add contents to image
+cp Dockerfile docker_image
+cd docker_image || exit
+mv "$WORKSPACE"/OpenJDK8*.tar.gz .
+gunzip -c OpenJDK8*.tar.gz | tar xf -
+
+# java release determined from directory name of unzipped image
+RELEASE=$(find . -mindepth 1 -maxdepth 1 -type d  \( ! -iname ".*" \) | sed 's|^\./||g')
+
+# remove unwanted files and directories
+rm -rf "$RELEASE/demo"  "$RELEASE/man"  "$RELEASE/sample"
+
+# create docker image locally
+# build arg RELEASE is required
+docker build --no-cache=true --build-arg "RELEASE=$RELEASE" -t "$REPO:$RELEASE" -t "$REPO:latest" -t "$REPO:$ARCH-$RELEASE"  -t "$REPO:$ARCH-latest" .

--- a/installer/docker/ubuntu/jdk/build.sh
+++ b/installer/docker/ubuntu/jdk/build.sh
@@ -32,7 +32,7 @@
 
 # remove any locally built images before building
 
-images=$(docker images | grep "^$REPO"  | awk '{print $3}' | uniq)
+images=$(docker images | grep "^$REPO"  | awk '{print $3}' | sort | uniq)
 
 for i in $images
 do


### PR DESCRIPTION
Changed the process for creating a docker image from a standalone approach to one suitable to be driven from Jenkins. Relies on docker push capabilities provided by Jenkins Docker plugins.

Prototype process is working on jenkins
using my repo See https://ci.adoptopenjdk.net/view/all/job/openjdk_docker_jdk8_ubuntu_x86_64_image/

Images are being pushed to Dockerhub - https://hub.docker.com/r/adoptopenjdk/openjdk8/