### PR TITLE
win/openj9 - download freetype with wget instead of curl

### DIFF
--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -196,7 +196,12 @@ checkingAndDownloadingFreeType()
   if [[ ! -z "$FOUND_FREETYPE" ]] ; then
     echo "Skipping FreeType download"
   else
-    curl -L -o "freetype.tar.gz" "https://download.savannah.gnu.org/releases/freetype/freetype-${BUILD_CONFIG[FREETYPE_FONT_VERSION]}.tar.gz"
+    # Temporary fudge as curl on my windows boxes is exiting with RC=127
+    if [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]] ; then
+      wget -O "freetype.tar.gz" "https://download.savannah.gnu.org/releases/freetype/freetype-${BUILD_CONFIG[FREETYPE_FONT_VERSION]}.tar.gz"
+    else
+      curl -L -o "freetype.tar.gz" "https://download.savannah.gnu.org/releases/freetype/freetype-${BUILD_CONFIG[FREETYPE_FONT_VERSION]}.tar.gz"
+    fi
 
     rm -rf "./freetype" || true
     mkdir -p "freetype" || true


### PR DESCRIPTION
Signed-off-by: Stewart Addison <sxa@uk.ibm.com>

Equivalent of https://github.com/AdoptOpenJDK/openjdk-build/pull/626 but for freetype instead of cacerts

Fixes https://ci.adoptopenjdk.net/job/build-scripts/job/jobs/job/jdk11/job/jdk11-windows-x64-openj9/