### PR TITLE
WIP: add version parser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
 
 script:
   - ./shellcheck.sh
-  - ./version-parser/test-version-parser.sh
+  - cd version-parser && ./test-version-parser.sh
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ install:
 
 script:
   - ./shellcheck.sh
+  - ./version-parser/test-version-parser.sh
 
 matrix:
   fast_finish: true

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -347,7 +347,7 @@ class Build {
                         context.string(name: 'UPSTREAM_JOB_NUMBER', value: "${env.BUILD_NUMBER}"),
                         context.string(name: 'UPSTREAM_JOB_NAME', value: "${env.JOB_NAME}"),
                         context.string(name: 'FILTER', value: "${filter}"),
-                        context.string(name: 'FULL_VERSION', value: "${versionData.semver}"),
+                        context.string(name: 'FULL_VERSION', value: "${versionData.version}"),
                         context.string(name: 'MAJOR_VERSION', value: "${versionData.major}"),
                         context.string(name: 'CERTIFICATE', value: "${certificate}"),
                         ['$class': 'LabelParameterValue', name: 'NODE_LABEL', label: "${nodeFilter}"]

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -419,6 +419,11 @@ removingUnnecessaryFiles()
 
   echo "Currently at '${PWD}'"
 
+  ADOPT_BUILD_NUMBER="${ADOPT_BUILD_NUMBER:-1}"
+  RESULT=$(python $WORKSPACE/version-parser/version-parser.py "$PRODUCT_HOME"/bin/java $ADOPT_BUILD_NUMBER)
+  IFS=', ' read -r -a result <<< "$RESULT"
+  openJdkVersion="${result[5]}" # 8.0.202+08.1
+
   local jdkPath=$(ls -d ${BUILD_CONFIG[JDK_PATH]})
   echo "moving ${jdkPath} to ${openJdkVersion}"
   rm -rf "${openJdkVersion}" || true

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -554,16 +554,14 @@ createOpenJDKTarArchive()
 {
   COMPRESS=gzip
 
-  local openJdkVersion=$(getOpenJdkVersion)
-
   if which pigz >/dev/null 2>&1; then COMPRESS=pigz; fi
   echo "Archiving the build OpenJDK image and compressing with $COMPRESS"
 
   if [ -z "${JDK_TARGET_PATH+x}" ] || [ -z "${JDK_TARGET_PATH}" ]; then
-    openJdkVersion=$(getFirstTagFromOpenJDKGitRepo)
+    JDK_TARGET_PATH=$(getFirstTagFromOpenJDKGitRepo)
   fi
   if [ -z "${JRE_TARGET_PATH+x}" ] || [ -z "${JRE_TARGET_PATH}" ]; then
-    JRE_TARGET_PATH="${openJdkVersion}-jre"
+    JRE_TARGET_PATH="${JDK_TARGET_PATH}-jre"
   fi
 
   echo "OpenJDK JDK path will be ${JDK_TARGET_PATH}. JRE path will be ${JRE_TARGET_PATH}"
@@ -576,7 +574,7 @@ createOpenJDKTarArchive()
     local jreName=$(echo "${BUILD_CONFIG[TARGET_FILE_NAME]}" | sed 's/-jdk/-jre/')
     createArchive "${JRE_TARGET_PATH}" "${jreName}"
   fi
-  createArchive "${openJdkVersion}" "${BUILD_CONFIG[TARGET_FILE_NAME]}"
+  createArchive "${JDK_TARGET_PATH}" "${BUILD_CONFIG[TARGET_FILE_NAME]}"
 }
 
 # Echo success
@@ -586,9 +584,8 @@ showCompletionMessage()
 }
 
 copyFreeFontForMacOS() {
-  local openJdkVersion=$(getOpenJdkVersion)
-  makeACopyOfLibFreeFontForMacOSX "${openJdkVersion}" "${BUILD_CONFIG[COPY_MACOSX_FREE_FONT_LIB_FOR_JDK_FLAG]}"
-  makeACopyOfLibFreeFontForMacOSX "${openJdkVersion}-jre" "${BUILD_CONFIG[COPY_MACOSX_FREE_FONT_LIB_FOR_JRE_FLAG]}"
+  makeACopyOfLibFreeFontForMacOSX "${JDK_TARGET_PATH}" "${BUILD_CONFIG[COPY_MACOSX_FREE_FONT_LIB_FOR_JDK_FLAG]}"
+  makeACopyOfLibFreeFontForMacOSX "${JRE_TARGET_PATH}" "${BUILD_CONFIG[COPY_MACOSX_FREE_FONT_LIB_FOR_JRE_FLAG]}"
 }
 
 ################################################################################

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -424,14 +424,15 @@ removingUnnecessaryFiles()
   IFS=', ' read -r -a result <<< "$RESULT"
   openJdkVersion="${result[5]}" # 8.0.202+08.1
 
+  JDK_TARGET_PATH="jdk-${openJdkVersion}"
   local jdkPath=$(ls -d ${BUILD_CONFIG[JDK_PATH]})
-  echo "moving ${jdkPath} to ${openJdkVersion}"
-  rm -rf "${openJdkVersion}" || true
-  mv "${jdkPath}" "${openJdkVersion}"
+  echo "moving ${jdkPath} to ${JDK_TARGET_PATH}"
+  rm -rf "${JDK_TARGET_PATH}" || true
+  mv "${jdkPath}" "${JDK_TARGET_PATH}"
 
   if [ -d "$(ls -d ${BUILD_CONFIG[JRE_PATH]})" ]
   then
-    JRE_TARGET_PATH="${openJdkVersion}-jre"
+    JRE_TARGET_PATH="jre-${openJdkVersion}"
     [ "${JRE_TARGET_PATH}" == "${openJdkVersion}" ] && JRE_TARGET_PATH="${openJdkVersion}.jre"
     echo "moving $(ls -d ${BUILD_CONFIG[JRE_PATH]}) to ${JRE_TARGET_PATH}"
     rm -rf "${JRE_TARGET_PATH}" || true
@@ -558,14 +559,14 @@ createOpenJDKTarArchive()
   if which pigz >/dev/null 2>&1; then COMPRESS=pigz; fi
   echo "Archiving the build OpenJDK image and compressing with $COMPRESS"
 
-  if [ -z "${openJdkVersion+x}" ] || [ -z "${openJdkVersion}" ]; then
+  if [ -z "${JDK_TARGET_PATH+x}" ] || [ -z "${JDK_TARGET_PATH}" ]; then
     openJdkVersion=$(getFirstTagFromOpenJDKGitRepo)
   fi
   if [ -z "${JRE_TARGET_PATH+x}" ] || [ -z "${JRE_TARGET_PATH}" ]; then
     JRE_TARGET_PATH="${openJdkVersion}-jre"
   fi
 
-  echo "OpenJDK repo tag is ${openJdkVersion}. JRE path will be ${JRE_TARGET_PATH}"
+  echo "OpenJDK JDK path will be ${JDK_TARGET_PATH}. JRE path will be ${JRE_TARGET_PATH}"
 
   ## clean out old builds
   rm -r "${BUILD_CONFIG[WORKSPACE_DIR]:?}/${BUILD_CONFIG[TARGET_DIR]}" || true

--- a/version-parser/README.md
+++ b/version-parser/README.md
@@ -20,6 +20,7 @@ security="${result[2]}" # 202
 build="${result[3]}" # 08
 opt="${result[4]}" # None or 201903130451
 semver="${result[5]}" # 8.0.202+08.1
+version="${result[6]}" # 1.8.0_202-b08
 ```
 
 ## testing:

--- a/version-parser/README.md
+++ b/version-parser/README.md
@@ -1,0 +1,28 @@
+# Python Version Parser for openjdk
+
+## usage:
+
+```bash
+python version-parser.py <path_to_java> <adopt_build_number>
+# e.g the following command returns something like 8, 0, 202, 08, None, 8.0.202+08.1
+python version-parse.py /usr/bin/java 1
+```
+
+#### Simple usage with bash:
+
+```bash
+#!/bin/bash
+RESULT=$(python version-parser.py /usr/bin/java 1)
+IFS=', ' read -r -a result <<< "$RESULT"
+major="${result[0]}" # 8
+minor="${result[1]}" # 0
+security="${result[2]}" # 202
+build="${result[3]}" # 08
+opt="${result[4]}" # None or 201903130451
+semver="${result[5]}" # 8.0.202+08.1
+```
+
+## testing:
+```bash
+./test-version-parser.sh
+```

--- a/version-parser/test-version-parser.sh
+++ b/version-parser/test-version-parser.sh
@@ -1,0 +1,69 @@
+#!/bin/bash -x
+
+unset TEST
+
+read -r -d '' java8 << EOM
+openjdk version "1.8.0_202"
+OpenJDK Runtime Environment (AdoptOpenJDK)(build 1.8.0_202-b08)
+OpenJDK 64-Bit Server VM (AdoptOpenJDK)(build 25.202-b08, mixed mode)
+EOM
+
+export TEST=$java8
+RESULT=$(python version-parser.py fake/path/java 1)
+IFS=', ' read -r -a result <<< "$RESULT"
+if [ "${result[0]}" != 8 ]; then exit 1; fi
+if [ "${result[1]}" != 0 ]; then exit 1; fi
+if [ "${result[2]}" != 202 ]; then exit 1; fi
+if [ "${result[3]}" != 08 ]; then exit 1; fi
+if [ "${result[4]}" != "None" ]; then exit 1; fi
+if [ "${result[5]}" != "8.0.202+08.1" ]; then exit 1; fi
+
+read -r -d '' java8Nightly << EOM
+openjdk version "1.8.0_181-internal"
+OpenJDK Runtime Environment (AdoptOpenJDK)(build 1.8.0_181-internal-201903130451-b13)
+OpenJDK 64-Bit Server VM (AdoptOpenJDK)(build 25.181-b13, mixed mode)
+EOM
+
+export TEST=$java8Nightly
+RESULT=$(python version-parser.py fake/path/java 12)
+IFS=', ' read -r -a result <<< "$RESULT"
+if [ "${result[0]}" != 8 ]; then exit 1; fi
+if [ "${result[1]}" != 0 ]; then exit 1; fi
+if [ "${result[2]}" != 181 ]; then exit 1; fi
+if [ "${result[3]}" != 13 ]; then exit 1; fi
+if [ "${result[4]}" != 201903130451 ]; then exit 1; fi
+if [ "${result[5]}" != "8.0.181+13.12" ]; then exit 1; fi
+
+read -r -d '' java11 << EOM
+openjdk version "11.0.2" 2018-10-16
+OpenJDK Runtime Environment AdoptOpenJDK (build 11.0.2+7)
+OpenJDK 64-Bit Server VM AdoptOpenJDK (build 11.0.2+7, mixed mode)
+EOM
+
+export TEST=$java11
+RESULT=$(python version-parser.py fake/path/java 3)
+IFS=', ' read -r -a result <<< "$RESULT"
+if [ "${result[0]}" != 11 ]; then exit 1; fi
+if [ "${result[1]}" != 0 ]; then exit 1; fi
+if [ "${result[2]}" != 2 ]; then exit 1; fi
+if [ "${result[3]}" != 7 ]; then exit 1; fi
+if [ "${result[4]}" != "None" ]; then exit 1; fi
+if [ "${result[5]}" != "11.0.2+7.3" ]; then exit 1; fi
+
+read -r -d '' java11Nightly << EOM
+openjdk version "11.0.3" 2019-04-16
+OpenJDK Runtime Environment AdoptOpenJDK (build 11.0.3+9-201903122221)
+OpenJDK 64-Bit Server VM AdoptOpenJDK (build 11.0.3+9-201903122221, mixed mode)
+EOM
+
+export TEST=$java11Nightly
+RESULT=$(python version-parser.py fake/path/java 7)
+IFS=', ' read -r -a result <<< "$RESULT"
+if [ "${result[0]}" != 11 ]; then exit 1; fi
+if [ "${result[1]}" != 0 ]; then exit 1; fi
+if [ "${result[2]}" != 3 ]; then exit 1; fi
+if [ "${result[3]}" != 9 ]; then exit 1; fi
+if [ "${result[4]}" != 201903122221 ]; then exit 1; fi
+if [ "${result[5]}" != "11.0.3+9.7" ]; then exit 1; fi
+
+unset TEST

--- a/version-parser/test-version-parser.sh
+++ b/version-parser/test-version-parser.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 
 ################################################################################
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,13 +24,24 @@ EOM
 
 export TEST=$java8
 RESULT=$(python version-parser.py fake/path/java 1)
-IFS=', ' read -r -a result <<< "$RESULT"
-if [ "${result[0]}" != 8 ]; then exit 1; fi
-if [ "${result[1]}" != 0 ]; then exit 1; fi
-if [ "${result[2]}" != 202 ]; then exit 1; fi
-if [ "${result[3]}" != 08 ]; then exit 1; fi
-if [ "${result[4]}" != "None" ]; then exit 1; fi
-if [ "${result[5]}" != "8.0.202+08.1" ]; then exit 1; fi
+EXPECTED="8, 0, 202, 08, None, 8.0.202+08.1, 1.8.0_202-b08"
+echo "testing if $RESULT == $EXPECTED"
+if [ "$RESULT" != "$EXPECTED" ]; then exit 1; else echo ✅; fi
+
+read -r -d '' java8j9 << EOM
+openjdk version "1.8.0_202"
+OpenJDK Runtime Environment (build 1.8.0_202-b08)
+Eclipse OpenJ9 VM (build openj9-0.12.1, JRE 1.8.0 Mac OS X amd64-64-Bit Compressed References 20190205_147 (JIT enabled, AOT enabled)
+OpenJ9   - 90dd8cb40
+OMR      - d2f4534b
+JCL      - d002501a90 based on jdk8u202-b08)
+EOM
+
+export TEST=$java8j9
+RESULT=$(python version-parser.py fake/path/java 1)
+EXPECTED="8, 0, 202, 08, None, 8.0.202+08.1, 1.8.0_202-b08"
+echo "testing if $RESULT == $EXPECTED"
+if [ "$RESULT" != "$EXPECTED" ]; then exit 1; else echo ✅; fi
 
 read -r -d '' java8Nightly << EOM
 openjdk version "1.8.0_181-internal"
@@ -40,13 +51,9 @@ EOM
 
 export TEST=$java8Nightly
 RESULT=$(python version-parser.py fake/path/java 12)
-IFS=', ' read -r -a result <<< "$RESULT"
-if [ "${result[0]}" != 8 ]; then exit 1; fi
-if [ "${result[1]}" != 0 ]; then exit 1; fi
-if [ "${result[2]}" != 181 ]; then exit 1; fi
-if [ "${result[3]}" != 13 ]; then exit 1; fi
-if [ "${result[4]}" != 201903130451 ]; then exit 1; fi
-if [ "${result[5]}" != "8.0.181+13.12" ]; then exit 1; fi
+EXPECTED="8, 0, 181, 13, 201903130451, 8.0.181+13.12, 1.8.0_181-internal-201903130451-b13"
+echo "testing if $RESULT == $EXPECTED"
+if [ "$RESULT" != "$EXPECTED" ]; then exit 1; else echo ✅; fi
 
 read -r -d '' java11 << EOM
 openjdk version "11.0.2" 2018-10-16
@@ -56,13 +63,9 @@ EOM
 
 export TEST=$java11
 RESULT=$(python version-parser.py fake/path/java 3)
-IFS=', ' read -r -a result <<< "$RESULT"
-if [ "${result[0]}" != 11 ]; then exit 1; fi
-if [ "${result[1]}" != 0 ]; then exit 1; fi
-if [ "${result[2]}" != 2 ]; then exit 1; fi
-if [ "${result[3]}" != 7 ]; then exit 1; fi
-if [ "${result[4]}" != "None" ]; then exit 1; fi
-if [ "${result[5]}" != "11.0.2+7.3" ]; then exit 1; fi
+EXPECTED="11, 0, 2, 7, None, 11.0.2+7.3, 11.0.2+7"
+echo "testing if $RESULT == $EXPECTED"
+if [ "$RESULT" != "$EXPECTED" ]; then exit 1; else echo ✅; fi
 
 read -r -d '' java11Nightly << EOM
 openjdk version "11.0.3" 2019-04-16
@@ -72,13 +75,24 @@ EOM
 
 export TEST=$java11Nightly
 RESULT=$(python version-parser.py fake/path/java 7)
-IFS=', ' read -r -a result <<< "$RESULT"
-if [ "${result[0]}" != 11 ]; then exit 1; fi
-if [ "${result[1]}" != 0 ]; then exit 1; fi
-if [ "${result[2]}" != 3 ]; then exit 1; fi
-if [ "${result[3]}" != 9 ]; then exit 1; fi
-if [ "${result[4]}" != 201903122221 ]; then exit 1; fi
-if [ "${result[5]}" != "11.0.3+9.7" ]; then exit 1; fi
+EXPECTED="11, 0, 3, 9, 201903122221, 11.0.3+9.7, 11.0.3+9-201903122221"
+echo "testing if $RESULT == $EXPECTED"
+if [ "$RESULT" != "$EXPECTED" ]; then exit 1; else echo ✅; fi
+
+read -r -d '' java11Nightlyj9 << EOM
+openjdk version "11.0.3" 2019-04-16
+OpenJDK Runtime Environment AdoptOpenJDK (build 11.0.3+2-201903171939)
+Eclipse OpenJ9 VM AdoptOpenJDK (build master-f2782748f, JRE 11 Linux ppc64le-64-Bit Compressed References 20190317_164 (JIT enabled, AOT enabled)
+OpenJ9   - f2782748f
+OMR      - 9b73e2bd
+JCL      - 3cd1a589af based on jdk-11.0.3+2)
+EOM
+
+export TEST=$java11Nightlyj9
+RESULT=$(python version-parser.py fake/path/java 7)
+EXPECTED="11, 0, 3, 2, 201903171939, 11.0.3+2.7, 11.0.3+2-201903171939"
+echo "testing if $RESULT == $EXPECTED"
+if [ "$RESULT" != "$EXPECTED" ]; then exit 1; else echo ✅; fi
 
 read -r -d '' java12Nightly << EOM
 openjdk version "12" 2019-03-19
@@ -88,12 +102,8 @@ EOM
 
 export TEST=$java12Nightly
 RESULT=$(python version-parser.py fake/path/java 11)
-IFS=', ' read -r -a result <<< "$RESULT"
-if [ "${result[0]}" != 12 ]; then exit 1; fi
-if [ "${result[1]}" != 0 ]; then exit 1; fi
-if [ "${result[2]}" != 0 ]; then exit 1; fi
-if [ "${result[3]}" != 33 ]; then exit 1; fi
-if [ "${result[4]}" != 201903171631 ]; then exit 1; fi
-if [ "${result[5]}" != "12.0.0+33.11" ]; then exit 1; fi
+EXPECTED="12, 0, 0, 33, 201903171631, 12.0.0+33.11, 12+33-201903171631"
+echo "testing if $RESULT == $EXPECTED"
+if [ "$RESULT" != "$EXPECTED" ]; then exit 1; else echo ✅; fi
 
 unset TEST

--- a/version-parser/test-version-parser.sh
+++ b/version-parser/test-version-parser.sh
@@ -66,4 +66,20 @@ if [ "${result[3]}" != 9 ]; then exit 1; fi
 if [ "${result[4]}" != 201903122221 ]; then exit 1; fi
 if [ "${result[5]}" != "11.0.3+9.7" ]; then exit 1; fi
 
+read -r -d '' java12Nightly << EOM
+openjdk version "12" 2019-03-19
+OpenJDK Runtime Environment AdoptOpenJDK (build 12+33-201903171631)
+OpenJDK 64-Bit Server VM AdoptOpenJDK (build 12+33-201903171631, mixed mode, sharing)
+EOM
+
+export TEST=$java12Nightly
+RESULT=$(python version-parser.py fake/path/java 11)
+IFS=', ' read -r -a result <<< "$RESULT"
+if [ "${result[0]}" != 12 ]; then exit 1; fi
+if [ "${result[1]}" != 0 ]; then exit 1; fi
+if [ "${result[2]}" != 0 ]; then exit 1; fi
+if [ "${result[3]}" != 33 ]; then exit 1; fi
+if [ "${result[4]}" != 201903171631 ]; then exit 1; fi
+if [ "${result[5]}" != "12.0.0+33.11" ]; then exit 1; fi
+
 unset TEST

--- a/version-parser/test-version-parser.sh
+++ b/version-parser/test-version-parser.sh
@@ -1,5 +1,19 @@
 #!/bin/bash -x
 
+################################################################################
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
 unset TEST
 
 read -r -d '' java8 << EOM

--- a/version-parser/version-parser.py
+++ b/version-parser/version-parser.py
@@ -1,5 +1,19 @@
 #!/usr/bin/python
 
+################################################################################
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
 import sys
 import commands
 import os
@@ -15,9 +29,9 @@ if "TEST" in os.environ:
     output = os.environ['TEST']
     build_num = sys.argv[2]
 else:
-    java = sys.argv[1]
+    java_cmd = sys.argv[1]
     build_num = sys.argv[2]
-    status, output = commands.getstatusoutput(java + ' -version')
+    status, output = commands.getstatusoutput(java_cmd + ' -version')
 
 # version_string should look like OpenJDK Runtime Environment AdoptOpenJDK (build 11.0.2+7)
 version_string = output.split('\n', 1)[1]

--- a/version-parser/version-parser.py
+++ b/version-parser/version-parser.py
@@ -27,17 +27,32 @@ version = version_string.split('build ')[1].split(')')[0]
 
 split_version = version.split('.')
 
+try:
+    isinstance(int(split_version[0]), (int, long))
+except ValueError:
+    split_version = version.split('+')
+
 if int(split_version[0]) > 1:
     # detected openjdk 9 or above
     major = int(split_version[0]) # 11
-    minor = int(split_version[1]) # 0
-    security = int(split_version[2].split('+')[0]) # 2
-    build = int(split_version[2].split('+')[1].split('-')[0]) # 9
-    # test if a timestamp is defined
     try:
-        opt = split_version[2].split('+')[1].split('-')[1]
-    except IndexError:
-        opt = None
+        minor = int(split_version[1]) # 0
+        security = int(split_version[2].split('+')[0]) # 2
+        build = int(split_version[2].split('+')[1].split('-')[0]) # 9
+        # test if a timestamp is defined
+        try:
+            opt = split_version[2].split('+')[1].split('-')[1]
+        except IndexError:
+            opt = None
+    except ValueError:
+        minor = 0
+        security = 0
+        build = int(split_version[1].split('-')[0]) # 9
+        # test if a timestamp is defined
+        try:
+            opt = split_version[1].split('-')[1]
+        except IndexError:
+            opt = None
 else:
     # detected openjdk 8
     major = int(split_version[1]) # 8

--- a/version-parser/version-parser.py
+++ b/version-parser/version-parser.py
@@ -1,0 +1,56 @@
+#!/usr/bin/python
+
+import sys
+import commands
+import os
+
+major = None
+minor = None
+security = None
+build = None
+opt = None
+semver = None
+
+if "TEST" in os.environ:
+    output = os.environ['TEST']
+    build_num = sys.argv[2]
+else:
+    java = sys.argv[1]
+    build_num = sys.argv[2]
+    status, output = commands.getstatusoutput(java + ' -version')
+
+# version_string should look like OpenJDK Runtime Environment AdoptOpenJDK (build 11.0.2+7)
+version_string = output.split('\n', 1)[1]
+
+# returns a string like 1.8.0_202-b08 or 11.0.2+7
+version = version_string.split('build ')[1].split(')')[0]
+
+split_version = version.split('.')
+
+if int(split_version[0]) > 1:
+    # detected openjdk 9 or above
+    major = int(split_version[0]) # 11
+    minor = int(split_version[1]) # 0
+    security = int(split_version[2].split('+')[0]) # 2
+    build = int(split_version[2].split('+')[1].split('-')[0]) # 9
+    # test if a timestamp is defined
+    try:
+        opt = split_version[2].split('+')[1].split('-')[1]
+    except IndexError:
+        opt = None
+else:
+    # detected openjdk 8
+    major = int(split_version[1]) # 8
+    minor = int(split_version[2].split('_')[0]) # 0
+    security = int(split_version[2].split('_')[1].split('-')[0]) # 202
+    # not int to prevent trimming of leading zeros
+    build = split_version[2].split('-b')[1] # 08
+    # test if a timestamp is defined
+    try:
+        opt = split_version[2].split('internal-')[1].split('-')[0]
+    except IndexError:
+        opt = None
+
+semver = str(major) + '.' + str(minor) + '.' + str(security) + '+' + str(build) + '.' + build_num # 8.0.202+08.1
+
+print str(major) + ", " + str(minor) + ", " + str(security) + ", " + str(build) + ", " + str(opt) + ", " + str(semver)

--- a/version-parser/version-parser.py
+++ b/version-parser/version-parser.py
@@ -24,6 +24,7 @@ security = None
 build = None
 opt = None
 semver = None
+version = None
 
 if "TEST" in os.environ:
     output = os.environ['TEST']
@@ -82,4 +83,4 @@ else:
 
 semver = str(major) + '.' + str(minor) + '.' + str(security) + '+' + str(build) + '.' + build_num # 8.0.202+08.1
 
-print str(major) + ", " + str(minor) + ", " + str(security) + ", " + str(build) + ", " + str(opt) + ", " + str(semver)
+print str(major) + ", " + str(minor) + ", " + str(security) + ", " + str(build) + ", " + str(opt) + ", " + str(semver) + ", " + str(version)


### PR DESCRIPTION
Changes the directory of the extracted tarball to be `jdk-8.0.202+08.1` or `jre-8.0.202+08.1`

@smlambert please confirm whether any changes will be required to the test scripts with this new directory name?

closes: https://github.com/AdoptOpenJDK/openjdk-build/issues/617