### PR TITLE
Fix unbound variable error for --help arg

### DIFF
--- a/sbin/common/config_init.sh
+++ b/sbin/common/config_init.sh
@@ -155,7 +155,10 @@ function parseConfigurationArguments() {
       shift;
 
       echo "Parsing opt: ${opt}"
-      echo "Possible opt arg: $1"
+      if [ -n "${1-}" ]
+      then
+        echo "Possible opt arg: $1"
+      fi
 
       case "$opt" in
         "--" ) break 2;;


### PR DESCRIPTION
Add check to prevent `--help` arg throwing unbound variable error (example below) when no java version is provided.

```bash
./makejdk-any-platform.sh --help
Starting ./makejdk-any-platform.sh to configure, build (Adopt)OpenJDK binary
Parsing opt: --help
/myworkspace/sbin/common/config_init.sh: line 158: $1: unbound variable
```

Signed-off-by: Parker Mauney <parkermauney@gmail.com>