### PR TITLE
Add windows x86-32 target to openjdk8 build pipelines

### DIFF
--- a/pipelines/openjdk8_nightly_pipeline.groovy
+++ b/pipelines/openjdk8_nightly_pipeline.groovy
@@ -5,12 +5,13 @@ def buildMaps = [:]
 def PIPELINE_TIMESTAMP = new Date(currentBuild.startTimeInMillis).format("yyyyMMddHHmm")
 
 buildMaps['Mac'] = [test:['openjdktest', 'systemtest'], ArchOSs:'x86-64_macos']
-buildMaps['Windows'] = [test:['openjdktest'], ArchOSs:'x86-64_windows']
 buildMaps['Linux'] = [test:['openjdktest', 'systemtest', 'perftest', 'externaltest'], ArchOSs:'x86-64_linux']
 buildMaps['zLinux'] = [test:['openjdktest', 'systemtest'], ArchOSs:'s390x_linux']
 buildMaps['ppc64le'] = [test:['openjdktest', 'systemtest'], ArchOSs:'ppc64le_linux']
 buildMaps['AIX'] = [test:false, ArchOSs:'ppc64_aix']
 buildMaps['aarch64'] = [test:['openjdktest'], ArchOSs:'aarch64_linux']
+buildMaps['Windows'] = [test:['openjdktest'], ArchOSs:'x86-64_windows']
+buildMaps['Windows32'] = [test:['openjdktest'], ArchOSs:'x86-32_windows']
 
 def jobs = [:]
 for ( int i = 0; i < buildPlatforms.size(); i++ ) {

--- a/pipelines/openjdk8_release_pipeline.groovy
+++ b/pipelines/openjdk8_release_pipeline.groovy
@@ -5,12 +5,13 @@ def buildMaps = [:]
 def PIPELINE_TIMESTAMP = new Date(currentBuild.startTimeInMillis).format("yyyyMMddHHmm")
 
 buildMaps['Mac'] = [test:['openjdktest', 'systemtest'], ArchOSs:'x86-64_macos']
-buildMaps['Windows'] = [test:['openjdktest'], ArchOSs:'x86-64_windows']
 buildMaps['Linux'] = [test:['openjdktest', 'systemtest'], ArchOSs:'x86-64_linux']
 buildMaps['zLinux'] = [test:['openjdktest', 'systemtest'], ArchOSs:'s390x_linux']
 buildMaps['ppc64le'] = [test:['openjdktest', 'systemtest'], ArchOSs:'ppc64le_linux']
 buildMaps['AIX'] = [test:false, ArchOSs:'ppc64_aix']
 buildMaps['aarch64'] = [test:['openjdktest'], ArchOSs:'aarch64_linux']
+buildMaps['Windows'] = [test:['openjdktest'], ArchOSs:'x86-64_windows']
+buildMaps['Windows32'] = [test:['openjdktest'], ArchOSs:'x86-32_windows']
 
 def jobs = [:]
 for ( int i = 0; i < buildPlatforms.size(); i++ ) {


### PR DESCRIPTION
This PR adds `Windows32` entry to `openjdk8` pipeline build map in order to have win32 artifacts to be generated and released.

Related to #384.