### PR TITLE
Fix empty string PIPELINE_TIMESTAMP issue

### DIFF
--- a/pipelines/openjdk8_nightly_pipeline.groovy
+++ b/pipelines/openjdk8_nightly_pipeline.groovy
@@ -22,7 +22,7 @@ for ( int i = 0; i < buildPlatforms.size(); i++ ) {
 		def buildJobNum
 		def checksumJob
 		stage('build') {
-			buildJob = build job: "openjdk8_build_${archOS}"
+			buildJob = build job: "openjdk8_build_${archOS}",
 					parameters: [string(name: 'BRANCH', value: "$ALT_BRANCH"),
 					string(name: 'PIPELINE_TIMESTAMP', value: "${PIPELINE_TIMESTAMP}")]
 			buildJobNum = buildJob.getNumber()


### PR DESCRIPTION
Recent openjdk8 build timestamp is either empty or use the build timestamp itself. It should use the timestamp generated by upstream pipeline job, which is passed in the jdk build job.

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>