### PR TITLE
[WIP] Build script support required to enable OpenSSL crypto implementation in openj9-openjdk builds

### DIFF
--- a/makejdk.sh
+++ b/makejdk.sh
@@ -144,7 +144,7 @@ doAnyBuildVariantOverrides()
 {
   if [[ "${BUILD_VARIANT}" == "openj9" ]]; then
     # current location of Extensions for OpenJDK9 for OpenJ9 project
-    REPOSITORY="ibmruntimes/openj9-openjdk-${OPENJDK_CORE_VERSION}"
+    REPOSITORY="bhamaram/openj9-openjdk-${OPENJDK_CORE_VERSION}"
     [ -z "$BRANCH" ] && BRANCH="openj9"
   fi
   if [[ "${BUILD_VARIANT}" == "SapMachine" ]]; then
@@ -251,9 +251,9 @@ checkOpenJDKGitRepo()
 cloneOpenJDKGitRepo()
 {
   if [[ "$USE_SSH" == "true" ]] ; then
-     GIT_REMOTE_REPO_ADDRESS="git@github.com:${REPOSITORY}.git"
+     GIT_REMOTE_REPO_ADDRESS="git@github.ibm.com:${REPOSITORY}.git"
   else
-     GIT_REMOTE_REPO_ADDRESS="https://github.com/${REPOSITORY}.git"
+     GIT_REMOTE_REPO_ADDRESS="https://github.ibm.com/${REPOSITORY}.git"
   fi
 
   showShallowCloningMessage "cloning"

--- a/makejdk.sh
+++ b/makejdk.sh
@@ -144,7 +144,7 @@ doAnyBuildVariantOverrides()
 {
   if [[ "${BUILD_VARIANT}" == "openj9" ]]; then
     # current location of Extensions for OpenJDK9 for OpenJ9 project
-    REPOSITORY="bhamaram/openj9-openjdk-${OPENJDK_CORE_VERSION}"
+    REPOSITORY="ibmruntimes/openj9-openjdk-${OPENJDK_CORE_VERSION}"
     [ -z "$BRANCH" ] && BRANCH="openj9"
   fi
   if [[ "${BUILD_VARIANT}" == "SapMachine" ]]; then
@@ -251,9 +251,9 @@ checkOpenJDKGitRepo()
 cloneOpenJDKGitRepo()
 {
   if [[ "$USE_SSH" == "true" ]] ; then
-     GIT_REMOTE_REPO_ADDRESS="git@github.ibm.com:${REPOSITORY}.git"
+     GIT_REMOTE_REPO_ADDRESS="git@github.com:${REPOSITORY}.git"
   else
-     GIT_REMOTE_REPO_ADDRESS="https://github.ibm.com/${REPOSITORY}.git"
+     GIT_REMOTE_REPO_ADDRESS="https://github.com/${REPOSITORY}.git"
   fi
 
   showShallowCloningMessage "cloning"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -207,6 +207,7 @@ buildingTheRestOfTheConfigParameters()
   # Point-in-time dependency for openj9 only
   if [[ "${BUILD_VARIANT}" == "openj9" ]] ; then
     addConfigureArg "--with-freemarker-jar=" "${WORKING_DIR}/freemarker-${FREEMARKER_LIB_VERSION}/lib/freemarker.jar"
+    addConfigureArg "--with-openssl=" "${WORKING_DIR}/openssl-${OPENSSL_VERSION}"
   fi
 
   if [[ -z "${FREETYPE}" ]] ; then


### PR DESCRIPTION
This fix download OpenSSL from https://github.com/openssl/openssl, build it and make it available for openj9-openjdk build.

This is required to enable OpenSSL crypto support added as part of PR https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/112