### PR TITLE
Ensure tag from the source repo instead of openjdk-build is used

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -179,6 +179,7 @@ configuringVersionStringParameter()
     addConfigureArgIfValueIsNotEmpty "--with-build-number=" "${OPENJDK_BUILD_NUMBER}"
   else
     if [ -z "$OPENJDK_REPO_TAG" ]; then
+      cd "${WORKING_DIR}/${OPENJDK_REPO_NAME}" || echo Cannot change to "${WORKING_DIR}/${OPENJDK_REPO_NAME}"
       OPENJDK_REPO_TAG=$(getFirstTagFromOpenJDKGitRepo)
       echo "OpenJDK repo tag is ${OPENJDK_REPO_TAG}"
     fi


### PR DESCRIPTION
Gah ... This is kinda why I don't use functions in my own shell scripts - can be hard to trace the flow, but not to worry.

This change ensures is changes into the source repo before trying to determine the tag (otherwise it picks up the tag from the `openjdk-build` repo apparently! Hopefully this won't result in any issues further down the line.

I've accidentally created this branch in the AdoptOpenJDK repo instead of my own so when merged please feel free to delete the branch.