### PR TITLE
Fix parameter parsing error in makejdk-any-platform.sh

### DIFF
--- a/makejdk-any-platform.sh
+++ b/makejdk-any-platform.sh
@@ -50,11 +50,15 @@ for i in "$@"; do
       if [[ $OPENJDK_FOREST_NAME == *u ]]; then
         OPENJDK_CORE_VERSION=${OPENJDK_FOREST_NAME%?}
       fi
+      # Switch it back to stop it being out of sync with i
+      let counter--
       ;;
     "--variant" | "-bv")
       let counter++
       string="\$$counter"
       BUILD_VARIANT=$(echo "$@" | awk "{print $string}")
+      # Switch it back to stop it being out of sync with i
+      let counter--
       ;;
   esac
 done


### PR DESCRIPTION
This is actually a fix for https://github.com/ibmruntimes/openj9-openjdk-jdk8/issues/23

The logic in the parameter parsing is to cycle over each parameter and use a variable `counter` to indicate the current parameter. In the case wher ewe are parsing a parameter such as `--version jdk8` the value of `counter` is incremented to give us access to the next parameter. This brings it out of sync with `i` for any subsequent iterations of the loop.

What this means is that if something like `--version jdk8u --variant openj9` is used, then the value of the `variant` parameter will not be picked up properly. This can be fixed in two ways:

1. Use a different variable for the "temporarily incremented" `counter`
2. Reset the value of `counter` by decrementing it after it has been used to read the correct variable.

I'm using option 2 in this PR for now, but I don't really have a strong view either way.