### PR TITLE
Add timestamps to top-level pipelines

### DIFF
--- a/pipelines/openjdk10_nightly_pipeline.groovy
+++ b/pipelines/openjdk10_nightly_pipeline.groovy
@@ -2,7 +2,7 @@ println "building ${JDK_VERSION}"
 
 def buildPlatforms = ['Mac', 'Windows', 'Linux', 'zLinux', 'ppc64le', 'AIX', 'aarch64']
 def buildMaps = [:]
-def PIPELINE_TIMESTAMP = new Date(currentBuild.startTimeInMillis).format("yyyyddMMHHmm")
+def PIPELINE_TIMESTAMP = new Date(currentBuild.startTimeInMillis).format("yyyyMMddHHmm")
 
 buildMaps['Mac'] = [test:['openjdktest', 'systemtest'], ArchOSs:'x86-64_macos']
 buildMaps['Windows'] = [test:['openjdktest'], ArchOSs:'x86-64_windows']

--- a/pipelines/openjdk10_nightly_pipeline.groovy
+++ b/pipelines/openjdk10_nightly_pipeline.groovy
@@ -2,6 +2,8 @@ println "building ${JDK_VERSION}"
 
 def buildPlatforms = ['Mac', 'Windows', 'Linux', 'zLinux', 'ppc64le', 'AIX', 'aarch64']
 def buildMaps = [:]
+def PIPELINE_TIMESTAMP = new Date(currentBuild.startTimeInMillis).format("yyyyddMMHHmm")
+
 buildMaps['Mac'] = [test:['openjdktest', 'systemtest'], ArchOSs:'x86-64_macos']
 buildMaps['Windows'] = [test:['openjdktest'], ArchOSs:'x86-64_windows']
 buildMaps['Linux'] = [test:['openjdktest', 'systemtest', 'externaltest'], ArchOSs:'x86-64_linux']
@@ -21,7 +23,8 @@ for ( int i = 0; i < buildPlatforms.size(); i++ ) {
 		def checksumJob
 		stage('build') {
 			buildJob = build job: "openjdk10_build_${archOS}",
-					parameters: [string(name: 'BRANCH', value: "$ALT_BRANCH")]
+					parameters: [string(name: 'BRANCH', value: "$ALT_BRANCH"),
+					string(name: 'PIPELINE_TIMESTAMP', value: "${PIPELINE_TIMESTAMP}")]
 			buildJobNum = buildJob.getNumber()
 		}
 		if (buildMaps[platform].test) {

--- a/pipelines/openjdk10_openj9_nightly_pipeline.groovy
+++ b/pipelines/openjdk10_openj9_nightly_pipeline.groovy
@@ -2,7 +2,7 @@ println "building ${JDK_VERSION}"
 
 def buildPlatforms = ['Linux', 'zLinux', 'ppc64le', 'AIX', "Windows"]
 def buildMaps = [:]
-def PIPELINE_TIMESTAMP = new Date(currentBuild.startTimeInMillis).format("yyyyddMMHHmm")
+def PIPELINE_TIMESTAMP = new Date(currentBuild.startTimeInMillis).format("yyyyMMddHHmm")
 
 buildMaps['Linux'] = [test:['openjdktest', 'systemtest', 'externaltest'], ArchOSs:'x86-64_linux']
 buildMaps['zLinux'] = [test:['openjdktest', 'systemtest'], ArchOSs:'s390x_linux']

--- a/pipelines/openjdk10_openj9_nightly_pipeline.groovy
+++ b/pipelines/openjdk10_openj9_nightly_pipeline.groovy
@@ -2,6 +2,8 @@ println "building ${JDK_VERSION}"
 
 def buildPlatforms = ['Linux', 'zLinux', 'ppc64le', 'AIX', "Windows"]
 def buildMaps = [:]
+def PIPELINE_TIMESTAMP = new Date(currentBuild.startTimeInMillis).format("yyyyddMMHHmm")
+
 buildMaps['Linux'] = [test:['openjdktest', 'systemtest', 'externaltest'], ArchOSs:'x86-64_linux']
 buildMaps['zLinux'] = [test:['openjdktest', 'systemtest'], ArchOSs:'s390x_linux']
 buildMaps['ppc64le'] = [test:['openjdktest', 'systemtest'], ArchOSs:'ppc64le_linux']
@@ -20,7 +22,8 @@ for ( int i = 0; i < buildPlatforms.size(); i++ ) {
 		def checksumJob
 		stage('build') {
 			buildJob = build job: "openjdk10_openj9_build_${archOS}",
-					parameters: [string(name: 'BRANCH', value: "$ALT_BRANCH")]
+					parameters: [string(name: 'BRANCH', value: "$ALT_BRANCH"),
+					string(name: 'PIPELINE_TIMESTAMP', value: "${PIPELINE_TIMESTAMP}")]
 			buildJobNum = buildJob.getNumber()
 		}
 		if (buildMaps[platform].test) {

--- a/pipelines/openjdk8_nightly_pipeline.groovy
+++ b/pipelines/openjdk8_nightly_pipeline.groovy
@@ -2,7 +2,7 @@ println "building ${JDK_VERSION}"
 
 def buildPlatforms = ['Mac', 'Windows', 'Linux', 'zLinux', 'ppc64le', 'AIX', 'aarch64']
 def buildMaps = [:]
-def PIPELINE_TIMESTAMP = new Date(currentBuild.startTimeInMillis).format("yyyyddMMHHmm")
+def PIPELINE_TIMESTAMP = new Date(currentBuild.startTimeInMillis).format("yyyyMMddHHmm")
 
 buildMaps['Mac'] = [test:['openjdktest', 'systemtest'], ArchOSs:'x86-64_macos']
 buildMaps['Windows'] = [test:['openjdktest'], ArchOSs:'x86-64_windows']

--- a/pipelines/openjdk8_nightly_pipeline.groovy
+++ b/pipelines/openjdk8_nightly_pipeline.groovy
@@ -2,6 +2,8 @@ println "building ${JDK_VERSION}"
 
 def buildPlatforms = ['Mac', 'Windows', 'Linux', 'zLinux', 'ppc64le', 'AIX', 'aarch64']
 def buildMaps = [:]
+def PIPELINE_TIMESTAMP = new Date(currentBuild.startTimeInMillis).format("yyyyddMMHHmm")
+
 buildMaps['Mac'] = [test:['openjdktest', 'systemtest'], ArchOSs:'x86-64_macos']
 buildMaps['Windows'] = [test:['openjdktest'], ArchOSs:'x86-64_windows']
 buildMaps['Linux'] = [test:['openjdktest', 'systemtest', 'perftest', 'externaltest'], ArchOSs:'x86-64_linux']
@@ -21,7 +23,8 @@ for ( int i = 0; i < buildPlatforms.size(); i++ ) {
 		def checksumJob
 		stage('build') {
 			buildJob = build job: "openjdk8_build_${archOS}"
-					parameters: [string(name: 'BRANCH', value: "$ALT_BRANCH")]
+					parameters: [string(name: 'BRANCH', value: "$ALT_BRANCH"),
+					string(name: 'PIPELINE_TIMESTAMP', value: "${PIPELINE_TIMESTAMP}")]
 			buildJobNum = buildJob.getNumber()
 		}
 		if (buildMaps[platform].test) {

--- a/pipelines/openjdk8_openj9_nightly_pipeline.groovy
+++ b/pipelines/openjdk8_openj9_nightly_pipeline.groovy
@@ -2,7 +2,7 @@ println "building ${JDK_VERSION}"
 
 def buildPlatforms = ['Linux', 'zLinux', 'ppc64le', 'AIX', 'Windows', 'Windows32', 'LinuxXL']
 def buildMaps = [:]
-def PIPELINE_TIMESTAMP = new Date(currentBuild.startTimeInMillis).format("yyyyddMMHHmm")
+def PIPELINE_TIMESTAMP = new Date(currentBuild.startTimeInMillis).format("yyyyMMddHHmm")
 
 buildMaps['Linux'] = [test:['openjdktest', 'systemtest', 'perftest', 'externaltest'], ArchOSs:'x86-64_linux']
 buildMaps['LinuxXL'] = [test:['openjdktest'], ArchOSs:'x86-64_linux_largeHeap']

--- a/pipelines/openjdk8_openj9_nightly_pipeline.groovy
+++ b/pipelines/openjdk8_openj9_nightly_pipeline.groovy
@@ -2,6 +2,8 @@ println "building ${JDK_VERSION}"
 
 def buildPlatforms = ['Linux', 'zLinux', 'ppc64le', 'AIX', 'Windows', 'Windows32', 'LinuxXL']
 def buildMaps = [:]
+def PIPELINE_TIMESTAMP = new Date(currentBuild.startTimeInMillis).format("yyyyddMMHHmm")
+
 buildMaps['Linux'] = [test:['openjdktest', 'systemtest', 'perftest', 'externaltest'], ArchOSs:'x86-64_linux']
 buildMaps['LinuxXL'] = [test:['openjdktest'], ArchOSs:'x86-64_linux_largeHeap']
 buildMaps['zLinux'] = [test:['openjdktest', 'systemtest'], ArchOSs:'s390x_linux']
@@ -21,7 +23,8 @@ for ( int i = 0; i < buildPlatforms.size(); i++ ) {
 		def checksumJob
 		stage('build') {
 			buildJob = build job: "openjdk8_openj9_build_${archOS}",
-					parameters: [string(name: 'BRANCH', value: "$ALT_BRANCH")]
+					parameters: [string(name: 'BRANCH', value: "$ALT_BRANCH"),
+					string(name: 'PIPELINE_TIMESTAMP', value: "${PIPELINE_TIMESTAMP}")]
 			buildJobNum = buildJob.getNumber()
 		}
 		if (buildMaps[platform].test) {

--- a/pipelines/openjdk8_openj9_release_pipeline.groovy
+++ b/pipelines/openjdk8_openj9_release_pipeline.groovy
@@ -2,7 +2,7 @@ println "building ${JDK_VERSION}"
 
 def buildPlatforms = ['Linux', 'zLinux', 'ppc64le', 'AIX', 'Windows']
 def buildMaps = [:]
-def PIPELINE_TIMESTAMP = new Date(currentBuild.startTimeInMillis).format("yyyyddMMHHmm")
+def PIPELINE_TIMESTAMP = new Date(currentBuild.startTimeInMillis).format("yyyyMMddHHmm")
 
 buildMaps['Linux'] = [test:['openjdktest', 'systemtest'], ArchOSs:'x86-64_linux']
 buildMaps['zLinux'] = [test:['openjdktest', 'systemtest'], ArchOSs:'s390x_linux']

--- a/pipelines/openjdk8_openj9_release_pipeline.groovy
+++ b/pipelines/openjdk8_openj9_release_pipeline.groovy
@@ -2,6 +2,8 @@ println "building ${JDK_VERSION}"
 
 def buildPlatforms = ['Linux', 'zLinux', 'ppc64le', 'AIX', 'Windows']
 def buildMaps = [:]
+def PIPELINE_TIMESTAMP = new Date(currentBuild.startTimeInMillis).format("yyyyddMMHHmm")
+
 buildMaps['Linux'] = [test:['openjdktest', 'systemtest'], ArchOSs:'x86-64_linux']
 buildMaps['zLinux'] = [test:['openjdktest', 'systemtest'], ArchOSs:'s390x_linux']
 buildMaps['ppc64le'] = [test:['openjdktest', 'systemtest'], ArchOSs:'ppc64le_linux']
@@ -17,7 +19,8 @@ for ( int i = 0; i < buildPlatforms.size(); i++ ) {
 		def buildJob
 		stage('build') {
 			buildJob = build job: "openjdk8_openj9_build_${archOS}",
-					parameters: [string(name: 'BRANCH', value: "$ALT_BRANCH")]
+					parameters: [string(name: 'BRANCH', value: "$ALT_BRANCH"),
+					string(name: 'PIPELINE_TIMESTAMP', value: "${PIPELINE_TIMESTAMP}")]
 		}
 		if (buildMaps[platform].test) {
 			stage('test') {

--- a/pipelines/openjdk8_release_pipeline.groovy
+++ b/pipelines/openjdk8_release_pipeline.groovy
@@ -2,6 +2,8 @@ println "building ${JDK_VERSION}"
 
 def buildPlatforms = ['Mac', 'Windows', 'Linux', 'zLinux', 'ppc64le', 'AIX', 'aarch64']
 def buildMaps = [:]
+def PIPELINE_TIMESTAMP = new Date(currentBuild.startTimeInMillis).format("yyyyddMMHHmm")
+
 buildMaps['Mac'] = [test:['openjdktest', 'systemtest'], ArchOSs:'x86-64_macos']
 buildMaps['Windows'] = [test:['openjdktest'], ArchOSs:'x86-64_windows']
 buildMaps['Linux'] = [test:['openjdktest', 'systemtest'], ArchOSs:'x86-64_linux']
@@ -20,7 +22,8 @@ for ( int i = 0; i < buildPlatforms.size(); i++ ) {
 		stage('build') {
 			buildJob = build job: "openjdk8_build_${archOS}",
 			parameters: [string(name: 'TAG', value: "${JDK_TAG}"),
-				     string(name: 'BRANCH', value: "${ALT_BRANCH}")]
+				     string(name: 'BRANCH', value: "${ALT_BRANCH}"),
+					string(name: 'PIPELINE_TIMESTAMP', value: "${PIPELINE_TIMESTAMP}")]
 		}
 		if (buildMaps[platform].test) {
 			buildMaps[platform].test.each {

--- a/pipelines/openjdk8_release_pipeline.groovy
+++ b/pipelines/openjdk8_release_pipeline.groovy
@@ -2,7 +2,7 @@ println "building ${JDK_VERSION}"
 
 def buildPlatforms = ['Mac', 'Windows', 'Linux', 'zLinux', 'ppc64le', 'AIX', 'aarch64']
 def buildMaps = [:]
-def PIPELINE_TIMESTAMP = new Date(currentBuild.startTimeInMillis).format("yyyyddMMHHmm")
+def PIPELINE_TIMESTAMP = new Date(currentBuild.startTimeInMillis).format("yyyyMMddHHmm")
 
 buildMaps['Mac'] = [test:['openjdktest', 'systemtest'], ArchOSs:'x86-64_macos']
 buildMaps['Windows'] = [test:['openjdktest'], ArchOSs:'x86-64_windows']

--- a/pipelines/openjdk9_nightly_pipeline.groovy
+++ b/pipelines/openjdk9_nightly_pipeline.groovy
@@ -2,6 +2,8 @@ println "building ${JDK_VERSION}"
 
 def buildPlatforms = ['Mac', 'Linux', 'zLinux', 'ppc64le', 'Windows', 'AIX', 'aarch64']
 def buildMaps = [:]
+def PIPELINE_TIMESTAMP = new Date(currentBuild.startTimeInMillis).format("yyyyddMMHHmm")
+
 buildMaps['Mac'] = [test:['openjdktest', 'systemtest'], ArchOSs:'x86-64_macos']
 buildMaps['Windows'] = [test:['openjdktest'], ArchOSs:'x86-64_windows']
 buildMaps['Linux'] = [test:['openjdktest', 'systemtest', 'externaltest'], ArchOSs:'x86-64_linux']
@@ -21,7 +23,8 @@ for ( int i = 0; i < buildPlatforms.size(); i++ ) {
 		def checksumJob
 		stage('build') {
 			buildJob = build job: "openjdk9_build_${archOS}",
-					parameters: [string(name: 'BRANCH', value: "$ALT_BRANCH")]
+					parameters: [string(name: 'BRANCH', value: "$ALT_BRANCH"),
+					string(name: 'PIPELINE_TIMESTAMP', value: "${PIPELINE_TIMESTAMP}")]
 
 			buildJobNum = buildJob.getNumber()
 		}

--- a/pipelines/openjdk9_nightly_pipeline.groovy
+++ b/pipelines/openjdk9_nightly_pipeline.groovy
@@ -2,7 +2,7 @@ println "building ${JDK_VERSION}"
 
 def buildPlatforms = ['Mac', 'Linux', 'zLinux', 'ppc64le', 'Windows', 'AIX', 'aarch64']
 def buildMaps = [:]
-def PIPELINE_TIMESTAMP = new Date(currentBuild.startTimeInMillis).format("yyyyddMMHHmm")
+def PIPELINE_TIMESTAMP = new Date(currentBuild.startTimeInMillis).format("yyyyMMddHHmm")
 
 buildMaps['Mac'] = [test:['openjdktest', 'systemtest'], ArchOSs:'x86-64_macos']
 buildMaps['Windows'] = [test:['openjdktest'], ArchOSs:'x86-64_windows']

--- a/pipelines/openjdk9_openj9_nightly_pipeline.groovy
+++ b/pipelines/openjdk9_openj9_nightly_pipeline.groovy
@@ -2,6 +2,8 @@ println "building ${JDK_VERSION}"
 
 def buildPlatforms = ['Linux', 'zLinux', 'ppc64le', 'AIX', "Windows"]
 def buildMaps = [:]
+def PIPELINE_TIMESTAMP = new Date(currentBuild.startTimeInMillis).format("yyyyddMMHHmm")
+
 buildMaps['Linux'] = [test:['openjdktest', 'systemtest', 'externaltest'], ArchOSs:'x86-64_linux']
 buildMaps['zLinux'] = [test:['openjdktest', 'systemtest'], ArchOSs:'s390x_linux']
 buildMaps['ppc64le'] = [test:['openjdktest', 'systemtest'], ArchOSs:'ppc64le_linux']
@@ -19,7 +21,8 @@ for ( int i = 0; i < buildPlatforms.size(); i++ ) {
 		def checksumJob
 		stage('build') {
 			buildJob = build job: "openjdk9_openj9_build_${archOS}",
-					parameters: [string(name: 'BRANCH', value: "$ALT_BRANCH")]
+					parameters: [string(name: 'BRANCH', value: "$ALT_BRANCH"),
+					string(name: 'PIPELINE_TIMESTAMP', value: "${PIPELINE_TIMESTAMP}")]
 			buildJobNum = buildJob.getNumber()
 		}
 		if (buildMaps[platform].test) {

--- a/pipelines/openjdk9_openj9_nightly_pipeline.groovy
+++ b/pipelines/openjdk9_openj9_nightly_pipeline.groovy
@@ -2,7 +2,7 @@ println "building ${JDK_VERSION}"
 
 def buildPlatforms = ['Linux', 'zLinux', 'ppc64le', 'AIX', "Windows"]
 def buildMaps = [:]
-def PIPELINE_TIMESTAMP = new Date(currentBuild.startTimeInMillis).format("yyyyddMMHHmm")
+def PIPELINE_TIMESTAMP = new Date(currentBuild.startTimeInMillis).format("yyyyMMddHHmm")
 
 buildMaps['Linux'] = [test:['openjdktest', 'systemtest', 'externaltest'], ArchOSs:'x86-64_linux']
 buildMaps['zLinux'] = [test:['openjdktest', 'systemtest'], ArchOSs:'s390x_linux']

--- a/pipelines/openjdk_amber_nightly_pipeline.groovy
+++ b/pipelines/openjdk_amber_nightly_pipeline.groovy
@@ -2,6 +2,8 @@ println "building ${JDK_VERSION}"
 
 def buildPlatforms = ['Mac', 'Linux', 'Windows']
 def buildMaps = [:]
+def PIPELINE_TIMESTAMP = new Date(currentBuild.startTimeInMillis).format("yyyyddMMHHmm")
+
 buildMaps['Mac'] = [test:['openjdktest'], ArchOSs:'x86-64_macos']
 buildMaps['Windows'] = [test:false, ArchOSs:'x86-64_windows']
 buildMaps['Linux'] = [test:['openjdktest'], ArchOSs:'x86-64_linux']
@@ -17,7 +19,8 @@ for ( int i = 0; i < buildPlatforms.size(); i++ ) {
 		def checksumJob
 		stage('build') {
 			buildJob = build job: "openjdk_amber_build_${archOS}",
-					parameters: [string(name: 'BRANCH', value: "$ALT_BRANCH")]
+					parameters: [string(name: 'BRANCH', value: "$ALT_BRANCH"),
+					string(name: 'PIPELINE_TIMESTAMP', value: "${PIPELINE_TIMESTAMP}")]
 			buildJobNum = buildJob.getNumber()
 		}
 		if (buildMaps[platform].test) {


### PR DESCRIPTION
This is to pass PIPELINE_TIMESTAMP to build jobs (so they can be same across platforms, which will ensure they will be part of the same 'release' set on the website).

Signed-off-by: smlambert <slambert@gmail.com>