### PR TITLE
Fix timestamp pattern for consistency

### DIFF
--- a/pipelines/openjdk_amber_nightly_pipeline.groovy
+++ b/pipelines/openjdk_amber_nightly_pipeline.groovy
@@ -2,7 +2,7 @@ println "building ${JDK_VERSION}"
 
 def buildPlatforms = ['Mac', 'Linux', 'Windows']
 def buildMaps = [:]
-def PIPELINE_TIMESTAMP = new Date(currentBuild.startTimeInMillis).format("yyyyddMMHHmm")
+def PIPELINE_TIMESTAMP = new Date(currentBuild.startTimeInMillis).format("yyyyMMddHHmm")
 
 buildMaps['Mac'] = [test:['openjdktest'], ArchOSs:'x86-64_macos']
 buildMaps['Windows'] = [test:false, ArchOSs:'x86-64_windows']


### PR DESCRIPTION
This is the same change as https://github.com/AdoptOpenJDK/openjdk-build/pull/427, applied to the 'new_build_scripts' branch.