### PR TITLE
Add Linux/arm32 (e.g. raspberry pi) back into openjdk10 pipeline (#395)

### DIFF
--- a/pipelines/openjdk10_nightly_pipeline.groovy
+++ b/pipelines/openjdk10_nightly_pipeline.groovy
@@ -1,6 +1,6 @@
 println "building ${JDK_VERSION}"
 
-def buildPlatforms = ['Mac', 'Windows', 'Linux', 'zLinux', 'ppc64le', 'AIX', 'aarch64']
+def buildPlatforms = ['Mac', 'Windows', 'Linux', 'zLinux', 'ppc64le', 'AIX', 'arm32','aarch64']
 def buildMaps = [:]
 def PIPELINE_TIMESTAMP = new Date(currentBuild.startTimeInMillis).format("yyyyMMddHHmm")
 
@@ -10,6 +10,7 @@ buildMaps['Linux'] = [test:['openjdktest', 'systemtest', 'externaltest'], ArchOS
 buildMaps['zLinux'] = [test:['openjdktest', 'systemtest'], ArchOSs:'s390x_linux']
 buildMaps['ppc64le'] = [test:['openjdktest', 'systemtest'], ArchOSs:'ppc64le_linux']
 buildMaps['AIX'] = [test:false, ArchOSs:'ppc64_aix']
+buildMaps['arm32'] = [test:['openjdktest'], ArchOSs:'arm32_linux']
 buildMaps['aarch64'] = [test:['openjdktest'], ArchOSs:'aarch64_linux']
 
 def jobs = [:]

--- a/pipelines/openjdk10_release_pipeline.groovy
+++ b/pipelines/openjdk10_release_pipeline.groovy
@@ -1,6 +1,6 @@
 println "building ${JDK_VERSION}"
 
-def buildPlatforms = ['Mac', 'Windows', 'Linux', 'zLinux', 'ppc64le', 'AIX', 'aarch64']
+def buildPlatforms = ['Mac', 'Windows', 'Linux', 'zLinux', 'ppc64le', 'AIX', 'arm32', 'aarch64']
 def buildMaps = [:]
 def PIPELINE_TIMESTAMP = new Date(currentBuild.startTimeInMillis).format("yyyyMMddHHmm")
 
@@ -10,6 +10,7 @@ buildMaps['Linux'] = [test:['openjdktest', 'systemtest'], ArchOSs:'x86-64_linux'
 buildMaps['zLinux'] = [test:['openjdktest', 'systemtest'], ArchOSs:'s390x_linux']
 buildMaps['ppc64le'] = [test:['openjdktest', 'systemtest'], ArchOSs:'ppc64le_linux']
 buildMaps['AIX'] = [test:false, ArchOSs:'ppc64_aix']
+buildMaps['arm32'] = [test:['openjdktest'], ArchOSs:'arm32_linux']
 buildMaps['aarch64'] = [test:['openjdktest'], ArchOSs:'aarch64_linux']
 
 def jobs = [:]


### PR DESCRIPTION
ao10 builds are now down to the 2 hour mark (as a result of things done in https://github.com/AdoptOpenJDK/openjdk-build/issues/406) which makes it feasible to put them back into the nightly flows.