### PR TITLE
Pipelines allow alternate branch

### DIFF
--- a/pipelines/openjdk10_nightly_pipeline.groovy
+++ b/pipelines/openjdk10_nightly_pipeline.groovy
@@ -20,7 +20,8 @@ for ( int i = 0; i < buildPlatforms.size(); i++ ) {
 		def buildJobNum
 		def checksumJob
 		stage('build') {
-			buildJob = build job: "openjdk10_build_${archOS}"
+			buildJob = build job: "openjdk10_build_${archOS}",
+					parameters: [string(name: 'BRANCH', value: "$ALT_BRANCH")]
 			buildJobNum = buildJob.getNumber()
 		}
 		if (buildMaps[platform].test) {

--- a/pipelines/openjdk10_openj9_nightly_pipeline.groovy
+++ b/pipelines/openjdk10_openj9_nightly_pipeline.groovy
@@ -19,7 +19,8 @@ for ( int i = 0; i < buildPlatforms.size(); i++ ) {
 		def buildJobNum
 		def checksumJob
 		stage('build') {
-			buildJob = build job: "openjdk10_openj9_build_${archOS}"
+			buildJob = build job: "openjdk10_openj9_build_${archOS}",
+					parameters: [string(name: 'BRANCH', value: "$ALT_BRANCH")]
 			buildJobNum = buildJob.getNumber()
 		}
 		if (buildMaps[platform].test) {

--- a/pipelines/openjdk8_nightly_pipeline.groovy
+++ b/pipelines/openjdk8_nightly_pipeline.groovy
@@ -21,6 +21,7 @@ for ( int i = 0; i < buildPlatforms.size(); i++ ) {
 		def checksumJob
 		stage('build') {
 			buildJob = build job: "openjdk8_build_${archOS}"
+					parameters: [string(name: 'BRANCH', value: "$ALT_BRANCH")]
 			buildJobNum = buildJob.getNumber()
 		}
 		if (buildMaps[platform].test) {

--- a/pipelines/openjdk8_openj9_nightly_pipeline.groovy
+++ b/pipelines/openjdk8_openj9_nightly_pipeline.groovy
@@ -20,7 +20,8 @@ for ( int i = 0; i < buildPlatforms.size(); i++ ) {
 		def buildJobNum
 		def checksumJob
 		stage('build') {
-			buildJob = build job: "openjdk8_openj9_build_${archOS}"
+			buildJob = build job: "openjdk8_openj9_build_${archOS}",
+					parameters: [string(name: 'BRANCH', value: "$ALT_BRANCH")]
 			buildJobNum = buildJob.getNumber()
 		}
 		if (buildMaps[platform].test) {

--- a/pipelines/openjdk8_openj9_release_pipeline.groovy
+++ b/pipelines/openjdk8_openj9_release_pipeline.groovy
@@ -16,7 +16,8 @@ for ( int i = 0; i < buildPlatforms.size(); i++ ) {
 	jobs[platform] = {
 		def buildJob
 		stage('build') {
-			buildJob = build job: "openjdk8_openj9_build_${archOS}"
+			buildJob = build job: "openjdk8_openj9_build_${archOS}",
+					parameters: [string(name: 'BRANCH', value: "$ALT_BRANCH")]
 		}
 		if (buildMaps[platform].test) {
 			stage('test') {

--- a/pipelines/openjdk8_release_pipeline.groovy
+++ b/pipelines/openjdk8_release_pipeline.groovy
@@ -19,7 +19,8 @@ for ( int i = 0; i < buildPlatforms.size(); i++ ) {
 		def buildJob
 		stage('build') {
 			buildJob = build job: "openjdk8_build_${archOS}",
-			parameters: [string(name: 'TAG', value: "${JDK_TAG}")]
+			parameters: [string(name: 'TAG', value: "${JDK_TAG}"),
+				     string(name: 'BRANCH', value: "${ALT_BRANCH}")]
 		}
 		if (buildMaps[platform].test) {
 			buildMaps[platform].test.each {

--- a/pipelines/openjdk9_nightly_pipeline.groovy
+++ b/pipelines/openjdk9_nightly_pipeline.groovy
@@ -20,7 +20,9 @@ for ( int i = 0; i < buildPlatforms.size(); i++ ) {
 		def buildJobNum
 		def checksumJob
 		stage('build') {
-			buildJob = build job: "openjdk9_build_${archOS}"
+			buildJob = build job: "openjdk9_build_${archOS}",
+					parameters: [string(name: 'BRANCH', value: "$ALT_BRANCH")]
+
 			buildJobNum = buildJob.getNumber()
 		}
 		if (buildMaps[platform].test) {

--- a/pipelines/openjdk9_openj9_nightly_pipeline.groovy
+++ b/pipelines/openjdk9_openj9_nightly_pipeline.groovy
@@ -18,7 +18,8 @@ for ( int i = 0; i < buildPlatforms.size(); i++ ) {
 		def buildJobNum
 		def checksumJob
 		stage('build') {
-			buildJob = build job: "openjdk9_openj9_build_${archOS}"
+			buildJob = build job: "openjdk9_openj9_build_${archOS}",
+					parameters: [string(name: 'BRANCH', value: "$ALT_BRANCH")]
 			buildJobNum = buildJob.getNumber()
 		}
 		if (buildMaps[platform].test) {

--- a/pipelines/openjdk_amber_nightly_pipeline.groovy
+++ b/pipelines/openjdk_amber_nightly_pipeline.groovy
@@ -16,7 +16,8 @@ for ( int i = 0; i < buildPlatforms.size(); i++ ) {
 		def buildJobNum
 		def checksumJob
 		stage('build') {
-			buildJob = build job: "openjdk_amber_build_${archOS}"
+			buildJob = build job: "openjdk_amber_build_${archOS}",
+					parameters: [string(name: 'BRANCH', value: "$ALT_BRANCH")]
 			buildJobNum = buildJob.getNumber()
 		}
 		if (buildMaps[platform].test) {


### PR DESCRIPTION
At the moment we can't pass in an alternate parameter to the pipelines for the openj9 release build process. Previously we've done temporary modifications to the build jobs. Now that we have the branch able to be passed as a parameter to the build jobs, it makes sense to allow this to be passed in from the pipelines.

I've done this across all pipelines (not just the openj9 ones) for consistency, although we're only likely to use it for the openj9 builds. I've modified the pipelines to take an optional `ALT_BRANCH` parameter