### PR TITLE
Do not force /usr/bin to start of PATH on Linux/s390x/J9

### DIFF
--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -29,8 +29,6 @@ then
 
   if [ "${VARIANT}" == "openj9" ]
   then
-    export PATH="/usr/bin:$PATH"
-
     if [ "${JAVA_TO_BUILD}" == "${JDK8_VERSION}" ] || [ "${JAVA_TO_BUILD}" == "${JDK9_VERSION}" ] || [ "${JAVA_TO_BUILD}" == "${JDK10_VERSION}" ]
     then
       if which g++-4.8; then


### PR DESCRIPTION
Fixes https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/595