### PR TITLE
Stop using GNU-tar specific option to create final archive

### DIFF
--- a/sbin/common/common.sh
+++ b/sbin/common/common.sh
@@ -68,9 +68,7 @@ createOpenJDKArchive()
 
   if [[ "${BUILD_CONFIG[OS_KERNEL_NAME]}" = *"cygwin"* ]]; then
       zip -r -q "${fileName}.zip" ./"${repoDir}"
-  elif [[ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "aix" ]]; then
-      GZIP=-9 tar -cf - "${repoDir}"/ | $COMPRESS -c > $fileName.tar.gz
   else
-      GZIP=-9 tar --use-compress-program=$COMPRESS -cf "${fileName}.tar.gz" "${repoDir}"
+      tar -cf - "${repoDir}"/ | GZIP=-9 $COMPRESS -c > $fileName.tar.gz
   fi
 }


### PR DESCRIPTION
Signed-off-by: Stewart Addison <sxa@uk.ibm.com>

Unnecessarily and we already bypass this for AIX - no disadvantage to doing it the same way elsewhere (Plus this makes the gzip on AIX use `-9` which the previous syntax didn't ...)