### PR TITLE
Use --with-freetype=bundled for JDK11

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -210,7 +210,10 @@ buildingTheRestOfTheConfigParameters()
   fi
 
   if [[ -z "${FREETYPE}" ]] ; then
-    FREETYPE_DIRECTORY=${FREETYPE_DIRECTORY:-"${WORKING_DIR}/${OPENJDK_REPO_NAME}/installedfreetype"}
+    case $OPENJDK_CORE_VERSION in
+       jdk8*|jdk9*|jdk10*) FREETYPE_DIRECTORY=${FREETYPE_DIRECTORY:-"${WORKING_DIR}/${OPENJDK_REPO_NAME}/installedfreetype"} ;;
+       *) FREETYPE_DIRECTORY=${FREETYPE_DIRECTORY:-bundled} ;;
+    esac
     addConfigureArg "--with-freetype=" "$FREETYPE_DIRECTORY"
   fi
 


### PR DESCRIPTION
JDK11 falls over in a heap if you try to use the parameters we've been using for previous versions.
This will also  need to be done in the new build scripts