### PR TITLE
Ensure JRE target is called for Linux/s390x

### DIFF
--- a/configureBuild.sh
+++ b/configureBuild.sh
@@ -214,7 +214,13 @@ processArgumentsforSpecificArchitectures() {
     fi
 
     build_full_name=linux-s390x-normal-${jvm_variant}-release
-    make_args_for_any_platform="CONF=${build_full_name} DEBUG_BINARIES=true images"
+
+    # This is to ensure consistency with the defaults defined in setMakeArgs()
+    if [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK11_CORE_VERSION}" ] || [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDKHEAD_VERSION}" ]; then
+      make_args_for_any_platform="CONF=${build_full_name} DEBUG_BINARIES=true product-images legacy-jre-image"
+    else
+      make_args_for_any_platform="CONF=${build_full_name} DEBUG_BINARIES=true images"
+    fi
   ;;
 
   "ppc64le")


### PR DESCRIPTION
Signed-off-by: Stewart Addison <sxa@uk.ibm.com>

I am not sure why `CONF` and the debug option is needed on `s390x` specifically, but this should resolve the lack of JRE in the release builds.

Running test at https://ci.adoptopenjdk.net/view/work%20in%20progress/job/SXA-s390x-jre/5/console but if reviewers are happy with the change, feel free to approve/merge ;-)

Fixes https://github.com/AdoptOpenJDK/openjdk-build/issues/885

NOTE FOR REVIEWERS: This is using `JDK11_CORE_VERSION` instead of `JDK11_VERSION` which is used in `setMakeArgs()` ... I'm a touch nervious that `setMakeArgs` isn't working since `OPENJDK_CORE_VERSION` is set to `jdk11u` in the JDK11 case, but `JDK11_VERSION` is `jdk11` without the `u` suffix (as defined in `sbin/common/constangs.sh`) hence I've used `JDK11_CORE_VERSION` in this patch.