### PR TITLE
Add queue stage to Jenkins pipelines

### DIFF
--- a/pipelines/build/openjdk_build_pipeline.groovy
+++ b/pipelines/build/openjdk_build_pipeline.groovy
@@ -152,20 +152,22 @@ try {
     def enableTests = Boolean.valueOf(ENABLE_TESTS)
     def cleanWorkspace = Boolean.valueOf(CLEAN_WORKSPACE)
 
-    stage("build") {
+    stage("queue") {
         if (NodeHelper.nodeIsOnline(NODE_LABEL)) {
             node(NODE_LABEL) {
-                if (cleanWorkspace) {
-                    cleanWs notFailBuild: true
-                }
-
-                checkout scm
-                try {
-                    sh "./build-farm/make-adopt-build-farm.sh"
-                    archiveArtifacts artifacts: "workspace/target/*"
-                } finally {
-                    if (config.os == "aix") {
+                stage("build") {
+                    if (cleanWorkspace) {
                         cleanWs notFailBuild: true
+                    }
+
+                    checkout scm
+                    try {
+                        sh "./build-farm/make-adopt-build-farm.sh"
+                        archiveArtifacts artifacts: "workspace/target/*"
+                    } finally {
+                        if (config.os == "aix") {
+                            cleanWs notFailBuild: true
+                        }
                     }
                 }
             }


### PR DESCRIPTION
- Adds a 'queue' stage to the pipelines.
- This will indicate how long the build
  waits for a node.

Fixes #863

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>