### PR TITLE
Docker builds do not honour the --ssh flag being passed through #273

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,8 @@ e.g. https://github.com/karianna/openjdk-jdk8u.
 specify the location to clone the OpenJDK source (and dependencies) to.
 
 -S, --ssh
-use ssh when cloning git. In case of docker build add github.com to ~/.ssh/known_hosts (e.g.: ssh github.com)
+use ssh when cloning git. 
+In case of docker build add github.com to ~/.ssh/known_hosts (e.g.: ssh github.com)
 if your ssh key has a passphrase, add it to ssh-agent (e.g.: ssh-add ~/.ssh/id_rsa)
 
 --sign

--- a/README.md
+++ b/README.md
@@ -169,7 +169,9 @@ e.g. https://github.com/karianna/openjdk-jdk8u.
 specify the location to clone the OpenJDK source (and dependencies) to.
 
 -S, --ssh
-use ssh when cloning git.
+use ssh when cloning git. In case of docker build:
+- make sure that github.com is in your ~/.ssh/known_hosts (e.g.: ssh github.com)
+- if your ssh key is a passphrase protected add your passphrase to ssh-agent (e.g.: ssh-add ~/.ssh/id_rsa)
 
 --sign
 sign the OpenJDK binary that you build.

--- a/README.md
+++ b/README.md
@@ -169,9 +169,8 @@ e.g. https://github.com/karianna/openjdk-jdk8u.
 specify the location to clone the OpenJDK source (and dependencies) to.
 
 -S, --ssh
-use ssh when cloning git. In case of docker build:
-- make sure that github.com is in your ~/.ssh/known_hosts (e.g.: ssh github.com)
-- if your ssh key is a passphrase protected add your passphrase to ssh-agent (e.g.: ssh-add ~/.ssh/id_rsa)
+use ssh when cloning git. In case of docker build add github.com to ~/.ssh/known_hosts (e.g.: ssh github.com)
+if your ssh key has a passphrase, add it to ssh-agent (e.g.: ssh-add ~/.ssh/id_rsa)
 
 --sign
 sign the OpenJDK binary that you build.

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -122,9 +122,9 @@ buildOpenJDKViaDocker()
   local cpuSet
   cpuSet="0-$((BUILD_CONFIG[NUM_PROCESSORS] - 1))"
   
-  local gitSshAccess=""
+  local gitSshAccess=()
   if [[ "${BUILD_CONFIG[USE_SSH]}" == "true" ]] ; then
-     gitSshAccess="-v ${HOME}/.ssh:/home/build/.ssh --volume $SSH_AUTH_SOCK:/build-ssh-agent -e SSH_AUTH_SOCK=/build-ssh-agent"
+     gitSshAccess=(-v "${HOME}/.ssh:/home/build/.ssh" -v "${SSH_AUTH_SOCK}:/build-ssh-agent" -e "SSH_AUTH_SOCK=/build-ssh-agent")
   fi
   
   # shellcheck disable=SC2140
@@ -134,7 +134,7 @@ buildOpenJDKViaDocker()
       --cpuset-cpus="${cpuSet}" \
        -v "${BUILD_CONFIG[DOCKER_SOURCE_VOLUME_NAME]}:/openjdk/build" \
        -v "${hostDir}/workspace/target":"/${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}" \
-       ${gitSshAccess} \
+       "${gitSshAccess[@]}" \
        -e BUILD_VARIANT="${BUILD_CONFIG[BUILD_VARIANT]}" \
        --entrypoint /openjdk/sbin/build.sh "${BUILD_CONFIG[CONTAINER_NAME]}"
   

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -113,15 +113,20 @@ buildOpenJDKViaDocker()
   # Show the user all of the config before we build
   displayParams
 
-  local hostDir;
-  hostDir="$(pwd)";
+  local hostDir
+  hostDir="$(pwd)"
 
   echo "Target binary directory on host machine: ${hostDir}/target"
   mkdir -p "${hostDir}/workspace/target"
 
-  local cpuSet;
+  local cpuSet
   cpuSet="0-$((BUILD_CONFIG[NUM_PROCESSORS] - 1))"
-
+  
+  local gitSshAccess=""
+  if [[ "${BUILD_CONFIG[USE_SSH]}" == "true" ]] ; then
+     gitSshAccess="-v ${HOME}/.ssh:/home/build/.ssh --volume $SSH_AUTH_SOCK:/build-ssh-agent -e SSH_AUTH_SOCK=/build-ssh-agent"
+  fi
+  
   # shellcheck disable=SC2140
   # Pass in the last important variables into the Docker container and call
   # the /openjdk/sbin/build.sh script inside
@@ -129,9 +134,10 @@ buildOpenJDKViaDocker()
       --cpuset-cpus="${cpuSet}" \
        -v "${BUILD_CONFIG[DOCKER_SOURCE_VOLUME_NAME]}:/openjdk/build" \
        -v "${hostDir}/workspace/target":"/${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}" \
-      -e BUILD_VARIANT="${BUILD_CONFIG[BUILD_VARIANT]}" \
-      --entrypoint /openjdk/sbin/build.sh "${BUILD_CONFIG[CONTAINER_NAME]}"
-
+       ${gitSshAccess} \
+       -e BUILD_VARIANT="${BUILD_CONFIG[BUILD_VARIANT]}" \
+       --entrypoint /openjdk/sbin/build.sh "${BUILD_CONFIG[CONTAINER_NAME]}"
+  
   # If we didn't specify to keep the container then remove it
   if [[ -z ${BUILD_CONFIG[KEEP_CONTAINER]} ]] ; then
     ${BUILD_CONFIG[DOCKER]} ps -a | awk '{ print $1,$2 }' | grep "${BUILD_CONFIG[CONTAINER_NAME]}" | awk '{print $1 }' | xargs -I {} "${BUILD_CONFIG[DOCKER]}" rm {}

--- a/docker/jdk10/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk10/x86_64/ubuntu/Dockerfile
@@ -48,6 +48,7 @@ RUN apt-get update \
     wget \
     zip \
     zulu-9 \
+    ssh \
 && rm -rf /var/lib/apt/lists/*
 
 # Pick up build instructions

--- a/docker/jdk8/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk8/x86_64/ubuntu/Dockerfile
@@ -47,6 +47,7 @@ RUN apt-get update \
     wget \
     zip \
     zulu-7 \
+    ssh \
 && rm -rf /var/lib/apt/lists/*
 
 # Pick up build instructions

--- a/docker/jdk9/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk9/x86_64/ubuntu/Dockerfile
@@ -42,6 +42,7 @@ RUN apt-get update \
     unzip \
     wget \
     zip \
+    ssh \
 
 && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Resolved issue #273. The ~/.ssh is exposed to docker with -v. In case of passphrase docker will reuse user ssh-agent. 
Extras description has been added to README. 
ssh packge has been added to Dockerfile for jdk8, jdk9 and jdk10

DCO 1.1 Signed-off-by: Andrzej Czarny