### PR TITLE
Fix java -version check in build, as it's currently running exit from…

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -318,9 +318,11 @@ printJavaVersionString()
   PRODUCT_HOME=$(ls -d $OPENJDK_DIR/build/*/images/${JDK_PATH})
   if [[ -d "$PRODUCT_HOME" ]]; then
      echo "${good}'$PRODUCT_HOME' found${normal}"
-     # shellcheck disable=SC2154
      echo "${info}"
-     "$PRODUCT_HOME"/bin/java -version || (echo "${error} Error executing 'java' does not exist in '$PRODUCT_HOME'.${normal}" && exit -1)
+     if ! "$PRODUCT_HOME"/bin/java -version; then
+       echo "${error} Error executing 'java' does not exist in '$PRODUCT_HOME'.${normal}"
+       exit -1
+     fi
      echo "${normal}"
      echo ""
   else


### PR DESCRIPTION
… a transient subshell

the () construct will typically cause commands to be executed in a subshell. Running `exit -1` from that subshell will not achieve the desired result. Will adjust the way I'm doing it if the `shellcheck disable` fails on this, as I prefer to fix the problem instead of disabling the check ...

Fixes https://github.com/AdoptOpenJDK/openjdk-build/issues/264