### PR TITLE
Add Windows to the openjdk9/openj9 nightly pipline

### DIFF
--- a/pipelines/openjdk9_openj9_nightly_pipeline.groovy
+++ b/pipelines/openjdk9_openj9_nightly_pipeline.groovy
@@ -1,11 +1,12 @@
 println "building ${JDK_VERSION}"
 
-def buildPlatforms = ['Linux', 'zLinux', 'ppc64le', 'AIX']
+def buildPlatforms = ['Linux', 'zLinux', 'ppc64le', 'AIX', "Windows"]
 def buildMaps = [:]
 buildMaps['Linux'] = [test:true, ArchOSs:'x86-64_linux']
 buildMaps['zLinux'] = [test:true, ArchOSs:'s390x_linux']
 buildMaps['ppc64le'] = [test:true, ArchOSs:'ppc64le_linux']
 buildMaps['AIX'] = [test:false, ArchOSs:'ppc64_aix']
+buildMaps['Windows'] = [test:false, ArchOSs:'x86-64_windows']
 def typeTests = ['openjdktest', 'systemtest']
 
 def jobs = [:]


### PR DESCRIPTION
Build job appears to be succeeding, so no reason not to have it in the pipeline