### PR TITLE
force openj9 builds to use gcc4.8

### DIFF
--- a/makejdk.sh
+++ b/makejdk.sh
@@ -141,7 +141,9 @@ doAnyBuildVariantOverrides()
     REPOSITORY="ibmruntimes/openj9-openjdk-${OPENJDK_CORE_VERSION}"
     BRANCH="openj9"
     if [[ "$OSTYPE" != "cygwin" ]]; then
+      # shellcheck disable=SC2155
       export CC=$(which gcc-4.8)
+      # shellcheck disable=SC2155
       export CXX=$(which g++-4.8)
     fi
   fi

--- a/makejdk.sh
+++ b/makejdk.sh
@@ -140,6 +140,10 @@ doAnyBuildVariantOverrides()
     # current (hoping not final) location of Extensions for OpenJDK9 for OpenJ9 project
     REPOSITORY="ibmruntimes/openj9-openjdk-${OPENJDK_CORE_VERSION}"
     BRANCH="openj9"
+    if [[ "$OSTYPE" != "cygwin" ]]; then
+      export CC=$(which gcc-4.8)
+      export CXX=$(which g++-4.8)
+    fi
   fi
   if [[ "${BUILD_VARIANT}" == "SapMachine" ]]; then
     # current (hoping not final) location of Extensions for OpenJDK9 for OpenJ9 project


### PR DESCRIPTION
OpenJ9 builds don't work on gcc4.8 or later. We currently have to use separate build machines in order to handle this but we can use environment variables to manage this.