### PR TITLE
Don't override CONFIGURE_ARGS when setting boot JDK

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -100,7 +100,7 @@ configuringBootJDKConfigureParameter()
 
   echo "Boot dir set to ${JDK_BOOT_DIR}"
 
-  CONFIGURE_ARGS=" --with-boot-jdk=${JDK_BOOT_DIR}"
+  CONFIGURE_ARGS="${CONFIGURE_ARGS} --with-boot-jdk=${JDK_BOOT_DIR}"
 }
 
 # Ensure that we produce builds with versions strings something like:


### PR DESCRIPTION
This causes the loss of the --with-milestone parameter. This fix stops it being overridden