### PR TITLE
Fixing issue with demo files not getting removed from with tarbal

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -167,7 +167,12 @@ stepIntoTheWorkingDirectory()
 
 runTheOpenJDKConfigureCommandAndUseThePrebuiltConfigParams()
 {
+  echo "Configuring command and using the pre-built config params..."
+
   cd "$OPENJDK_DIR" || exit
+
+  echo "Currently at '${PWD}'"
+
   CONFIGURED_OPENJDK_ALREADY=$(find . -name "config.status")
 
   if [[ ! -z "$CONFIGURED_OPENJDK_ALREADY" ]] ; then
@@ -241,13 +246,17 @@ removingUnnecessaryFiles()
 {
   echo "Removing unnecessary files now..."
 
+  echo "Fetching the first tag from the OpenJDK git repo..."
   OPENJDK_REPO_TAG=$(getFirstTagFromOpenJDKGitRepo)
   if [ "$USE_DOCKER" != "true" ] ; then
      rm -rf cacerts_area
   fi
 
+  cd "${WORKING_DIR}/${OPENJDK_REPO_NAME}" || return
+
   cd build/*/images || return
 
+  echo "Currently at '${PWD}'"
 
   echo "moving ${JDK_PATH} to ${OPENJDK_REPO_TAG}"
   rm -rf "${OPENJDK_REPO_TAG}" || true
@@ -258,10 +267,12 @@ removingUnnecessaryFiles()
   rm -rf "${OPENJDK_REPO_TAG}"/demo/jfc/Font2DTest || true
   rm -rf "${OPENJDK_REPO_TAG}"/demo/jfc/SwingApplet || true
   find . -name "*.diz" -type f -delete || true
+
+  echo "Finished removing unnecessary files from ${OPENJDK_REPO_TAG}"
 }
 
 signRelease()
-{
+{ 
   if [ "$SIGN" ]; then
     if [[ "$OSTYPE" == "cygwin" ]]; then
       echo "Signing release"


### PR DESCRIPTION
Adding some echoes to the build.sh and common-functions.sh script files. Also changing to the image folder to be able to remove the AWT/GUI components from the demo folder in the newly created JDK image.

PR fixes issue #167. 