### PR TITLE
Add jdk/lib/security as location of cacert

### DIFF
--- a/security/README.md
+++ b/security/README.md
@@ -10,4 +10,4 @@
 
 3. Run the provided `GenerateCertsFile.sh` script with: `bash ./GenerateCertsFile.sh` - this will use the above files assuming they're located in the same directory as the script
 
-4. Use the cacerts provided: it must be in the `jdk/jre/lib/security` folder
+4. Use the cacerts provided: it must be in the `jdk/jre/lib/security` or `jdk/lib/security`folder


### PR DESCRIPTION
In JDK 9 or above, cacert is in 'jdk/lib/security ' folder.