### PR TITLE
Update to set new repository var format for OpenJ9/SAP builds

### DIFF
--- a/configureBuild.sh
+++ b/configureBuild.sh
@@ -73,11 +73,11 @@ doAnyBuildVariantOverrides()
 {
   if [[ "${BUILD_CONFIG[BUILD_VARIANT]}" == "openj9" ]]; then
     # current location of Extensions for OpenJDK9 for OpenJ9 project
-    local repository="ibmruntimes/openj9-openjdk-${BUILD_CONFIG[OPENJDK_CORE_VERSION]}"
+    local repository="https://github.com/ibmruntimes/openj9-openjdk-${BUILD_CONFIG[OPENJDK_CORE_VERSION]}"
   fi
   if [[ "${BUILD_CONFIG[BUILD_VARIANT]}" == "SapMachine" ]]; then
     # current location of SAP variant
-    local repository="SAP/SapMachine"
+    local repository="https://github.com/SAP/SapMachine"
      # sapmachine10 is the current branch for OpenJDK10 mainline
      # (equivalent to jdk/jdk10 on hotspot)
     local branch="sapmachine10"


### PR DESCRIPTION
Fixes `repository` values after a change to what it's set to being introduced in https://github.com/AdoptOpenJDK/openjdk-build/commit/23f3c289306bc10548d451716d18b326c7e945fb