### PR TITLE
Replace 'file' use with '-r' check for CaCerts

### DIFF
--- a/sbin/common-functions.sh
+++ b/sbin/common-functions.sh
@@ -141,7 +141,7 @@ checkingAndDownloadCaCerts()
   echo "cacerts should be here..."
 
   # shellcheck disable=SC2046
-  if ! (file "${WORKING_DIR}/cacerts_area/security/cacerts"); then
+  if ! [ -r "${WORKING_DIR}/cacerts_area/security/cacerts" ]; then
     echo "Failed to retrieve the cacerts file, exiting..."
     exit;
   else


### PR DESCRIPTION
Should fix https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/326