### PR TITLE
Do not override JDK10_BOOT_DIR if already defined

### DIFF
--- a/build-farm/platform-specific-configurations/aix.sh
+++ b/build-farm/platform-specific-configurations/aix.sh
@@ -60,13 +60,14 @@ echo LDR_CNTRL=$LDR_CNTRL
 
 if [ "${JAVA_TO_BUILD}" == "${JDK11_VERSION}" ] || [ "${JAVA_TO_BUILD}" == "${JDKHEAD_VERSION}" ];
 then
-  export JDK10_BOOT_DIR="$PWD/jdk-10"
-  if [ ! -d "$JDK10_BOOT_DIR/bin" ]; then
-    mkdir -p "$JDK10_BOOT_DIR"
-    wget -q -O - "https://api.adoptopenjdk.net/v2/binary/releases/openjdk10?os=aix&release=latest&arch=${ARCHITECTURE}" | tar xpzf - --strip-components=2 -C "$JDK10_BOOT_DIR"
+  if [ ! -d "$JDK10_BOOT_DIR" ]; then
+    export JDK10_BOOT_DIR="$PWD/jdk-10"
+    if [ ! -d "$JDK10_BOOT_DIR/bin" ]; then
+      mkdir -p "$JDK10_BOOT_DIR"
+      wget -q -O - "https://api.adoptopenjdk.net/v2/binary/releases/openjdk10?os=aix&release=latest&arch=${ARCHITECTURE}" | tar xpzf - --strip-components=2 -C "$JDK10_BOOT_DIR"
+    fi
   fi
   export JDK_BOOT_DIR=$JDK10_BOOT_DIR
-
 
   if [ "${VARIANT}" == "hotspot" ]; then
     export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} DF=/usr/sysv/bin/df"

--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -84,13 +84,14 @@ fi
 
 if [ "${JAVA_TO_BUILD}" == "${JDK11_VERSION}" ] || [ "${JAVA_TO_BUILD}" == "${JDKHEAD_VERSION}" ]
 then
-    export JDK10_BOOT_DIR="$PWD/jdk-10"
-    if [ ! -d "$JDK10_BOOT_DIR/bin" ]; then
-      downloadArch="${ARCHITECTURE}"
-      [ "$downloadArch" == "arm" ] && downloadArch="arm32"
-
-      mkdir -p "$JDK10_BOOT_DIR"
-      wget -q -O - "https://api.adoptopenjdk.net/v2/binary/releases/openjdk10?os=linux&release=latest&arch=${downloadArch}" | tar xpzf - --strip-components=2 -C "$JDK10_BOOT_DIR"
+    if [ ! -d "$JDK10_BOOT_DIR" ]; then
+      export JDK10_BOOT_DIR="$PWD/jdk-10"
+      if [ ! -d "$JDK10_BOOT_DIR/bin" ]; then
+        downloadArch="${ARCHITECTURE}"
+        [ "$downloadArch" == "arm" ] && downloadArch="arm32"
+        mkdir -p "$JDK10_BOOT_DIR"
+        wget -q -O - "https://api.adoptopenjdk.net/v2/binary/releases/openjdk10?os=linux&release=latest&arch=${downloadArch}" | tar xpzf - --strip-components=2 -C "$JDK10_BOOT_DIR"
+      fi
     fi
     export JDK_BOOT_DIR=$JDK10_BOOT_DIR
 fi

--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -40,12 +40,14 @@ if [ "${JAVA_TO_BUILD}" == "${JDK11_VERSION}" ] || [ "${JAVA_TO_BUILD}" == "${JD
 then
     export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-extra-cxxflags=-mmacosx-version-min=10.8"
 
+  if [ ! -d "$JDK10_BOOT_DIR" ]; then
     export JDK10_BOOT_DIR="$PWD/jdk-10"
     if [ ! -d "$JDK10_BOOT_DIR/bin" ]; then
       mkdir -p "$JDK10_BOOT_DIR"
       wget -q -O - 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk10?os=mac&release=latest' | tar xpzf - --strip-components=2 -C "$JDK10_BOOT_DIR"
     fi
-    export JDK_BOOT_DIR=$JDK10_BOOT_DIR
+  fi
+  export JDK_BOOT_DIR=$JDK10_BOOT_DIR
 fi
 
 if [ "${VARIANT}" == "openj9" ]; then


### PR DESCRIPTION
Linux/ppc64le is trying to download a bootstrap JVM which requires a version of GLIBC that isn't in the path (probably because it was built on Ubuntu 16.04 ...)

At the moment any existing JDK10_BOOT_DIR defined on the jenkins machine configuration is ignored and JDK10_BOOT_DIR is set to $WORKSPACE/jdk-10 which is downloaded if it wasn't already cached from a previous run. This change will allow it to use a version of JDK10 from JDK10_BOOT_DIR which already exists on the box.

Will fix ppc64le/JDK11 build failures