### PR TITLE
Set nightly builds deployment per platform

### DIFF
--- a/pipelines/openjdk10_nightly_pipeline.groovy
+++ b/pipelines/openjdk10_nightly_pipeline.groovy
@@ -17,26 +17,35 @@ for ( int i = 0; i < buildPlatforms.size(); i++ ) {
 	def archOS = buildMaps[platform].ArchOSs
 	jobs[platform] = {
 		def buildJob
+		def buildJobNum
+		def checksumJob
 		stage('build') {
 			buildJob = build job: "openjdk10_build_${archOS}"
+			buildJobNum = buildJob.getNumber()
 		}
 		if (buildMaps[platform].test) {
 			stage('test') {
 				typeTests.each {
 					build job:"openjdk10_hs_${it}_${archOS}",
 							propagate: false,
-							parameters: [string(name: 'UPSTREAM_JOB_NUMBER', value: "${buildJob.getNumber()}"),
+							parameters: [string(name: 'UPSTREAM_JOB_NUMBER', value: "${buildJobNum}"),
 									string(name: 'UPSTREAM_JOB_NAME', value: "openjdk10_build_${archOS}")]
 				}
 			}
 		}
+		stage('checksums') {
+			checksumJob = build job: 'openjdk10_build_checksum',
+							parameters: [string(name: 'UPSTREAM_JOB_NUMBER', value: "${buildJobNum}"),
+									string(name: 'UPSTREAM_JOB_NAME', value: "openjdk10_build_${archOS}")]
+		}
+		stage('publish nightly') {
+			build job: 'openjdk_release_tool',
+						parameters: [string(name: 'REPO', value: 'nightly'),
+									string(name: 'TAG', value: "${JDK_TAG}"),
+									string(name: 'VERSION', value: 'jdk10'),
+									string(name: 'CHECKSUM_JOB_NAME', value: "openjdk10_build_checksum"),
+									string(name: 'CHECKSUM_JOB_NUMBER', value: "${checksumJob.getNumber()}")]
+		}
 	}
 }
 parallel jobs
-
-stage('checksums') {
-	build job: 'openjdk10_build_checksum'
-}
-stage('publish nightly') {
-	build job: 'openjdk_release_tool', parameters: [string(name: 'REPO', value: 'nightly'), string(name: 'TAG', value: "${JDK_TAG}"), string(name: 'VERSION', value: 'jdk10')]
-}

--- a/pipelines/openjdk10_openj9_nightly_pipeline.groovy
+++ b/pipelines/openjdk10_openj9_nightly_pipeline.groovy
@@ -15,26 +15,35 @@ for ( int i = 0; i < buildPlatforms.size(); i++ ) {
 	def archOS = buildMaps[platform].ArchOSs
 	jobs[platform] = {
 		def buildJob
+		def buildJobNum
+		def checksumJob
 		stage('build') {
 			buildJob = build job: "openjdk10_openj9_build_${archOS}"
+			buildJobNum = buildJob.getNumber()
 		}
 		if (buildMaps[platform].test) {
 			stage('test') {
 				typeTests.each {
 					build job:"openjdk10_j9_${it}_${archOS}",
 							propagate: false,
-							parameters: [string(name: 'UPSTREAM_JOB_NUMBER', value: "${buildJob.getNumber()}"),
+							parameters: [string(name: 'UPSTREAM_JOB_NUMBER', value: "${buildJobNum}"),
 									string(name: 'UPSTREAM_JOB_NAME', value: "openjdk10_openj9_build_${archOS}")]
 				}
 			}
 		}
+		stage('checksums') {
+			checksumJob = build job: 'openjdk10_openj9_build_checksum',
+							parameters: [string(name: 'UPSTREAM_JOB_NUMBER', value: "${buildJobNum}"),
+									string(name: 'UPSTREAM_JOB_NAME', value: "openjdk10_openj9_build_${archOS}")]
+		}
+		stage('publish nightly') {
+			build job: 'openjdk_release_tool',
+						parameters: [string(name: 'REPO', value: 'nightly'),
+									string(name: 'TAG', value: "${JDK_TAG}"),
+									string(name: 'VERSION', value: 'jdk10-openj9'),
+									string(name: 'CHECKSUM_JOB_NAME', value: "openjdk10_openj9_build_checksum"),
+									string(name: 'CHECKSUM_JOB_NUMBER', value: "${checksumJob.getNumber()}")]
+		}
 	}
 }
 parallel jobs
-
-stage('checksums') {
-	build job: 'openjdk10_openj9_build_checksum'
-}
-stage('publish nightly') {
-	build job: 'openjdk_release_tool', parameters: [string(name: 'REPO', value: 'nightly'), string(name: 'TAG', value: "${JDK_TAG}"), string(name: 'VERSION', value: 'jdk10-openj9')]
-}

--- a/pipelines/openjdk8_nightly_pipeline.groovy
+++ b/pipelines/openjdk8_nightly_pipeline.groovy
@@ -17,26 +17,36 @@ for ( int i = 0; i < buildPlatforms.size(); i++ ) {
 	def archOS = buildMaps[platform].ArchOSs
 	jobs[platform] = {
 		def buildJob
+		def buildJobNum
+		def checksumJob
 		stage('build') {
 			buildJob = build job: "openjdk8_build_${archOS}"
+			buildJobNum = buildJob.getNumber()
 		}
 		if (buildMaps[platform].test) {
 			stage('test') {
 				typeTests.each {
 					build job:"openjdk8_hs_${it}_${archOS}",
 							propagate: false,
-							parameters: [string(name: 'UPSTREAM_JOB_NUMBER', value: "${buildJob.getNumber()}"),
+							parameters: [string(name: 'UPSTREAM_JOB_NUMBER', value: "${buildJobNum}"),
 									string(name: 'UPSTREAM_JOB_NAME', value: "openjdk8_build_${archOS}")]
 				}
 			}
+		}
+		stage('checksums') {
+			checksumJob = build job: 'openjdk8_build_checksum',
+							parameters: [string(name: 'UPSTREAM_JOB_NUMBER', value: "${buildJobNum}"),
+									string(name: 'UPSTREAM_JOB_NAME', value: "openjdk8_build_${archOS}")]
+		}
+		stage('publish nightly') {
+			build job: 'openjdk_release_tool',
+						parameters: [string(name: 'REPO', value: 'nightly'),
+									string(name: 'TAG', value: 'jdk8u172-b00'),
+									string(name: 'VERSION', value: 'jdk8'),
+									string(name: 'CHECKSUM_JOB_NAME', value: "openjdk8_build_checksum"),
+									string(name: 'CHECKSUM_JOB_NUMBER', value: "${checksumJob.getNumber()}")]
 		}
 	}
 }
 parallel jobs
 
-stage('checksums') {
-	build job: 'openjdk8_build_checksum'
-}
-stage('publish nightly') {
-	build job: 'openjdk_release_tool', parameters: [string(name: 'REPO', value: 'nightly'), string(name: 'TAG', value: 'jdk8u172-b00'), string(name: 'VERSION', value: 'jdk8')]
-}

--- a/pipelines/openjdk8_openj9_nightly_pipeline.groovy
+++ b/pipelines/openjdk8_openj9_nightly_pipeline.groovy
@@ -16,26 +16,36 @@ for ( int i = 0; i < buildPlatforms.size(); i++ ) {
 	def archOS = buildMaps[platform].ArchOSs
 	jobs[platform] = {
 		def buildJob
+		def buildJobNum
+		def checksumJob
 		stage('build') {
 			buildJob = build job: "openjdk8_openj9_build_${archOS}"
+			buildJobNum = buildJob.getNumber()
 		}
 		if (buildMaps[platform].test) {
 			stage('test') {
 				typeTests.each {
 					build job:"openjdk8_j9_${it}_${archOS}",
 							propagate: false,
-							parameters: [string(name: 'UPSTREAM_JOB_NUMBER', value: "${buildJob.getNumber()}"),
+							parameters: [string(name: 'UPSTREAM_JOB_NUMBER', value: "${buildJobNum)}"),
 									string(name: 'UPSTREAM_JOB_NAME', value: "openjdk8_openj9_build_${archOS}")]
 				}
 			}
+		}
+		stage('checksums') {
+			checksumJob = build job: 'openjdk8_openj9_build_checksum',
+							parameters: [string(name: 'UPSTREAM_JOB_NUMBER', value: "${buildJobNum}"),
+									string(name: 'UPSTREAM_JOB_NAME', value: "openjdk8_openj9_build_${archOS}")]
+		}
+		stage('publish nightly') {
+			build job: 'openjdk_release_tool',
+						parameters: [string(name: 'REPO', value: 'nightly'),
+									string(name: 'TAG', value: 'jdk8u162-b12'),
+									string(name: 'VERSION', value: 'jdk8-openj9'),
+									string(name: 'CHECKSUM_JOB_NAME', value: "openjdk8_openj9_build_checksum"),
+									string(name: 'CHECKSUM_JOB_NUMBER', value: "${checksumJob.getNumber()}")]
 		}
 	}
 }
 parallel jobs
 
-stage('checksums') {
-	build job: 'openjdk8_openj9_build_checksum'
-}
-stage('publish nightly') {
-	build job: 'openjdk_release_tool', parameters: [string(name: 'REPO', value: 'nightly'), string(name: 'TAG', value: 'jdk8u162-b12'), string(name: 'VERSION', value: 'jdk8-openj9')]
-}

--- a/pipelines/openjdk8_openj9_release_pipeline.groovy
+++ b/pipelines/openjdk8_openj9_release_pipeline.groovy
@@ -33,9 +33,16 @@ for ( int i = 0; i < buildPlatforms.size(); i++ ) {
 }
 parallel jobs
 
+def checksumJob
 stage('checksums') {
-	build job: 'openjdk8_openj9_build_checksum'
+	checksumJob = build job: 'openjdk8_openj9_build_checksum',
+							parameters: [string(name: 'PRODUCT', value: 'releases')]
 }
 stage('publish release') {
-	build job: 'openjdk_release_tool', parameters: [string(name: 'REPO', value: 'releases'), string(name: 'TAG', value: "${JDK_TAG}"), string(name: 'VERSION', value: 'jdk8-openj9')]
+	build job: 'openjdk_release_tool', 
+		parameters: [string(name: 'REPO', value: 'releases'), 
+					string(name: 'TAG', value: "${JDK_TAG}"), 
+					string(name: 'VERSION', value: 'jdk8-openj9')，
+					string(name: 'CHECKSUM_JOB_NAME', value: "openjdk8_openj9_build_checksum"),
+					string(name: 'CHECKSUM_JOB_NUMBER', value: "${checksumJob.getNumber()}")]
 }

--- a/pipelines/openjdk8_release_pipeline.groovy
+++ b/pipelines/openjdk8_release_pipeline.groovy
@@ -34,12 +34,20 @@ for ( int i = 0; i < buildPlatforms.size(); i++ ) {
 }
 parallel jobs
 
+def checksumJob
 stage('checksums') {
 	build job: 'openjdk8_build_checksum'
+	checksumJob = build job: 'openjdk8_build_checksum',
+							parameters: [string(name: 'PRODUCT', value: 'releases')]
 }
 stage('installers') {
 	build job: 'openjdk8_build_installer', parameters: [string(name: 'VERSION', value: "${JDK_VERSION}")]
 }
 stage('publish release') {
-	build job: 'openjdk_release_tool', parameters: [string(name: 'REPO', value: 'release'), string(name: 'TAG', value: "${JDK_TAG}"), string(name: 'VERSION', value: 'jdk8')]
+	build job: 'openjdk_release_tool', 
+				parameters: [string(name: 'REPO', value: 'release'),
+							string(name: 'TAG', value: "${JDK_TAG}"),
+							string(name: 'VERSION', value: 'jdk8'),
+							string(name: 'CHECKSUM_JOB_NAME', value: "openjdk8_build_checksum"),
+							string(name: 'CHECKSUM_JOB_NUMBER', value: "${checksumJob.getNumber()}")]
 }

--- a/pipelines/openjdk9_nightly_pipeline.groovy
+++ b/pipelines/openjdk9_nightly_pipeline.groovy
@@ -18,26 +18,35 @@ for ( int i = 0; i < buildPlatforms.size(); i++ ) {
 	def archOS = buildMaps[platform].ArchOSs
 	jobs[platform] = {
 		def buildJob
+		def buildJobNum
+		def checksumJob
 		stage('build') {
 			buildJob = build job: "openjdk9_build_${archOS}"
+			buildJobNum = buildJob.getNumber()
 		}
 		if (buildMaps[platform].test) {
 			stage('test') {
 				typeTests.each {
 					build job:"openjdk9_hs_${it}_${archOS}",
 							propagate: false,
-							parameters: [string(name: 'UPSTREAM_JOB_NUMBER', value: "${buildJob.getNumber()}"),
+							parameters: [string(name: 'UPSTREAM_JOB_NUMBER', value: "${buildJobNum}"),
 									string(name: 'UPSTREAM_JOB_NAME', value: "openjdk9_build_${archOS}")]
 				}
 			}
 		}
+		stage('checksums') {
+			checksumJob = build job: 'openjdk9_build_checksum',
+							parameters: [string(name: 'UPSTREAM_JOB_NUMBER', value: "${buildJobNum}"),
+									string(name: 'UPSTREAM_JOB_NAME', value: "openjdk9_build_${archOS}")]
+		}
+		stage('publish nightly') {
+			build job: 'openjdk_release_tool',
+						parameters: [string(name: 'REPO', value: 'nightly'),
+									string(name: 'TAG', value: 'jdk-9+181'),
+									string(name: 'VERSION', value: 'jdk9'),
+									string(name: 'CHECKSUM_JOB_NAME', value: "openjdk9_build_checksum"),
+									string(name: 'CHECKSUM_JOB_NUMBER', value: "${checksumJob.getNumber()}")]
+		}
 	}
 }
 parallel jobs
-
-stage('checksums') {
-	build job: 'openjdk9_build_checksum'
-}
-stage('publish nightly') {
-	build job: 'openjdk_release_tool', parameters: [string(name: 'REPO', value: 'nightly'), string(name: 'TAG', value: 'jdk-9+181'), string(name: 'VERSION', value: 'jdk9')]
-}

--- a/pipelines/openjdk9_openj9_nightly_pipeline.groovy
+++ b/pipelines/openjdk9_openj9_nightly_pipeline.groovy
@@ -15,26 +15,35 @@ for ( int i = 0; i < buildPlatforms.size(); i++ ) {
 	def archOS = buildMaps[platform].ArchOSs
 	jobs[platform] = {
 		def buildJob
+		def buildJobNum
+		def checksumJob
 		stage('build') {
 			buildJob = build job: "openjdk9_openj9_build_${archOS}"
+			buildJobNum = buildJob.getNumber()
 		}
 		if (buildMaps[platform].test) {
 			stage('test') {
 				typeTests.each {
 					build job:"openjdk9_j9_${it}_${archOS}",
 							propagate: false,
-							parameters: [string(name: 'UPSTREAM_JOB_NUMBER', value: "${buildJob.getNumber()}"),
+							parameters: [string(name: 'UPSTREAM_JOB_NUMBER', value: "${buildJobNum}"),
 									string(name: 'UPSTREAM_JOB_NAME', value: "openjdk9_openj9_build_${archOS}")]
 				}
 			}
 		}
+		stage('checksums') {
+			checksumJob = build job: 'openjdk9_openj9_build_checksum',
+							parameters: [string(name: 'UPSTREAM_JOB_NUMBER', value: "${buildJobNum}"),
+									string(name: 'UPSTREAM_JOB_NAME', value: "openjdk9_openj9_build_${archOS}")]
+		}
+		stage('publish nightly') {
+			build job: 'openjdk_release_tool',
+						parameters: [string(name: 'REPO', value: 'nightly'),
+									string(name: 'TAG', value: 'jdk-9+181'),
+									string(name: 'VERSION', value: 'jdk9-openj9'),
+									string(name: 'CHECKSUM_JOB_NAME', value: "openjdk9_openj9_build_checksum"),
+									string(name: 'CHECKSUM_JOB_NUMBER', value: "${checksumJob.getNumber()}")]
+		}
 	}
 }
 parallel jobs
-
-stage('checksums') {
-	build job: 'openjdk9_openj9_build_checksum'
-}
-stage('publish nightly') {
-	build job: 'openjdk_release_tool', parameters: [string(name: 'REPO', value: 'nightly'), string(name: 'TAG', value: 'jdk-9+181'), string(name: 'VERSION', value: 'jdk9-openj9')]
-}

--- a/pipelines/openjdk_amber_nightly_pipeline.groovy
+++ b/pipelines/openjdk_amber_nightly_pipeline.groovy
@@ -14,16 +14,23 @@ for ( int i = 0; i < buildPlatforms.size(); i++ ) {
 	def archOS = buildMaps[platform].ArchOSs
 	jobs[platform] = {
 		def buildJob
+		def checksumJob
 		stage('build') {
 			buildJob = build job: "openjdk_amber_build_${archOS}"
+		}
+		stage('checksums') {
+			checksumJob = build job: 'openjdk_amber_build_checksum',
+							parameters: [string(name: 'UPSTREAM_JOB_NUMBER', value: "${buildJob.getNumber()}"),
+									string(name: 'UPSTREAM_JOB_NAME', value: "openjdk_amber_build_${archOS}")]
+		}
+		stage('publish nightly') {
+			build job: 'openjdk_release_tool',
+						parameters: [string(name: 'REPO', value: 'nightly'),
+									string(name: 'TAG', value: "${JDK_TAG}"),
+									string(name: 'VERSION', value: 'jdk-amber'),
+									string(name: 'CHECKSUM_JOB_NAME', value: "openjdk_amber_build_checksum"),
+									string(name: 'CHECKSUM_JOB_NUMBER', value: "${checksumJob.getNumber()}")]
 		}
 	}
 }
 parallel jobs
-
-stage('checksums') {
-	build job: 'openjdk_amber_build_checksum'
-}
-stage('publish nightly') {
-	build job: 'openjdk_release_tool', parameters: [string(name: 'REPO', value: 'nightly'), string(name: 'TAG', value: "${JDK_TAG}"), string(name: 'VERSION', value: 'jdk-amber')]
-}


### PR DESCRIPTION
Set nightly builds deployment per platform, keep release as before. This will need co-operation with configuration updates of build openjdk_{JVMVERSION}_build_checksum and openjdk_release_tool

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>