### PR TITLE
Add --disable-warnings-as-errors to arm32

### DIFF
--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -58,7 +58,7 @@ fi
 
 if [ "${ARCHITECTURE}" == "arm" ]
 then
-  export CONFIGURE_ARGS_FOR_ANY_PLATFORM="--with-jobs=4 --with-memory-size=2000"
+  export CONFIGURE_ARGS_FOR_ANY_PLATFORM="--with-jobs=4 --with-memory-size=2000 --disable-warnings-as-errors"
 fi
 
 # Skip Building Freetype for certain platforms


### PR DESCRIPTION
Fixes this failure - I feel this could perhaps use a proper upstream fix though ...
```

Compiling 394 files for BUILD_jdk.compiler.interim
../../src/hotspot/cpu/arm/c1_LIRGenerator_arm.cpp: In member function ‘void LIRGenerator::do_ArithmeticOp_Int(ArithmeticOp*)’:
../../src/hotspot/cpu/arm/c1_LIRGenerator_arm.cpp:831:43: error: ‘out_reg’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
../../src/hotspot/cpu/arm/c1_LIRGenerator_arm.cpp:823:15: note: ‘out_reg’ was declared here
       LIR_Opr out_reg;
               ^
../../src/hotspot/cpu/arm/c1_LIRGenerator_arm.cpp: In member function ‘void LIRGenerator::do_ArithmeticOp_Long(ArithmeticOp*)’:
../../src/hotspot/cpu/arm/c1_LIRGenerator_arm.cpp:761:74: error: ‘entry’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
       LIR_Opr result = call_runtime(x->y(), x->x(), entry, x->type(), NULL);
                                                                          ^
../../src/hotspot/cpu/arm/c1_LIRGenerator_arm.cpp:747:15: note: ‘entry’ was declared here
       address entry;
               ^
cc1plus: all warnings being treated as errors
gmake[3]: *** [/home/jenkins/workspace/SXA-arm32-jdk11/workspace/build/src/build/linux-arm-normal-server-release/hotspot/variant-server/libjvm/objs/c1_LIRGenerator_arm.o] Error 1
lib/CompileJvm.gmk:149: recipe for target '/home/jenkins/workspace/SXA-arm32-jdk11/workspace/build/src/build/linux-arm-normal-server-release/hotspot/variant-server/libjvm/objs/c1_LIRGenerator_arm.o' failed
gmake[3]: *** Waiting for unfinished jobs....
gmake[2]: *** [hotspot-server-libs] Error 1
make/Main.gmk:257: recipe for target 'hotspot-server-libs' failed
gmake[2]: *** Waiting for unfinished jobs....
Compiling 299 files for BUILD_jdk.javadoc.interim

ERROR: Build failed for targets 'images test-image' in configuration 'linux-arm-normal-server-release' (exit code 2) 

=== Output from failing command(s) repeated here ===
* For target hotspot_variant-server_libjvm_objs_c1_LIRGenerator_arm.o:
../../src/hotspot/cpu/arm/c1_LIRGenerator_arm.cpp: In member function ‘void LIRGenerator::do_ArithmeticOp_Int(ArithmeticOp*)’:
../../src/hotspot/cpu/arm/c1_LIRGenerator_arm.cpp:831:43: error: ‘out_reg’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
../../src/hotspot/cpu/arm/c1_LIRGenerator_arm.cpp:823:15: note: ‘out_reg’ was declared here
       LIR_Opr out_reg;
               ^
../../src/hotspot/cpu/arm/c1_LIRGenerator_arm.cpp: In member function ‘void LIRGenerator::do_ArithmeticOp_Long(ArithmeticOp*)’:
../../src/hotspot/cpu/arm/c1_LIRGenerator_arm.cpp:761:74: error: ‘entry’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
       LIR_Opr result = call_runtime(x->y(), x->x(), entry, x->type(), NULL);
                                                                          ^
../../src/hotspot/cpu/arm/c1_LIRGenerator_arm.cpp:747:15: note: ‘entry’ was declared here
       address entry;
               ^
   ... (rest of output omitted)

* All command lines available in /home/jenkins/workspace/SXA-arm32-jdk11/workspace/build/src/build/linux-arm-normal-server-release/make-support/failure-logs.
=== End of repeated output ===

=== Make failed targets repeated here ===
lib/CompileJvm.gmk:149: recipe for target '/home/jenkins/workspace/SXA-arm32-jdk11/workspace/build/src/build/linux-arm-normal-server-release/hotspot/variant-server/libjvm/objs/c1_LIRGenerator_arm.o' failed
make/Main.gmk:257: recipe for target 'hotspot-server-libs' failed
=== End of repeated output ===

Hint: Try searching the build log for the name of the first failed target.
Hint: See doc/building.html#troubleshooting for assistance.

/home/jenkins/workspace/SXA-arm32-jdk11/workspace/build/src/make/Init.gmk:300: recipe for target 'main' failed
make[1]: *** [main] Error 1
/home/jenkins/workspace/SXA-arm32-jdk11/workspace/build/src/make/Init.gmk:186: recipe for target 'images' failed
make: *** [images] Error 2
```