### PR TITLE
Use --topo-order when retrieving git tags

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -479,7 +479,7 @@ makeACopyOfLibFreeFontForMacOSX() {
 getFirstTagFromOpenJDKGitRepo()
 {
     git fetch --tags "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}"
-    revList=$(git rev-list --tags --max-count=$GIT_TAGS_TO_SEARCH)
+    revList=$(git rev-list --tags --topo-order --max-count=$GIT_TAGS_TO_SEARCH)
     firstMatchingNameFromRepo=$(git describe --tags $revList | grep jdk | grep -v openj9 | head -1)
     echo "$firstMatchingNameFromRepo"
 }


### PR DESCRIPTION
Signed-off-by: Stewart Addison <sxa@uk.ibm.com>

From @andrew-m-leonard : 

This appears to be happening unless `--topo-order` is specified on the git describe command line. This PR will add it. Not quite sure why openj9 is having this issue but the main hotspot mirror is not, but I will leave it to the openj9 team to justify if required. Have not 
```
[sxa@sxat470p openj9-openjdk-jdk11]$ git rev-list --tags --max-count=10 --topo-order | xargs git describe --tags
jdk-11.0.2+7
jdk-11.0.2+6
jdk-11.0.2+5-2-g743cc6ccf0
jdk-11.0.2+5-1-g6970e5c340
jdk-11.0.2+5
jdk-11.0.2+4-4-gf761c6949f
jdk-11.0.2+4-3-g3f60c236d4
jdk-11.0.2+4-2-ga31b99b526
jdk-11.0.2+4-1-gd81782b9b8
jdk-11.0.2+4
[sxa@sxat470p openj9-openjdk-jdk11]$ git rev-list --tags --max-count=10 | xargs git describe --tags
jdk-11.0.2+6
jdk-11.0.2+5
jdk-11.0.2+4-4-gf761c6949f
jdk-11.0.2+7
jdk-11.0.2+2
jdk-11.0.2+4
jdk-11.0.2+2-2-g70273bcf3b
jdk-11.0.2+2-1-g47d918ac42
jdk-11.0.2+1-27-g94e9f1d5b3
jdk-11.0.2+1-26-g1b14aa4e64
```
The ordering for the Hotspot builds appear unaffected by this change (it's currently picking up `+13` by default):
```
[sxa@sxat470p openjdk-jdk11u]$ git rev-list --tags --max-count=10 | xargs git describe --tags
jdk-11.0.1+13
jdk-11.0.1+12-1-g1dbdea2432
jdk-11.0.1+12
jdk-11.0.1+11-1-gcbe607ed0e
jdk-11.0.1+11
jdk-11.0.1+10-2-g8b1ea258bc
jdk-11.0.1+10-1-g4f16ac660c
jdk-11.0.1+10
jdk-11.0.1+9-2-g3af72db857
jdk-11.0.1+9-1-g17915b6357
[sxa@sxat470p openjdk-jdk11u]$ git rev-list --tags --max-count=10 --topo-order | xargs git describe --tags 
jdk-11.0.1+13
jdk-11.0.1+12-1-g1dbdea2432
jdk-11.0.1+12
jdk-11.0.1+11-1-gcbe607ed0e
jdk-11.0.1+11
jdk-11.0.1+10-2-g8b1ea258bc
jdk-11.0.1+10-1-g4f16ac660c
jdk-11.0.1+10
jdk-11.0.1+9-2-g3af72db857
jdk-11.0.1+9-1-g17915b6357
```