### PR TITLE
Add Windows32 to buildPlatforms list

### DIFF
--- a/pipelines/openjdk8_nightly_pipeline.groovy
+++ b/pipelines/openjdk8_nightly_pipeline.groovy
@@ -1,6 +1,6 @@
 println "building ${JDK_VERSION}"
 
-def buildPlatforms = ['Mac', 'Windows', 'Linux', 'zLinux', 'ppc64le', 'AIX', 'aarch64']
+def buildPlatforms = ['Mac', 'Windows', 'Windows32', 'Linux', 'zLinux', 'ppc64le', 'AIX', 'aarch64']
 def buildMaps = [:]
 def PIPELINE_TIMESTAMP = new Date(currentBuild.startTimeInMillis).format("yyyyMMddHHmm")
 

--- a/pipelines/openjdk8_release_pipeline.groovy
+++ b/pipelines/openjdk8_release_pipeline.groovy
@@ -1,6 +1,6 @@
 println "building ${JDK_VERSION}"
 
-def buildPlatforms = ['Mac', 'Windows', 'Linux', 'zLinux', 'ppc64le', 'AIX', 'aarch64']
+def buildPlatforms = ['Mac', 'Windows', 'Windows32', 'Linux', 'zLinux', 'ppc64le', 'AIX', 'aarch64']
 def buildMaps = [:]
 def PIPELINE_TIMESTAMP = new Date(currentBuild.startTimeInMillis).format("yyyyMMddHHmm")
 


### PR DESCRIPTION
This PR adds the missing pieces for #462 in order for the scheduled build pipelines to trigger builds for `Windows32` platform.