### PR TITLE
Replace curly braces with parenthesis because typo

### DIFF
--- a/makejdk-any-platform.sh
+++ b/makejdk-any-platform.sh
@@ -46,7 +46,7 @@ for i in "$@"; do
       let counter++
       string="\$$counter"
       OPENJDK_FOREST_NAME=$(echo "$@" | awk "{print $string}")
-      OPENJDK_CORE_VERSION=$(OPENJDK_FOREST_NAME)
+      OPENJDK_CORE_VERSION=${OPENJDK_FOREST_NAME}
       if [[ $OPENJDK_FOREST_NAME == *u ]]; then
         OPENJDK_CORE_VERSION=${OPENJDK_FOREST_NAME::-1}
       fi


### PR DESCRIPTION
Typo in my last commit. $(OPENJDK_FOREST_NAME) will not extract the value of the variable OPENJDK_FOREST_NAME. ${OPENJDK_FOREST_NAME} will.

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>