### PR TITLE
Automate trigger of openjdk10-openj9 systemtest in x64x & ppc64le linux

### DIFF
--- a/pipelines/openjdk10_openj9_nightly_pipeline.groovy
+++ b/pipelines/openjdk10_openj9_nightly_pipeline.groovy
@@ -2,12 +2,12 @@ println "building ${JDK_VERSION}"
 
 def buildPlatforms = ['Linux', 'zLinux', 'ppc64le', 'AIX', "Windows"]
 def buildMaps = [:]
-buildMaps['Linux'] = [test:false, ArchOSs:'x86-64_linux']
+buildMaps['Linux'] = [test:true, ArchOSs:'x86-64_linux']
 buildMaps['zLinux'] = [test:false, ArchOSs:'s390x_linux']
-buildMaps['ppc64le'] = [test:false, ArchOSs:'ppc64le_linux']
+buildMaps['ppc64le'] = [test:true, ArchOSs:'ppc64le_linux']
 buildMaps['AIX'] = [test:false, ArchOSs:'ppc64_aix']
 buildMaps['Windows'] = [test:false, ArchOSs:'x86-64_windows']
-def typeTests = ['openjdktest', 'systemtest']
+def typeTests = ['systemtest']
 
 def jobs = [:]
 for ( int i = 0; i < buildPlatforms.size(); i++ ) {


### PR DESCRIPTION
Automate triggering of openjdk10-openj9 systemtest in x64x & ppc64le linux platforms once the sdk build job of these platforms succeeds. 
Signed-off-by: Mesbah <Mesbah_Alam@ca.ibm.com>