### PR TITLE
Switch ppc64le builds from Ubuntu to CentOS7

### DIFF
--- a/pipelines/build/openjdk10_pipeline.groovy
+++ b/pipelines/build/openjdk10_pipeline.groovy
@@ -56,11 +56,6 @@ def buildConfigurations = [
         ppc64leLinux    : [
                 os                  : 'linux',
                 arch                : 'ppc64le',
-                additionalNodeLabels: [
-                        // Pinned as at time of writing build-osuosl-centos74-ppc64le-2 does not have a valid boot jdk
-                        hotspot: 'centos7&&build-osuosl-centos74-ppc64le-1',
-                        openj9:  'ubuntu'
-                ],
                 test                : ['openjdktest', 'systemtest']
         ],
 

--- a/pipelines/build/openjdk11_pipeline.groovy
+++ b/pipelines/build/openjdk11_pipeline.groovy
@@ -67,7 +67,6 @@ def buildConfigurations = [
         ppc64leLinux    : [
                 os                  : 'linux',
                 arch                : 'ppc64le',
-                additionalNodeLabels: 'ubuntu',
                 test                : ['openjdktest', 'systemtest', 'perftest']
         ],
 


### PR DESCRIPTION
Hopefully finally fixes https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/256

I'll remove the `build` tag from the two Ubuntu build machines when this is in.

Note for reviewers ref the removal of the boot JDK comment - `-2` has a JDK9 available now:

```
[root@build-osuosl-centos74-ppc64le-2 ~]# /usr/lib/jvm/jdk-9.0.4+11/bin/java -version
openjdk version "9.0.4-adoptopenjdk"
OpenJDK Runtime Environment (build 9.0.4-adoptopenjdk+11)
OpenJDK 64-Bit Server VM (build 9.0.4-adoptopenjdk+11, mixed mode)
[root@build-osuosl-centos74-ppc64le-2 ~]# ^C
```