### PR TITLE
docker builds leave volumes behind even when cleaning #583

### DIFF
--- a/configureBuild.sh
+++ b/configureBuild.sh
@@ -63,6 +63,7 @@ parseCommandLineArgs()
 
     # Now that we've processed the flags, grab the mandatory argument(s)
     setOpenJdkVersion "$1"
+    setDockerVolumeSuffix "$1"
   fi
 }
 

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -40,7 +40,7 @@ createPersistentDockerDataVolume()
 
     # shellcheck disable=SC2154
     echo "Removing old volumes and containers"
-    ${BUILD_CONFIG[DOCKER]} rm -f "$(${BUILD_CONFIG[DOCKER]} ps -a --no-trunc | grep "${BUILD_CONFIG[CONTAINER_NAME]}" | cut -d' ' -f1)" || true
+    ${BUILD_CONFIG[DOCKER]} rm -f $(${BUILD_CONFIG[DOCKER]} ps -a --no-trunc -q -f volume="${BUILD_CONFIG[DOCKER_SOURCE_VOLUME_NAME]}") || true
     ${BUILD_CONFIG[DOCKER]} volume rm -f "${BUILD_CONFIG[DOCKER_SOURCE_VOLUME_NAME]}" || true
 
     # shellcheck disable=SC2154

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -40,6 +40,7 @@ createPersistentDockerDataVolume()
 
     # shellcheck disable=SC2154
     echo "Removing old volumes and containers"
+    # shellcheck disable=SC2046
     ${BUILD_CONFIG[DOCKER]} rm -f $(${BUILD_CONFIG[DOCKER]} ps -a --no-trunc -q -f volume="${BUILD_CONFIG[DOCKER_SOURCE_VOLUME_NAME]}") || true
     ${BUILD_CONFIG[DOCKER]} volume rm -f "${BUILD_CONFIG[DOCKER_SOURCE_VOLUME_NAME]}" || true
 

--- a/sbin/common/common.sh
+++ b/sbin/common/common.sh
@@ -32,6 +32,14 @@ function setOpenJdkVersion() {
     BUILD_CONFIG[OPENJDK_CORE_VERSION]=${BUILD_CONFIG[OPENJDK_FOREST_NAME]%?}
   fi
 }
+
+function setDockerVolumeSuffix() {
+  local suffix=$1
+  if [[ "${BUILD_CONFIG[DOCKER_SOURCE_VOLUME_NAME]}" != *"-${suffix}" ]]; then
+    BUILD_CONFIG[DOCKER_SOURCE_VOLUME_NAME]="${BUILD_CONFIG[DOCKER_SOURCE_VOLUME_NAME]}-${suffix}"
+  fi
+}
+
 # Create a Tar ball
 getArchiveExtension()
 {

--- a/sbin/common/config_init.sh
+++ b/sbin/common/config_init.sh
@@ -248,7 +248,8 @@ function parseConfigurationArguments() {
         BUILD_CONFIG[USE_JEP319_CERTS]=true;;
 
         "--version"  | "-v" )
-        setOpenJdkVersion "$1"; shift;;
+        setOpenJdkVersion "$1"
+        setDockerVolumeSuffix "$1"; shift;;
 
         "--jvm-variant"  | "-V" )
         BUILD_CONFIG[JVM_VARIANT]="$1"; shift;;
@@ -273,6 +274,7 @@ function setBranch() {
 
 # Set the config defaults
 function configDefaults() {
+ 
   # The OS kernel name, e.g. 'darwin' for Mac OS X
   BUILD_CONFIG[OS_KERNEL_NAME]=$(uname | awk '{print tolower($0)}')
 


### PR DESCRIPTION
Resolved issue #583.
Added jdk version suffix to docker volumes
Clean up dockers containers using '-f volume=...'

DCO 1.1 Signed-off-by: Andrzej Czarny