### PR TITLE
Stop tag detection failing when there's a subdir with name of tag

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -522,17 +522,13 @@ makeACopyOfLibFreeFontForMacOSX() {
 # Excluding "openj9" tag names as they have other ones for milestones etc. that get in the way
 getFirstTagFromOpenJDKGitRepo()
 {
-    # This cd should avoid the situation where there's a subdir with tag name
-    # Ref: https://github.com/AdoptOpenJDK/openjdk-build/issues/977
-    cd "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}" || exit 1
-    git fetch --tags
+    git fetch --tags "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}"
     revList=$(git rev-list --tags --topo-order --max-count=$GIT_TAGS_TO_SEARCH)
     firstMatchingNameFromRepo=$(git describe --tags $revList | grep jdk | grep -v openj9 | head -1)
     # this may not find the correct tag if there are multiples on the commit so find commit
     # that contains this tag and then use `git tag` to find the real tag
-    revList=$(git rev-list -n 1 $firstMatchingNameFromRepo) 
+    revList=$(git rev-list -n 1 $firstMatchingNameFromRepo --)
     firstMatchingNameFromRepo=$(git tag --points-at $revList | tail -1)
-    cd - > /dev/null
     if [ -z "$firstMatchingNameFromRepo" ]; then
       echo "WARNING: Failed to identify latest tag in the repository" 1>&2
     else


### PR DESCRIPTION
Signed-off-by: Stewart Addison <sxa@uk.ibm.com>

Fixes https://github.com/AdoptOpenJDK/openjdk-build/issues/977

Also will throw a message to stderr if the tag detection fails - I could do an `exit 1` in that case but wanted to keep this critical fix simple for now in case that causes other side effects with some builds