### PR TITLE
Add linux+osx Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
  
 install:
  - choco upgrade msys2
- - ps a
+ - ps axu
  - export PATH=/c/tools/msys64/usr/bin/:/c/tools/msys64/bin:$PATH
  - pacman -S autoconf
  - bash -i -l -c "pacman -Sy autoconf"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,20 @@
 language: cpp
+os: windows
 
-matrix:
-  include:
-    - os: osx
-    - os: linux
-      dist: xenial
-      sudo: required
-      before_install:
-       - sudo apt-get install -y libx11-dev libxext-dev libxrender-dev libxtst-dev libxt-dev libcups2-dev libasound2
-       - sudo ln -s /usr/lib/x86_64-linux-gnu/libasound.so.2 /usr/lib/x86_64-linux-gnu/libasound.so
-
+env:
+ - MSBUILD_PATH="c:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin"
+ 
 before_script:
+ # - refreshenv
  - unset -v _JAVA_OPTIONS
- - wget https://github.com/sormuras/bach/raw/master/install-jdk.sh
+
 script: 
- - source install-jdk.sh -f 10
- - bash -c './makejdk-any-platform.sh jdk11u'
+ - refreshenv
+ - url=$(curl -silent https://api.adoptopenjdk.net/openjdk10/nightly/x64_Win/ | grep 'binary_link' | grep -Eo '(http|https)://[^"]+' | head -1)
+ - wget --quiet ${url}
+ - zip_file=$(basename ${url})
+ - target=$(unzip -Z1 ${zip_file} | grep 'bin/javac'  | tr '/' '\n' | tail -3 | head -1)
+ - unzip -q ${zip_file}
+ - export JAVA_HOME=$(cd "${target}"; pwd)
+ - export PATH=${JAVA_HOME}/bin:$PATH 
+ - bash -c 'export LOG=info && ./makejdk-any-platform.sh jdk11u'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
  - MSBUILD_PATH="c:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin"
  
 install:
+ - choco upgrade msys2
  - find /c/ -name "msys*"
  - bash -i -l -c "pacman -Sy autoconf"
  

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,14 @@ os: windows
 env:
  - MSBUILD_PATH="c:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin"
  
+ install:
+ - bash -i -l -c "pacman -Sy autoconf"
+ 
 before_script:
  # - refreshenv
  - unset -v _JAVA_OPTIONS
 
 script: 
- - refreshenv
  - url=$(curl -silent https://api.adoptopenjdk.net/openjdk10/nightly/x64_Win/ | grep 'binary_link' | grep -Eo '(http|https)://[^"]+' | head -1)
  - wget --quiet ${url}
  - zip_file=$(basename ${url})

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,8 @@ env:
  
 install:
  - choco upgrade msys2
- - find /c/ -name "pacman*"
- - export PATH=/c/tools/msys64/usr/bin/:/c/tools/msys64/bin:$PATH
  - ps a
+ - export PATH=/c/tools/msys64/usr/bin/:/c/tools/msys64/bin:$PATH
  - pacman -S autoconf
  - bash -i -l -c "pacman -Sy autoconf"
  

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ env:
 install:
  - choco upgrade msys2
  - find /c/ -name "pacman*"
+ - export PATH=/c/tools/msys64/usr/bin/:/c/tools/msys64/bin:$PATH
+ - pacman -S autoconf
  - bash -i -l -c "pacman -Sy autoconf"
  
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
  
 install:
  - choco upgrade msys2
- - find /c/ -name "msys*"
+ - find /c/ -name "pacman*"
  - bash -i -l -c "pacman -Sy autoconf"
  
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
  - MSBUILD_PATH="c:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin"
  
 install:
+ - find /c/ -name "msys2*"
  - bash -i -l -c "pacman -Sy autoconf"
  
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os: windows
 env:
  - MSBUILD_PATH="c:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin"
  
- install:
+install:
  - bash -i -l -c "pacman -Sy autoconf"
  
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
  - choco upgrade msys2
  - find /c/ -name "pacman*"
  - export PATH=/c/tools/msys64/usr/bin/:/c/tools/msys64/bin:$PATH
- - ps axu
+ - ps a
  - pacman -S autoconf
  - bash -i -l -c "pacman -Sy autoconf"
  

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ install:
  - choco upgrade msys2
  - find /c/ -name "pacman*"
  - export PATH=/c/tools/msys64/usr/bin/:/c/tools/msys64/bin:$PATH
+ - ps axu
  - pacman -S autoconf
  - bash -i -l -c "pacman -Sy autoconf"
  

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
  - MSBUILD_PATH="c:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin"
  
 install:
- - find /c/ -name "msys2*"
+ - find /c/ -name "msys*"
  - bash -i -l -c "pacman -Sy autoconf"
  
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,18 @@
-language: bash
-
-# Use container-based infrastructure for quicker build start-up
-sudo: false
-
-install:
-
-script:
-  - ./shellcheck.sh
+language: cpp
 
 matrix:
-  fast_finish: true
+  include:
+    - os: osx
+    - os: linux
+      dist: xenial
+      sudo: required
+      before_install:
+       - sudo apt-get install -y libx11-dev libxext-dev libxrender-dev libxtst-dev libxt-dev libcups2-dev libasound2
+       - sudo ln -s /usr/lib/x86_64-linux-gnu/libasound.so.2 /usr/lib/x86_64-linux-gnu/libasound.so
+
+before_script:
+ - unset -v _JAVA_OPTIONS
+ - wget https://github.com/sormuras/bach/raw/master/install-jdk.sh
+script: 
+ - source install-jdk.sh -f 10
+ - bash -c './makejdk-any-platform.sh jdk11u'

--- a/configureBuild.sh
+++ b/configureBuild.sh
@@ -300,8 +300,10 @@ function setBootJdk() {
   if [ -z "${BUILD_CONFIG[JDK_BOOT_DIR]}" ] ; then
     echo "Searching for JDK_BOOT_DIR"
 
+    if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
+      BUILD_CONFIG[JDK_BOOT_DIR]=$(dirname $(dirname $(greadlink -f $(which javac))))
     # shellcheck disable=SC2046,SC2230
-    if [[ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "darwin" ]]; then
+    elif [[ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "darwin" ]]; then
       BUILD_CONFIG[JDK_BOOT_DIR]=$(dirname $(dirname $(readlink $(which javac))))
     else
       BUILD_CONFIG[JDK_BOOT_DIR]=$(dirname $(dirname $(readlink -f $(which javac))))


### PR DESCRIPTION
Add better integration with Travis. It builds OSX and Linux images (support of Windows on Travis is still in early stages) . Target images are not uploaded to any destination, it is left on users. Travis integration is inteded as a simplification of customized AdoptOpenJDK's builds, can be used for build script development, tuning, experiments etc. Build reseults at https://travis-ci.org/skybber/openjdk-build/builds/456612289