### PR TITLE
[WIP] Avoid leading dot from tarball paths (#660)

### DIFF
--- a/sbin/common/common.sh
+++ b/sbin/common/common.sh
@@ -69,8 +69,8 @@ createOpenJDKArchive()
   if [[ "${BUILD_CONFIG[OS_KERNEL_NAME]}" = *"cygwin"* ]]; then
       zip -r -q "${fileName}.zip" ./"${repoDir}"
   elif [[ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "aix" ]]; then
-      GZIP=-9 tar -cf - ./"${repoDir}"/ | $COMPRESS -c > $fileName.tar.gz
+      GZIP=-9 tar -cf - "${repoDir}"/ | $COMPRESS -c > $fileName.tar.gz
   else
-      GZIP=-9 tar --use-compress-program=$COMPRESS -cf "${fileName}.tar.gz" ./"${repoDir}"
+      GZIP=-9 tar --use-compress-program=$COMPRESS -cf "${fileName}.tar.gz" "${repoDir}"
   fi
 }


### PR DESCRIPTION
Fix tarball creation to get rid of the leading dots. A build of jdk8u on my workstation shows resulting tarball now match other JDKs layout:

```bash
$ ./makejdk-any-platform.sh  --docker -p 4  -J /usr/lib/jvm/zulu-7-amd64/ jdk8u
[...]
$  tar tvf  workspace/target/OpenJDK.tar.gz | head
drwxr-xr-x build/build       0 2018-10-18 20:59 jdk8u181-b13/
drwxr-xr-x build/build       0 2018-10-18 20:59 jdk8u181-b13/lib/
-rw-r--r-- build/build 2282796 2018-10-18 20:59 jdk8u181-b13/lib/sa-jdi.jar
-rw-r--r-- build/build  407738 2018-10-18 20:59 jdk8u181-b13/lib/jconsole.jar
-rw-r--r-- build/build  163049 2018-10-18 20:59 jdk8u181-b13/lib/dt.jar
-rw-r--r-- build/build 17793678 2018-10-18 20:59 jdk8u181-b13/lib/ct.sym
drwxr-xr-x build/build        0 2018-10-18 20:59 jdk8u181-b13/lib/amd64/
-rwxr-xr-x build/build     8376 2018-10-18 20:59 jdk8u181-b13/lib/amd64/libjawt.so
drwxr-xr-x build/build        0 2018-10-18 20:59 jdk8u181-b13/lib/amd64/jli/
-rwxr-xr-x build/build   109816 2018-10-18 20:59 jdk8u181-b13/lib/amd64/jli/libjli.so
```

I not tested building 10 or 11 but don't see why result would differ.

Outstanding issues:

 * Build farm scripts relies on `--strip-components=2` to build 11 from 10. If a new 10 is released then CI builds will fails. However, 10 is now dead so perhaps it is a non issue. 