### PR TITLE
Pass in jdk version to jtreg

### DIFF
--- a/makejdk.sh
+++ b/makejdk.sh
@@ -50,6 +50,7 @@ KEEP=false
 JTREG=false
 BUILD_VARIANT=${BUILD_VARIANT-:""}
 USER_SUPPLIED_CONFIGURE_ARGS=""
+VERSION=""
 
 JVM_VARIANT=${JVM_VARIANT:-server}
 
@@ -122,7 +123,7 @@ parseCommandLineArgs()
       export FREETYPE=false;;
 
       "--version" | "-v" )
-      shift;;
+      VERSION="$1"; shift;;
 
       "--freetype-dir" | "-ftd" )
       export FREETYPE_DIRECTORY="$1"; shift;;
@@ -420,7 +421,7 @@ testOpenJDKInNativeEnvironmentIfExpected()
 {
   if [[ "$JTREG" == "true" ]];
   then
-      "${SCRIPT_DIR}"/sbin/jtreg.sh "${WORKING_DIR}" "${OPENJDK_REPO_NAME}" "${BUILD_FULL_NAME}" "${JTREG_TEST_SUBSETS}"
+      "${SCRIPT_DIR}"/sbin/jtreg.sh "${WORKING_DIR}" "${OPENJDK_REPO_NAME}" "${BUILD_FULL_NAME}" "${VERSION}" "${JTREG_TEST_SUBSETS}"
   fi
 }
 

--- a/sbin/jtreg.sh
+++ b/sbin/jtreg.sh
@@ -20,8 +20,9 @@ source "$SCRIPT_DIR/common-functions.sh"
 WORKING_DIR=$1
 OPENJDK_REPO_NAME=$2
 BUILD_FULL_NAME=$3
+VERSION=$4
 # shellcheck disable=SC2001
-JTREG_TEST_SUBSETS=$(echo "$4" | sed 's/:/ /')
+JTREG_TEST_SUBSETS=$(echo "$5" | sed 's/:/ /')
 JTREG_VERSION=${JTREG_VERSION:-4.2.0-tip}
 JTREG_TARGET_FOLDER=${JTREG_TARGET_FOLDER:-jtreg}
 JOB_NAME=${JOB_NAME:-OpenJDK}
@@ -77,12 +78,16 @@ downloadJtregAndSetupEnvironment()
 
 applyingJCovSettingsToMakefileForTests()
 {
-  echo "Apply JCov settings to Makefile..." 
-  cd "$OPENJDK_DIR/jdk/test" || exit
+  echo "Apply JCov settings to Makefile..."
+  if [[ $VERSION == *8* ]]; then
+  	cd "$OPENJDK_DIR/jdk/test" || exit
+  	sed -i "s/-vmoption:-Xmx512m.*/-vmoption:-Xmx512m -xml:verify -jcov\/classes:\$\(ABS_PLATFORM_BUILD_ROOT\)\/images\/j2sdk-image\/jre\/lib\/rt.jar  -jcov\/source:\$\(ABS_PLATFORM_BUILD_ROOT\)\/images\/j2sdk-image\/src.zip  -jcov\/include:*/" Makefile
+  else
+  	cd "$OPENJDK_DIR/test" || exit
+  	# TODO pass in correct jcov parameter for jdk9 and up
+  	# sed -i "s/-vmoption:-Xmx512m.*/-vmoption:-Xmx512m -xml:verify -jcov\/classes:\$\(ABS_PLATFORM_BUILD_ROOT\)\/jdk\/classes\/  -jcov\/source:\$\(ABS_PLATFORM_BUILD_ROOT\)\/..\/..\/jdk\/src\/share\/classes  -jcov\/include:*/" TestCommon.gmk
+  fi
   pwd
-  
-  sed -i "s/-vmoption:-Xmx512m.*/-vmoption:-Xmx512m -xml:verify -jcov\/classes:\$\(ABS_PLATFORM_BUILD_ROOT\)\/images\/j2sdk-image\/jre\/lib\/rt.jar  -jcov\/source:\$\(ABS_PLATFORM_BUILD_ROOT\)\/images\/j2sdk-image\/src.zip  -jcov\/include:*/" Makefile
-  
   cd "$OPENJDK_DIR" || exit
 }
 


### PR DESCRIPTION
Pass in jdk version to jtreg as jdk test structure is different with
different jdk version

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>