### PR TITLE
update MAINTAINER in Dockerfile #188

### DIFF
--- a/docker/jdk10/x86_64/ubuntu/Dockerfile-openj9
+++ b/docker/jdk10/x86_64/ubuntu/Dockerfile-openj9
@@ -13,7 +13,7 @@
 
 FROM openjdk_container
 
-MAINTAINER Mark Stoodley <mstoodle@ca.ibm.com>
+MAINTAINER AdoptOpenJDK <adoption-discuss@openjdk.java.net>
 
 # Install required OS tools
 RUN apt-get update \

--- a/docker/jdk8/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk8/x86_64/ubuntu/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM ubuntu:14.04
 
-MAINTAINER Tim Ellison <tim_ellison@uk.ibm.com>
+MAINTAINER AdoptOpenJDK <adoption-discuss@openjdk.java.net>
 
 # Install required OS tools
 RUN apt-get update \

--- a/docker/jdk8/x86_64/ubuntu/Dockerfile-openj9
+++ b/docker/jdk8/x86_64/ubuntu/Dockerfile-openj9
@@ -13,7 +13,7 @@
 
 FROM openjdk_container
 
-MAINTAINER Mark Stoodley <mstoodle@ca.ibm.com>
+MAINTAINER AdoptOpenJDK <adoption-discuss@openjdk.java.net>
 
 # Install required OS tools
 RUN apt-get update \

--- a/docker/jdk9/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk9/x86_64/ubuntu/Dockerfile
@@ -13,7 +13,7 @@
 
 FROM ubuntu:16.04
 
-MAINTAINER George Adams <george.adams@uk.ibm.com>
+MAINTAINER AdoptOpenJDK <adoption-discuss@openjdk.java.net>
 
 # Install required OS tools
 RUN apt-get update \

--- a/docker/jdk9/x86_64/ubuntu/Dockerfile-openj9
+++ b/docker/jdk9/x86_64/ubuntu/Dockerfile-openj9
@@ -13,7 +13,7 @@
 
 FROM openjdk_container
 
-MAINTAINER Mark Stoodley <mstoodle@ca.ibm.com>
+MAINTAINER AdoptOpenJDK <adoption-discuss@openjdk.java.net>
 
 # Install required OS tools
 RUN apt-get update \


### PR DESCRIPTION
Resolved issue #188. All docker MAINTAINER replaced with 
AdoptOpenJDK <adoption-discuss@openjdk.java.net>

DCO 1.1 Signed-off-by: Andrzej Czarny