### PR TITLE
Add Windows to openjdk10_openj9 pipeline

### DIFF
--- a/pipelines/openjdk10_openj9_nightly_pipeline.groovy
+++ b/pipelines/openjdk10_openj9_nightly_pipeline.groovy
@@ -1,11 +1,12 @@
 println "building ${JDK_VERSION}"
 
-def buildPlatforms = ['Linux', 'zLinux', 'ppc64le', 'AIX']
+def buildPlatforms = ['Linux', 'zLinux', 'ppc64le', 'AIX', "Windows"]
 def buildMaps = [:]
 buildMaps['Linux'] = [test:false, ArchOSs:'x86-64_linux']
 buildMaps['zLinux'] = [test:false, ArchOSs:'s390x_linux']
 buildMaps['ppc64le'] = [test:false, ArchOSs:'ppc64le_linux']
 buildMaps['AIX'] = [test:false, ArchOSs:'ppc64_aix']
+buildMaps['Windows'] = [test:false, ArchOSs:'x86-64_windows']
 def typeTests = ['openjdktest', 'systemtest']
 
 def jobs = [:]


### PR DESCRIPTION
Adding windows builds to the pipeline created in https://github.com/AdoptOpenJDK/openjdk-build/issues/272 now that https://github.com/AdoptOpenJDK/openjdk-build/issues/281 has been resolved