### PR TITLE
Undo build.sh typo

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -92,7 +92,7 @@ addConfigureArg()
 addConfigureArgIfValueIsNotEmpty()
 {
   #Only try to add an arg if the second argument is not empty.
-  if [ ! -z "$1" ]; then
+  if [ ! -z "$2" ]; then
     addConfigureArg "$1" "$2"
   fi
 }


### PR DESCRIPTION
Argument 1 will never be empty because we always pass hard-coded
strings. It is argument 2 we should be worried about, as that's the
one containing potentially-empty variables.

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>