### PR TITLE
Enable synchronizing openjfx repository into github

### DIFF
--- a/git-hg/update-without-modules.sh
+++ b/git-hg/update-without-modules.sh
@@ -27,9 +27,9 @@ bpaths=${1:-$(ls -d -1 */*)}     # maintain backward compatibility
 
 for bpath in $bpaths
 do
-    bpathAsArray=(${bpath//\// })      # for e.g. jdk10/jdk10 or jdk/jdk, becomes:
-    hg_root_forest=${bpathAsArray[0]}  #          jdk10 or jdk
-    hg_repo=${bpathAsArray[1]}         #          jdk10 or jdk
+    bpathAsArray=(${bpath/\// })       # for e.g. jdk10/jdk10 or jdk/jdk or openjfx/jfx-dev/rt, becomes:
+    hg_root_forest=${bpathAsArray[0]}  #          jdk10 or jdk or openjfx
+    hg_repo=${bpathAsArray[1]}         #          jdk10 or jdk or jfx-dev/rt
 
     pushd "$hg_root_forest/$hg_repo/root"
     echo "Update $hg_root_forest/$hg_repo -> (root)"


### PR DESCRIPTION
Enable synchronizing OpenJFX repository in GitHub.

This PR adds the possibility to use the git-hg scripts for synchronising the OpenJFX mercurial repository at http://hg.openjdk.java.net/openjfx/jfx-dev/rt with a git repository hosted on github.com.

The setup and update-without-modules scripts can then be called as follows:

    $ ./setup.sh jfx open-jfx/jfx-dev/rt
    $ ./update-without-modules.sh openjfx/jfx-dev/rt

The changes in the PR will only replace the first slash of the cli argument instead of all slashes.