### PR TITLE
Resolve one of the Shellcheck warnings reported by TravisCI for PR #145

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -201,6 +201,7 @@ buildOpenJDK()
   fi
 
   echo "Building the JDK: calling ${MAKE_COMMAND_NAME} ${MAKE_ARGS_FOR_ANY_PLATFORM}"
+  # shellcheck disable=SC2086
   ${MAKE_COMMAND_NAME} ${MAKE_ARGS_FOR_ANY_PLATFORM}
 
   if [ $? -ne 0 ]; then


### PR DESCRIPTION
Added shellcheck disable notation to not warn about `SC2086` - the variable will contain values with spaces and its okay