### PR TITLE
Revert "Lock JDK11 to our VS2017 machine (tagged openj9 for now)"

### DIFF
--- a/pipelines/build/openjdk11_pipeline.groovy
+++ b/pipelines/build/openjdk11_pipeline.groovy
@@ -30,7 +30,7 @@ def buildConfigurations = [
         x64Windows: [
                 os                  : 'windows',
                 arch                : 'x64',
-                additionalNodeLabels: 'win2012&&openj9',
+                additionalNodeLabels: 'win2012',
                 test                : ['openjdktest']
         ],
 


### PR DESCRIPTION
This reverts commit e1499e919e2135d460e560f055f48810e61dcae5.

OpenJ9 builds already get the buildj9 tag added so this is not needed