### PR TITLE
add libfontconfig1-dev to jdk10 dockerfile

### DIFF
--- a/docker/jdk10/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk10/x86_64/ubuntu/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
     libelf-dev \
     libcups2-dev \
     libfreetype6-dev \
+    libfontconfig1-dev \
     libasound2-dev \
     zulu-9 \
     ccache \


### PR DESCRIPTION
libfontconfig1-dev is a build dependency for jdk10 builds