### PR TITLE
Stop locking JDK11/12 on Linux/s390x to one build box

### DIFF
--- a/pipelines/build/openjdk11_pipeline.groovy
+++ b/pipelines/build/openjdk11_pipeline.groovy
@@ -76,7 +76,6 @@ def buildConfigurations = [
         s390xLinux    : [
                 os                  : 'linux',
                 arch                : 's390x',
-                additionalNodeLabels: 'build-marist-rhel74-s390x-2',
                 test                : ['openjdktest', 'systemtest', 'perftest'],
                 configureArgs        : '--disable-ccache'
         ],

--- a/pipelines/build/openjdk12_pipeline.groovy
+++ b/pipelines/build/openjdk12_pipeline.groovy
@@ -73,7 +73,6 @@ def buildConfigurations = [
         s390xLinux    : [
                 os                  : 'linux',
                 arch                : 's390x',
-                additionalNodeLabels: 'build-marist-rhel74-s390x-2',
                 test                : ['openjdktest', 'systemtest', 'perftest'],
                 configureArgs        : '--disable-ccache'
         ],


### PR DESCRIPTION
Signed-off-by: Stewart Addison <sxa@uk.ibm.com>

Don't believe there's any reason for this to be locked to marist-2 any more as the machine setup is the same.