### PR TITLE
Update JDK8 build pipelines with version jdk8u181-b13

### DIFF
--- a/pipelines/openjdk8_nightly_pipeline.groovy
+++ b/pipelines/openjdk8_nightly_pipeline.groovy
@@ -44,7 +44,7 @@ for ( int i = 0; i < buildPlatforms.size(); i++ ) {
 		stage('publish nightly') {
 			build job: 'openjdk_release_tool',
 						parameters: [string(name: 'REPO', value: 'nightly'),
-									string(name: 'TAG', value: 'jdk8u172-b00'),
+									string(name: 'TAG', value: 'jdk8u181-b13'),
 									string(name: 'VERSION', value: 'jdk8'),
 									string(name: 'CHECKSUM_JOB_NAME', value: "openjdk8_build_checksum"),
 									string(name: 'CHECKSUM_JOB_NUMBER', value: "${checksumJob.getNumber()}")]

--- a/pipelines/openjdk8_openj9_nightly_pipeline.groovy
+++ b/pipelines/openjdk8_openj9_nightly_pipeline.groovy
@@ -45,7 +45,7 @@ for ( int i = 0; i < buildPlatforms.size(); i++ ) {
 		stage('publish nightly') {
 			build job: 'openjdk_release_tool',
 						parameters: [string(name: 'REPO', value: 'nightly'),
-									string(name: 'TAG', value: 'jdk8u172-b11'),
+									string(name: 'TAG', value: 'jdk8u181-b13'),
 									string(name: 'VERSION', value: 'jdk8-openj9'),
 									string(name: 'CHECKSUM_JOB_NAME', value: "openjdk8_openj9_build_checksum"),
 									string(name: 'CHECKSUM_JOB_NUMBER', value: "${checksumJob.getNumber()}")]


### PR DESCRIPTION
Default pipelines for some releases still have the version number hardcoded - we should fix this so it's a parameter in all flows, but for now I'll just change the defaults.

If no-one's reviewed this by the time I need to kick off the build tomorrow morning I'm going to make an executive decision to merge regardless