### PR TITLE
Openjdk10 release updates

### DIFF
--- a/pipelines/openjdk10_nightly_pipeline.groovy
+++ b/pipelines/openjdk10_nightly_pipeline.groovy
@@ -1,6 +1,6 @@
 println "building ${JDK_VERSION}"
 
-def buildPlatforms = ['Mac', 'Windows', 'Linux', 'zLinux', 'ppc64le', 'AIX', 'aarch64']
+def buildPlatforms = ['Mac', 'Windows', 'Linux', 'zLinux', 'ppc64le', 'AIX', 'arm32','aarch64']
 def buildMaps = [:]
 def PIPELINE_TIMESTAMP = new Date(currentBuild.startTimeInMillis).format("yyyyMMddHHmm")
 
@@ -10,6 +10,7 @@ buildMaps['Linux'] = [test:['openjdktest', 'systemtest', 'externaltest'], ArchOS
 buildMaps['zLinux'] = [test:['openjdktest', 'systemtest'], ArchOSs:'s390x_linux']
 buildMaps['ppc64le'] = [test:['openjdktest', 'systemtest'], ArchOSs:'ppc64le_linux']
 buildMaps['AIX'] = [test:false, ArchOSs:'ppc64_aix']
+buildMaps['arm32'] = [test:['openjdktest'], ArchOSs:'arm32_linux']
 buildMaps['aarch64'] = [test:['openjdktest'], ArchOSs:'aarch64_linux']
 
 def jobs = [:]

--- a/pipelines/openjdk10_release_pipeline.groovy
+++ b/pipelines/openjdk10_release_pipeline.groovy
@@ -1,6 +1,6 @@
 println "building ${JDK_VERSION}"
 
-def buildPlatforms = ['Mac', 'Windows', 'Linux', 'zLinux', 'ppc64le', 'AIX', 'aarch64']
+def buildPlatforms = ['Mac', 'Windows', 'Linux', 'zLinux', 'ppc64le', 'AIX', 'arm32', 'aarch64']
 def buildMaps = [:]
 def PIPELINE_TIMESTAMP = new Date(currentBuild.startTimeInMillis).format("yyyyMMddHHmm")
 
@@ -10,6 +10,7 @@ buildMaps['Linux'] = [test:['openjdktest', 'systemtest'], ArchOSs:'x86-64_linux'
 buildMaps['zLinux'] = [test:['openjdktest', 'systemtest'], ArchOSs:'s390x_linux']
 buildMaps['ppc64le'] = [test:['openjdktest', 'systemtest'], ArchOSs:'ppc64le_linux']
 buildMaps['AIX'] = [test:false, ArchOSs:'ppc64_aix']
+buildMaps['arm32'] = [test:['openjdktest'], ArchOSs:'arm32_linux']
 buildMaps['aarch64'] = [test:['openjdktest'], ArchOSs:'aarch64_linux']
 
 def jobs = [:]

--- a/pipelines/openjdk10_release_pipeline.groovy
+++ b/pipelines/openjdk10_release_pipeline.groovy
@@ -26,8 +26,8 @@ for ( int i = 0; i < buildPlatforms.size(); i++ ) {
 				     string(name: 'PIPELINE_TIMESTAMP', value: "${PIPELINE_TIMESTAMP}")]
 		}
 		if (buildMaps[platform].test) {
-			buildMaps[platform].test.each {
-				typeTests.each {
+			stage('test') {
+				buildMaps[platform].test.each {
 					build job:"openjdk10_hs_${it}_${archOS}",
 							propagate: false,
 							parameters: [string(name: 'UPSTREAM_JOB_NUMBER', value: "${buildJob.getNumber()}"),


### PR DESCRIPTION
Release pipelines are failing on a section that's different between the nightly and release sections of the openjdk10 pipeline. This unifies the code between both of them