### PR TITLE
Enable jdk11 systemtest build on aarch64 linux

### DIFF
--- a/pipelines/build/openjdk11_pipeline.groovy
+++ b/pipelines/build/openjdk11_pipeline.groovy
@@ -75,7 +75,7 @@ def buildConfigurations = [
                 os                  : 'linux',
                 arch                : 'aarch64',
                 additionalNodeLabels: 'centos7',
-                test                : ['openjdktest']
+                test                : ['openjdktest', 'systemtest']
         ],
 
         /*


### PR DESCRIPTION
Enable jdk11 systemtest build on aarch64 linux
Signed-off-by: Mesbah <Mesbah_Alam@ca.ibm.com>