### PR TITLE
Move aix related checks to main script

### DIFF
--- a/makejdk-any-platform.sh
+++ b/makejdk-any-platform.sh
@@ -27,6 +27,7 @@
 set -eu
 
 OS_MACHINE_NAME=$(uname -m)
+OS_KERNEL_NAME=$(uname | awk '{print tolower($0)}')
 
 if [[ "$OS_MACHINE_NAME" == "s390x" ]] ; then
    export JVM_VARIANT=${JVM_VARIANT:-zero}
@@ -44,6 +45,10 @@ if [[ "$OS_MACHINE_NAME" == "armv7l" ]] ; then
    export JVM_VARIANT=${JVM_VARIANT:-zero}
    export MAKE_ARGS_FOR_ANY_PLATFORM=${MAKE_ARGS_FOR_ANY_PLATFORM:-"DEBUG_BINARIES=true images"}
    export CONFIGURE_ARGS_FOR_ANY_PLATFORM=${CONFIGURE_ARGS_FOR_ANY_PLATFORM:-"--with-jobs=${NUM_PROCESSORS}"}
+fi
+
+if [[ "$OS_KERNEL_NAME" == "aix" ]] ; then
+   export MAKE_COMMAND_NAME=${MAKE_COMMAND_NAME:-"gmake"}
 fi
 
 ./makejdk.sh "$@"

--- a/makejdk.sh
+++ b/makejdk.sh
@@ -180,7 +180,7 @@ cloneOpenJDKGitRepo()
     echo "${info}Will reset the repository at $PWD in 10 seconds...${git}"
     sleep 10
     echo "${git}Pulling latest changes from git repo"
-    git fetch --all
+    git fetch --all $SHALLOW_CLONE_OPTION
     git reset --hard origin/$BRANCH
     echo "${normal}"
     cd "${WORKING_DIR}" || return
@@ -215,7 +215,7 @@ getOpenJDKUpdateAndBuildVersion()
     # It does exist and it's a repo other than the AdoptOpenJDK one
     cd "${WORKING_DIR}/${OPENJDK_REPO_NAME}" || return
     echo "${git}Pulling latest tags and getting the latest update version"
-    git fetch --tags
+    git fetch --tags $SHALLOW_CLONE_OPTION
     OPENJDK_UPDATE_VERSION=$(git describe --abbrev=0 --tags | cut -d'u' -f 2 | cut -d'-' -f 1)
     OPENJDK_BUILD_NUMBER=$(git describe --abbrev=0 --tags | cut -d'b' -f 2 | cut -d'-' -f 1)
     echo "${OPENJDK_UPDATE_VERSION} ${OPENJDK_BUILD_NUMBER}"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -36,6 +36,7 @@ if [ "$JVM_VARIANT" == "--run-jtreg-tests-only" ]; then
   JVM_VARIANT="server"
 fi
 
+MAKE_COMMAND_NAME=${MAKE_COMMAND_NAME:-"make"}
 MAKE_ARGS_FOR_ANY_PLATFORM=${MAKE_ARGS_FOR_ANY_PLATFORM:-"images"}
 CONFIGURE_ARGS_FOR_ANY_PLATFORM=${CONFIGURE_ARGS_FOR_ANY_PLATFORM:-""}
 
@@ -199,15 +200,8 @@ buildOpenJDK()
     exit 0
   fi
 
-  case "${OS_KERNEL_NAME}" in
-    aix)
-      makeCMD="gmake ${MAKE_ARGS_FOR_ANY_PLATFORM}" ;;
-    *)
-      makeCMD="make ${MAKE_ARGS_FOR_ANY_PLATFORM}" ;;
-  esac
-
-  echo "Building the JDK: calling ${makeCMD}"
-  $makeCMD
+  echo "Building the JDK: calling ${MAKE_COMMAND_NAME} ${MAKE_ARGS_FOR_ANY_PLATFORM}"
+  ${MAKE_COMMAND_NAME} ${MAKE_ARGS_FOR_ANY_PLATFORM}
 
   if [ $? -ne 0 ]; then
      echo "${error}Failed to make the JDK, exiting"


### PR DESCRIPTION
At the moment we are checking if we are running in AIX and then choosing to run `gmake` to build OpenJDK source, this can already been predetermined and set in the `makejdk-any-platform.sh` script like we do for the other platforms checks.

There is still some more such checks in the different scripts but that's for subsequent PRs.