### PR TITLE
Force git clean to remove dirs with .git repos

### DIFF
--- a/makejdk.sh
+++ b/makejdk.sh
@@ -233,7 +233,7 @@ checkOpenJDKGitRepo()
        if [ ! -z "$TAG" ]; then
          git checkout "$TAG"
        fi
-       git clean -fdx
+       git clean -ffdx
      else
        # The repo is not for the correct JDK Version
        echo "Incorrect Source Code for ${OPENJDK_FOREST_NAME}. Will re-clone"


### PR DESCRIPTION
- Git clean -fxd will not remove directories
  that contain a Git repository (.git folder).
- Adding a second force will remove these folders
- Ref https://git-scm.com/docs/git-clean#git-clean---force

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>