### PR TITLE
fixed --keep option #198

### DIFF
--- a/makejdk.sh
+++ b/makejdk.sh
@@ -355,11 +355,11 @@ createPersistentDockerDataVolume()
 buildDockerContainer()
 {
   echo Building docker container
-  docker build -t "${CONTAINER}" "${PATH_BUILD}" "$1" "$2"
+  docker build -t "${CONTAINER}" "${PATH_BUILD}" --build-arg "OPENJDK_CORE_VERSION=${OPENJDK_CORE_VERSION}"
   if [[ "${BUILD_VARIANT}" != "" && -f "${PATH_BUILD}/Dockerfile-${BUILD_VARIANT}" ]]; then
     CONTAINER="${CONTAINER}-${BUILD_VARIANT}"
     echo Building dockerfile variant "${BUILD_VARIANT}"
-    docker build -t "${CONTAINER}" -f "${PATH_BUILD}/Dockerfile-${BUILD_VARIANT}" "${PATH_BUILD}" "$1" "$2"
+    docker build -t "${CONTAINER}" -f "${PATH_BUILD}/Dockerfile-${BUILD_VARIANT}" "${PATH_BUILD}" --build-arg "OPENJDK_CORE_VERSION=${OPENJDK_CORE_VERSION}"
   fi
 }
 
@@ -396,7 +396,7 @@ buildAndTestOpenJDKViaDocker()
      echo "${info}Building as you've not specified -k or --keep"
      echo "$good"
      docker ps -a | awk '{ print $1,$2 }' | grep "$CONTAINER" | awk '{print $1 }' | xargs -I {} docker rm -f {}
-     buildDockerContainer --build-arg "OPENJDK_CORE_VERSION=${OPENJDK_CORE_VERSION}"
+     buildDockerContainer
      echo "$normal"
   fi
 


### PR DESCRIPTION
Resolve the problem from #198. The issue exist only for first build. The function buildDockerContainer has been triggered without args. Args have been removed and handled inside buildDockerContainer to simplify execution. 

I would assume that the disucussion of usfulness of -k should be considered as separte issue (refere to last comment from #198). 

DCO 1.1 Signed-off-by: Andrzej Czarny