### PR TITLE
fixed stripping of \u\ char for jdk8

### DIFF
--- a/makejdk-any-platform.sh
+++ b/makejdk-any-platform.sh
@@ -48,7 +48,7 @@ for i in "$@"; do
       OPENJDK_FOREST_NAME=$(echo "$@" | awk "{print $string}")
       OPENJDK_CORE_VERSION=${OPENJDK_FOREST_NAME}
       if [[ $OPENJDK_FOREST_NAME == *u ]]; then
-        OPENJDK_CORE_VERSION=${OPENJDK_FOREST_NAME::-1}
+        OPENJDK_CORE_VERSION=${OPENJDK_FOREST_NAME%?}
       fi
       ;;
     "--variant" | "-bv")


### PR DESCRIPTION
cloning of jdk8u failed when running with bash on macos