### PR TITLE
update version tags for jdk9 and later

### DIFF
--- a/makejdk-any-platform.sh
+++ b/makejdk-any-platform.sh
@@ -46,9 +46,9 @@ for i in "$@"; do
       let counter++
       string="\$$counter"
       OPENJDK_FOREST_NAME=$(echo "$@" | awk "{print $string}")
-      OPENJDK_CORE_VERSION=${OPENJDK_FOREST_NAME}
+      export OPENJDK_CORE_VERSION=${OPENJDK_FOREST_NAME}
       if [[ $OPENJDK_FOREST_NAME == *u ]]; then
-        OPENJDK_CORE_VERSION=${OPENJDK_FOREST_NAME%?}
+        export OPENJDK_CORE_VERSION=${OPENJDK_FOREST_NAME%?}
       fi
       # Switch it back to stop it being out of sync with i
       let counter--


### PR DESCRIPTION
This changes the version string from:
`* Version string: 9-internal+0-adhoc.jenkins.openjdk (9-internal)`
to:
`* Version string: 9-adoptopenjdk+181 (9-adoptopenjdk)`