### PR TITLE
Add Windows into AO8/J9 pipelines

### DIFF
--- a/pipelines/openjdk8_openj9_nightly_pipeline.groovy
+++ b/pipelines/openjdk8_openj9_nightly_pipeline.groovy
@@ -1,11 +1,12 @@
 println "building ${JDK_VERSION}"
 
-def buildPlatforms = ['Linux', 'zLinux', 'ppc64le', 'AIX']
+def buildPlatforms = ['Linux', 'zLinux', 'ppc64le', 'AIX', 'Windows']
 def buildMaps = [:]
 buildMaps['Linux'] = [test:true, ArchOSs:'x86-64_linux']
 buildMaps['zLinux'] = [test:true, ArchOSs:'s390x_linux']
 buildMaps['ppc64le'] = [test:true, ArchOSs:'ppc64le_linux']
 buildMaps['AIX'] = [test:false, ArchOSs:'ppc64_aix']
+buildMaps['Windows'] = [test:false, ArchOSs:'x86-64_windows']
 def typeTests = ['openjdktest', 'systemtest']
 
 def jobs = [:]

--- a/pipelines/openjdk8_openj9_release_pipeline.groovy
+++ b/pipelines/openjdk8_openj9_release_pipeline.groovy
@@ -1,11 +1,12 @@
 println "building ${JDK_VERSION}"
 
-def buildPlatforms = ['Linux', 'zLinux', 'ppc64le', 'AIX']
+def buildPlatforms = ['Linux', 'zLinux', 'ppc64le', 'AIX', 'Windows']
 def buildMaps = [:]
 buildMaps['Linux'] = [test:true, ArchOSs:'x86-64_linux']
 buildMaps['zLinux'] = [test:true, ArchOSs:'s390x_linux']
 buildMaps['ppc64le'] = [test:true, ArchOSs:'ppc64le_linux']
 buildMaps['AIX'] = [test:false, ArchOSs:'ppc64_aix']
+buildMaps['Windows'] = [test:false, ArchOSs:'x86-64_windows']
 def typeTests = ['openjdktest', 'systemtest']
 
 def jobs = [:]


### PR DESCRIPTION
Now that I've implemented a rather horrible tactical fix to https://github.com/AdoptOpenJDK/openjdk-build/issues/243 to get the Debugging SDK opn the machine, the [AO8/J9 Windows build](https://ci.adoptopenjdk.net/job/openjdk8_openj9_build_x86-64_windows/) is now passing so should be integrated into the overnight pipelines.