### PR TITLE
Automatically trigger Openjdk10-Openj9 systemtest on zLinux

### DIFF
--- a/pipelines/openjdk10_openj9_nightly_pipeline.groovy
+++ b/pipelines/openjdk10_openj9_nightly_pipeline.groovy
@@ -3,7 +3,7 @@ println "building ${JDK_VERSION}"
 def buildPlatforms = ['Linux', 'zLinux', 'ppc64le', 'AIX', "Windows"]
 def buildMaps = [:]
 buildMaps['Linux'] = [test:true, ArchOSs:'x86-64_linux']
-buildMaps['zLinux'] = [test:false, ArchOSs:'s390x_linux']
+buildMaps['zLinux'] = [test:true, ArchOSs:'s390x_linux']
 buildMaps['ppc64le'] = [test:true, ArchOSs:'ppc64le_linux']
 buildMaps['AIX'] = [test:false, ArchOSs:'ppc64_aix']
 buildMaps['Windows'] = [test:false, ArchOSs:'x86-64_windows']


### PR DESCRIPTION
Add option to automatically trigger Openjdk10-Openj9 systemtest on zLinux