### PR TITLE
Updates to macos compiler as per OpenJ9 request

### DIFF
--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -38,14 +38,17 @@ fi
 
 if [ "${JAVA_TO_BUILD}" == "${JDK11_VERSION}" ] || [ "${JAVA_TO_BUILD}" == "${JDKHEAD_VERSION}" ]
 then
+  if [ "${VARIANT}" != "openj9" ]; then
     export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-extra-cxxflags=-mmacosx-version-min=10.8"
-
+  fi
+  if [ ! -d "$JDK10_BOOT_DIR" ]; then
     export JDK10_BOOT_DIR="$PWD/jdk-10"
     if [ ! -d "$JDK10_BOOT_DIR/bin" ]; then
       mkdir -p "$JDK10_BOOT_DIR"
       wget -q -O - 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk10?os=mac&release=latest' | tar xpzf - --strip-components=2 -C "$JDK10_BOOT_DIR"
     fi
-    export JDK_BOOT_DIR=$JDK10_BOOT_DIR
+  fi
+  export JDK_BOOT_DIR=$JDK10_BOOT_DIR
 fi
 
 if [ "${VARIANT}" == "openj9" ]; then
@@ -53,14 +56,12 @@ if [ "${VARIANT}" == "openj9" ]; then
   export PATH=/usr/local/bin:$PATH
   # ccache causes too many errors (either the default version on 3.2.4) so disabling
   export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-ccache"
+  export MACOSX_DEPLOYMENT_TARGET=10.9.0
   if [ "${JAVA_TO_BUILD}" == "${JDK8_VERSION}" ]
   then
     export SED=gsed
     export TAR=gtar
-    export UMA_SUPPRESS_WARNINGS_AS_ERRORS=1
-    export OMR_WARNINGS_AS_ERRORS=0
-    export MACOSX_DEPLOYMENT_TARGET=10.8
     export SDKPATH=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.8.sdk
-    export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-xcode-path=/Applications/Xcode.app --with-openj9-cc=/usr/local/bin/gcc-4.9 --with-openj9-cxx=/usr/local/bin/g++-4.9 --with-openj9-developer-dir=/Applications/Xcode7/Xcode.app/Contents/Developer"
+    export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-xcode-path=/Applications/Xcode.app --with-openj9-cc=/Applications/Xcode7/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang --with-openj9-cxx=/Applications/Xcode7/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++ --with-openj9-developer-dir=/Applications/Xcode7/Xcode.app/Contents/Developer"
   fi
 fi


### PR DESCRIPTION
Fixes https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/561 (Once gcc49 is removed)

Must not be merged until the current JDK8/JDK11 with OpenJ9 release rebuilds are completed.