### PR TITLE
Revert "force openj9 builds to use gcc4.8 (#228)"

### DIFF
--- a/makejdk.sh
+++ b/makejdk.sh
@@ -144,12 +144,6 @@ doAnyBuildVariantOverrides()
     # current (hoping not final) location of Extensions for OpenJDK9 for OpenJ9 project
     REPOSITORY="ibmruntimes/openj9-openjdk-${OPENJDK_CORE_VERSION}"
     BRANCH="openj9"
-    if [[ "$OSTYPE" != "cygwin" ]]; then
-      # shellcheck disable=SC2155
-      export CC=$(which gcc-4.8)
-      # shellcheck disable=SC2155
-      export CXX=$(which g++-4.8)
-    fi
   fi
   if [[ "${BUILD_VARIANT}" == "SapMachine" ]]; then
     # current (hoping not final) location of Extensions for OpenJDK9 for OpenJ9 project


### PR DESCRIPTION
This reverts commit 4f9e3014ed3d72f9669d819d9d66a90412df6258.