### PR TITLE
Handle and check exit code from make properly

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -300,12 +300,10 @@ buildOpenJDK()
 
   FULL_MAKE_COMMAND="${MAKE_COMMAND_NAME} ${MAKE_ARGS_FOR_ANY_PLATFORM} ${MAKE_TEST_IMAGE}"
   echo "Building the JDK: calling '${FULL_MAKE_COMMAND}'"
-  exitCode=$(${FULL_MAKE_COMMAND})
 
-  # shellcheck disable=SC2181
-  if [ "${exitCode}" -ne 0 ]; then
-     echo "${error}Failed to make the JDK, exiting"
-    exit;
+  if ! ${FULL_MAKE_COMMAND}; then
+    echo "${error}Failed to make the JDK, exiting"
+    exit 1;
   else
     echo "${good}Built the JDK!"
   fi


### PR DESCRIPTION
Fixes https://github.com/AdoptOpenJDK/openjdk-build/issues/302
Logic to obtain the exit code was incorrect