### PR TITLE
Revert "Add Linux/arm32 (e.g. raspberry pi) back into openjdk10 pipel…

### DIFF
--- a/pipelines/openjdk10_nightly_pipeline.groovy
+++ b/pipelines/openjdk10_nightly_pipeline.groovy
@@ -1,6 +1,6 @@
 println "building ${JDK_VERSION}"
 
-def buildPlatforms = ['Mac', 'Windows', 'Linux', 'zLinux', 'ppc64le', 'AIX', 'arm32','aarch64']
+def buildPlatforms = ['Mac', 'Windows', 'Linux', 'zLinux', 'ppc64le', 'AIX', 'aarch64']
 def buildMaps = [:]
 def PIPELINE_TIMESTAMP = new Date(currentBuild.startTimeInMillis).format("yyyyMMddHHmm")
 
@@ -10,7 +10,6 @@ buildMaps['Linux'] = [test:['openjdktest', 'systemtest', 'externaltest'], ArchOS
 buildMaps['zLinux'] = [test:['openjdktest', 'systemtest'], ArchOSs:'s390x_linux']
 buildMaps['ppc64le'] = [test:['openjdktest', 'systemtest'], ArchOSs:'ppc64le_linux']
 buildMaps['AIX'] = [test:false, ArchOSs:'ppc64_aix']
-buildMaps['arm32'] = [test:['openjdktest'], ArchOSs:'arm32_linux']
 buildMaps['aarch64'] = [test:['openjdktest'], ArchOSs:'aarch64_linux']
 
 def jobs = [:]

--- a/pipelines/openjdk10_release_pipeline.groovy
+++ b/pipelines/openjdk10_release_pipeline.groovy
@@ -1,6 +1,6 @@
 println "building ${JDK_VERSION}"
 
-def buildPlatforms = ['Mac', 'Windows', 'Linux', 'zLinux', 'ppc64le', 'AIX', 'arm32', 'aarch64']
+def buildPlatforms = ['Mac', 'Windows', 'Linux', 'zLinux', 'ppc64le', 'AIX', 'aarch64']
 def buildMaps = [:]
 def PIPELINE_TIMESTAMP = new Date(currentBuild.startTimeInMillis).format("yyyyMMddHHmm")
 
@@ -10,7 +10,6 @@ buildMaps['Linux'] = [test:['openjdktest', 'systemtest'], ArchOSs:'x86-64_linux'
 buildMaps['zLinux'] = [test:['openjdktest', 'systemtest'], ArchOSs:'s390x_linux']
 buildMaps['ppc64le'] = [test:['openjdktest', 'systemtest'], ArchOSs:'ppc64le_linux']
 buildMaps['AIX'] = [test:false, ArchOSs:'ppc64_aix']
-buildMaps['arm32'] = [test:['openjdktest'], ArchOSs:'arm32_linux']
 buildMaps['aarch64'] = [test:['openjdktest'], ArchOSs:'aarch64_linux']
 
 def jobs = [:]


### PR DESCRIPTION
This is hopelessly slow so removing it to avoid clogging up pipelines which is holding up getting an AO10 build released. Will reinstate once I get a JITted bootstrap VM in place