### PR TITLE
Makejdk man update

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,21 +42,30 @@ Versions:
   jdk10 - https://github.com/AdoptOpenJDK/openjdk-jdk10
 
 Options:
-  -s, --source <path>        specify the location for the source and dependencies to be cloned, defaults to ./openjdk
-  -d, --destination <path>   specify the location for the tarball (eg. /path/ or /path/here.tar.gz)
-  -r, --repository <repo>    specify a custom repository (eg. username/openjdk-jdk8u)
-  -b, --branch <branch>      specify a custom branch (eg. dev)
-  -k, --keep                 reuse docker container (prevents deleting)
-  -j, --jtreg                run jtreg after building
-  -S, --ssh                  use ssh when cloning git
-  --variant <name>           specify a build variant name, e.g. openj9
+  -s,   --source <path>              specify the location for the source and dependencies to be cloned, defaults to ./openjdk. If it is specified, docker is not used
+  -d,   --destination <path>         specify the location for the tarball (eg. /path/ or /path/here.tar.gz)
+  -r,   --repository <repo>          specify a custom repository (eg. username/openjdk-jdk8u)
+  -b,   --branch <branch>            specify a custom branch (eg. dev)
+  -k,   --keep                       reuse docker container (prevents deleting)
+  -j,   --jtreg                      run jtreg after building
+  -js,  --jtreg-subsets              select one or more jtreg tests to run
+  -S,   --ssh                        use ssh when cloning git
+  -sf   --skip-freetype              skip building freetype
+  -nc   --no-colour                  disable colour output
+  -ftd  --freetype-dir               specify the location of an existing FreeType library that can be used for the OpenJDK build process
+  -dsgc --disable-shallow-git-clone  disable shallow cloning of git repo(s) using the --depth=1 CLI option
+  -bv   --variant <name>             specify a build variant name, e.g. openj9
+  -c    --clean-docker-build         clean docker data volume
+  -t    --tag <tag>                  specify a custom tag
+  --sign <path>                      specify the location for the windows p12 certificate. Used only for windows builds to sign DLL
+  -ca   --configure-args <args>      specify a custom configuration arguments
 ```
 
 The simplest way to build OpenJDK using our scripts is to run `makejdk-any-platform.sh` and have your user be in the Docker group on the machine 
 (or prefix all of your Docker commands with `sudo`). This script will create a Docker container that will be configured with all of the required 
 dependencies and a base operating system in order to build OpenJDK. For example:
 
-`./makejdk-any-platform.sh --keep --version --ssh jdk8u`
+`./makejdk-any-platform.sh -c --version --ssh jdk8u`
 
 * **NOTE:** If you don't use SSH keys (if you do then pass `-ssh`) to connect to GitHub then the script will challenge you for your GitHub username and password.
 * **NOTE:** The script will clone source code into the `--source` directory (defaults to `openjdk`).

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The simplest way to build OpenJDK using our scripts is to run `makejdk-any-platf
 (or prefix all of your Docker commands with `sudo`). This script will create a Docker container that will be configured with all of the required 
 dependencies and a base operating system in order to build OpenJDK. For example:
 
-`./makejdk-any-platform.sh -c --version --ssh jdk8u`
+`./makejdk-any-platform.sh -c --ssh --version jdk8u`
 
 * **NOTE:** If you don't use SSH keys (if you do then pass `-ssh`) to connect to GitHub then the script will challenge you for your GitHub username and password.
 * **NOTE:** The script will clone source code into the `--source` directory (defaults to `openjdk`).

--- a/makejdk-any-platform.1
+++ b/makejdk-any-platform.1
@@ -5,7 +5,7 @@ makejdk.sh
 .SH SYNOPSIS
 "./makejdk-any-platform.sh --version [version] [options]"
 .SH DESCRIPTION
-The simplest way to build OpenJDK using our scripts is to run makejdk-any-platform.sh --version <jdk8u/jdk9> and have your user be in the Docker group on the machine (or prefix all of your Docker commands with sudo. This script can be used to create a Docker container that will be configured with all of the required dependencies and a base operating system in order to build OpenJDK.
+The simplest way to build OpenJDK using our scripts is to run makejdk-any-platform.sh -c --version <jdk8u/jdk9> and have your user be in the Docker group on the machine (or prefix all of your Docker commands with sudo. This script can be used to create a Docker container that will be configured with all of the required dependencies and a base operating system in order to build OpenJDK.
 
 .SH VERSIONS
 .TP
@@ -22,7 +22,7 @@ https://github.com/AdoptOpenJDK/openjdk-jdk10
 .SH OPTIONS
 .TP
 .BR \-s ", " \-\-source " " \fI<path>\fR
-specify the location for the source and dependencies to be cloned
+specify the location for the source and dependencies to be cloned, defaults to ./openjdk. If it is specified, docker is not used
 .TP
 .BR \-d ", " \-\-destination " " \fI<path>\fR
 specify the location for the tarball (eg. /path/ or /path/here.tar.gz)
@@ -58,4 +58,20 @@ disable shallow cloning of git repo(s) using the --depth=1 CLI option
 .TP
 .BR \-bv ", " \-\-variant " " \fI<variant name>\fR
 specify a custom build variant (eg. openj9)
+.TP
+.TP
+.BR \-c ", " \-\-clean-docker-build
+clean docker data volume
+.TP
+.TP
+.BR \-t ", " \-\-tag " " \fI<tag>\fR
+specify a custom tag
+.TP
+.TP
+.BR \-\-sign " " \fI<path>\fR
+specify the location for the windows p12 certificate. Used only for windows builds to sign DLL
+.TP
+.TP
+.BR \-ca ", " \-\-configure-args " " \fI<args>\fR
+specify a custom configuration arguments 
 .TP


### PR DESCRIPTION
Updated man page for makejdk-any-platform.sh with latest options.

Updated REAME.md section for makejdk-any-platform.sh options and usage example. The --keep is replaced with -c (--keep is currently broken #198).

DCO 1.1 Signed-off-by: Andrzej Czarny