### PR TITLE
Fix broken docker build for OpenJ9

### DIFF
--- a/docker/jdk10/x86_64/ubuntu/Dockerfile-openj9
+++ b/docker/jdk10/x86_64/ubuntu/Dockerfile-openj9
@@ -17,12 +17,22 @@ MAINTAINER Mark Stoodley <mstoodle@ca.ibm.com>
 
 # Install required OS tools
 RUN apt-get update \
-  && apt-get install -qq -y --no-install-recommends \
-    autoconf \
-    libnuma-dev \
-    g++-4.8 \
-    gcc-4.8 \
-&& rm -rf /var/lib/apt/lists/*
+    && apt-get install -qq -y --no-install-recommends \
+       autoconf \
+       ccache \
+       cpio \
+       file \
+       g++-4.8 \
+       gcc-4.8 \
+       libdwarf-dev \
+       libelf-dev \
+       libfontconfig \
+       libfreetype6-dev \
+       libnuma-dev \
+       pkg-config \
+       ssh \
+    && rm -rf /var/lib/apt/lists/*
+
 
 # Make sure build uses 4.8
 RUN rm /usr/bin/gcc \

--- a/docker/jdk8/x86_64/ubuntu/Dockerfile-openj9
+++ b/docker/jdk8/x86_64/ubuntu/Dockerfile-openj9
@@ -17,13 +17,21 @@ MAINTAINER Mark Stoodley <mstoodle@ca.ibm.com>
 
 # Install required OS tools
 RUN apt-get update \
-  && apt-get install -qq -y --no-install-recommends \
-    autoconf \
-    libfontconfig \
-    libnuma-dev \
-    g++-4.8 \
-    gcc-4.8 \
-&& rm -rf /var/lib/apt/lists/*
+    && apt-get install -qq -y --no-install-recommends \
+       autoconf \
+       ccache \
+       cpio \
+       file \
+       g++-4.8 \
+       gcc-4.8 \
+       libdwarf-dev \
+       libelf-dev \
+       libfontconfig \
+       libfreetype6-dev \
+       libnuma-dev \
+       pkg-config \
+       ssh \
+    && rm -rf /var/lib/apt/lists/*
 
 # Make sure build uses 4.8
 RUN rm /usr/bin/gcc \

--- a/docker/jdk9/x86_64/ubuntu/Dockerfile-openj9
+++ b/docker/jdk9/x86_64/ubuntu/Dockerfile-openj9
@@ -17,12 +17,21 @@ MAINTAINER Mark Stoodley <mstoodle@ca.ibm.com>
 
 # Install required OS tools
 RUN apt-get update \
-  && apt-get install -qq -y --no-install-recommends \
-    autoconf \
-    libnuma-dev \
-    g++-4.8 \
-    gcc-4.8 \
-&& rm -rf /var/lib/apt/lists/*
+    && apt-get install -qq -y --no-install-recommends \
+       autoconf \
+       ccache \
+       cpio \
+       file \
+       g++-4.8 \
+       gcc-4.8 \
+       libdwarf-dev \
+       libelf-dev \
+       libfontconfig \
+       libfreetype6-dev \
+       libnuma-dev \
+       pkg-config \
+       ssh \
+    && rm -rf /var/lib/apt/lists/*
 
 # Make sure build uses 4.8
 RUN rm /usr/bin/gcc \

--- a/makejdk.sh
+++ b/makejdk.sh
@@ -396,7 +396,7 @@ buildAndTestOpenJDKViaDocker()
      echo "${info}Building as you've not specified -k or --keep"
      echo "$good"
      docker ps -a | awk '{ print $1,$2 }' | grep "$CONTAINER" | awk '{print $1 }' | xargs -I {} docker rm -f {}
-     buildDockerContainer --build-arg "OPENJDK_CORE_VERSION=${OPENJDK_FOREST_NAME}"
+     buildDockerContainer --build-arg "OPENJDK_CORE_VERSION=${OPENJDK_CORE_VERSION}"
      echo "$normal"
   fi
 


### PR DESCRIPTION
Pass the right OPENJDK_CORE_VERSION to the docker build and update the Dockerfile-openj9 to add additional dependencies.