### PR TITLE
Add Win32 & x64_linux_largeHeap

### DIFF
--- a/pipelines/openjdk8_openj9_nightly_pipeline.groovy
+++ b/pipelines/openjdk8_openj9_nightly_pipeline.groovy
@@ -1,12 +1,14 @@
 println "building ${JDK_VERSION}"
 
-def buildPlatforms = ['Linux', 'zLinux', 'ppc64le', 'AIX', 'Windows']
+def buildPlatforms = ['Linux', 'zLinux', 'ppc64le', 'AIX', 'Windows', 'Windows32', 'LinuxXL']
 def buildMaps = [:]
 buildMaps['Linux'] = [test:['openjdktest', 'systemtest', 'perftest', 'externaltest'], ArchOSs:'x86-64_linux']
+buildMaps['LinuxXL'] = buildMaps['AIX'] = [test:false, ArchOSs:'x86-64_linux_largeHeap']
 buildMaps['zLinux'] = [test:['openjdktest', 'systemtest'], ArchOSs:'s390x_linux']
 buildMaps['ppc64le'] = [test:['openjdktest', 'systemtest'], ArchOSs:'ppc64le_linux']
 buildMaps['AIX'] = [test:false, ArchOSs:'ppc64_aix']
 buildMaps['Windows'] = [test:['openjdktest'], ArchOSs:'x86-64_windows']
+buildMaps['Windows32'] = [test:['openjdktest'], ArchOSs:'x86-32_windows']
 
 def jobs = [:]
 for ( int i = 0; i < buildPlatforms.size(); i++ ) {

--- a/pipelines/openjdk8_openj9_nightly_pipeline.groovy
+++ b/pipelines/openjdk8_openj9_nightly_pipeline.groovy
@@ -3,7 +3,7 @@ println "building ${JDK_VERSION}"
 def buildPlatforms = ['Linux', 'zLinux', 'ppc64le', 'AIX', 'Windows', 'Windows32', 'LinuxXL']
 def buildMaps = [:]
 buildMaps['Linux'] = [test:['openjdktest', 'systemtest', 'perftest', 'externaltest'], ArchOSs:'x86-64_linux']
-buildMaps['LinuxXL'] = buildMaps['AIX'] = [test:false, ArchOSs:'x86-64_linux_largeHeap']
+buildMaps['LinuxXL'] = [test:['openjdktest'], ArchOSs:'x86-64_linux_largeHeap']
 buildMaps['zLinux'] = [test:['openjdktest', 'systemtest'], ArchOSs:'s390x_linux']
 buildMaps['ppc64le'] = [test:['openjdktest', 'systemtest'], ArchOSs:'ppc64le_linux']
 buildMaps['AIX'] = [test:false, ArchOSs:'ppc64_aix']


### PR DESCRIPTION
Adding Win32 and x64_linux_largeHeap to the openjdk8_openj9 nightly build pipelines
(for now keep as separate buildPlatforms, to be able to keep test lists separate/different from the win64, x64_linux builds)

Signed-off-by: smlambert <slambert@gmail.com>