### PR TITLE
Stop generating hash json, Use openjdk version for dir name, Fix using readlink on solaris

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -289,7 +289,7 @@ class Build {
 
     List<String> listArchives() {
         return context.sh(
-                script: """find workspace/target/ | egrep '.tar.gz|.zip|.msi|.pkg|.deb|.rpm'""",
+                script: '''find workspace/target/ | egrep '(.tar.gz|.zip|.msi|.pkg|.deb|.rpm)$' ''',
                 returnStdout: true,
                 returnStatus: false
         )

--- a/pipelines/library/src/ParseVersion.groovy
+++ b/pipelines/library/src/ParseVersion.groovy
@@ -25,7 +25,11 @@ class ParseVersion {
         if (parsedArgs.f) {
             def toPrint = ((String) parsedArgs.getProperty("f")).split(",")
             toPrint.each { arg ->
-                println(version.getProperty(arg))
+                if (arg == "openjdk-semver") {
+                    println(version.formOpenjdkSemver())
+                } else {
+                    println(version.getProperty(arg))
+                }
             }
         } else {
             println(JsonOutput.prettyPrint(JsonOutput.toJson(version)))

--- a/pipelines/library/src/common/VersionInfo.groovy
+++ b/pipelines/library/src/common/VersionInfo.groovy
@@ -136,4 +136,24 @@ class VersionInfo {
             return null
         }
     }
+
+    /**
+     * Form semver without adopt build number or timestamp
+     * @return
+     */
+    String formOpenjdkSemver() {
+        if (major != null) {
+            def semver = major + "." + minor + "." + security
+
+            if (pre) {
+                semver += "-" + pre
+            }
+
+            semver += "+"
+            semver += (build ?: "0")
+            return semver
+        } else {
+            return null
+        }
+    }
 }

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -466,8 +466,8 @@ printJavaVersionString()
 # Clean up
 removingUnnecessaryFiles() {
   local openJdkVersion="$1"
-  local jdkTargetPath="jdk-$1"
-  local jreTargetPath="jre-$1"
+  local jdkTargetPath="$1"
+  local jreTargetPath="$1-jre"
 
   echo "Removing unnecessary files now..."
 
@@ -612,8 +612,8 @@ createArchive() {
 createOpenJDKTarArchive()
 {
   local openJdkVersion="$1"
-  local jdkTargetPath="jdk-$1"
-  local jreTargetPath="jre-$1"
+  local jdkTargetPath="$1"
+  local jreTargetPath="$1-jre"
 
   COMPRESS=gzip
 
@@ -637,8 +637,8 @@ showCompletionMessage()
 
 copyFreeFontForMacOS() {
   local openJdkVersion="$1"
-  local jdkTargetPath="jdk-$1"
-  local jreTargetPath="jre-$1"
+  local jdkTargetPath="$1"
+  local jreTargetPath="$1-jre"
 
   makeACopyOfLibFreeFontForMacOSX "${jdkTargetPath}" "${BUILD_CONFIG[COPY_MACOSX_FREE_FONT_LIB_FOR_JDK_FLAG]}"
   makeACopyOfLibFreeFontForMacOSX "${jreTargetPath}" "${BUILD_CONFIG[COPY_MACOSX_FREE_FONT_LIB_FOR_JRE_FLAG]}"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -466,8 +466,8 @@ printJavaVersionString()
 # Clean up
 removingUnnecessaryFiles() {
   local openJdkVersion="$1"
-  local jdkTargetPath="$1"
-  local jreTargetPath="$1-jre"
+  local jdkTargetPath="jdk-$1"
+  local jreTargetPath="jdk-$1-jre"
 
   echo "Removing unnecessary files now..."
 
@@ -612,8 +612,8 @@ createArchive() {
 createOpenJDKTarArchive()
 {
   local openJdkVersion="$1"
-  local jdkTargetPath="$1"
-  local jreTargetPath="$1-jre"
+  local jdkTargetPath="jdk-$1"
+  local jreTargetPath="jdk-$1-jre"
 
   COMPRESS=gzip
 
@@ -637,8 +637,8 @@ showCompletionMessage()
 
 copyFreeFontForMacOS() {
   local openJdkVersion="$1"
-  local jdkTargetPath="$1"
-  local jreTargetPath="$1-jre"
+  local jdkTargetPath="jdk-$1"
+  local jreTargetPath="jdk-$1-jre"
 
   makeACopyOfLibFreeFontForMacOSX "${jdkTargetPath}" "${BUILD_CONFIG[COPY_MACOSX_FREE_FONT_LIB_FOR_JDK_FLAG]}"
   makeACopyOfLibFreeFontForMacOSX "${jreTargetPath}" "${BUILD_CONFIG[COPY_MACOSX_FREE_FONT_LIB_FOR_JRE_FLAG]}"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -385,7 +385,7 @@ getGradleHome() {
   fi
 
   if [ ! -d "$gradleJavaHome" ]; then
-    echo "Unable to find java to run gradle with, set JAVA_HOME, JDK8_BOOT_DIR or JDK11_BOOT_DIR"
+    echo "Unable to find java to run gradle with, set JAVA_HOME, JDK8_BOOT_DIR or JDK11_BOOT_DIR: $gradleJavaHome">&2
     exit 1
   fi
 
@@ -410,7 +410,7 @@ parseJavaVersionString() {
 
   cd "${LIB_DIR}"
   local gradleJavaHome=$(getGradleHome)
-  local version=$(echo "$javaVersion" | JAVA_HOME="$gradleJavaHome" "$gradleJavaHome"/bin/java -cp "target/libs/adopt-shared-lib.jar" ParseVersion -s -f semver $ADOPT_BUILD_NUMBER)
+  local version=$(echo "$javaVersion" | JAVA_HOME="$gradleJavaHome" "$gradleJavaHome"/bin/java -cp "target/libs/adopt-shared-lib.jar" ParseVersion -s -f openjdk-semver $ADOPT_BUILD_NUMBER)
   echo $version
 }
 

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -418,7 +418,7 @@ parseJavaVersionString() {
 
   cd "${LIB_DIR}"
   local gradleJavaHome=$(getGradleHome)
-  local version=$(echo "$javaVersion" | JAVA_HOME="$gradleJavaHome" "$gradleJavaHome"/bin/java -cp "target/libs/adopt-shared-lib.jar" ParseVersion -s -f openjdk-semver $ADOPT_BUILD_NUMBER)
+  local version=$(echo "$javaVersion" | JAVA_HOME="$gradleJavaHome" "$gradleJavaHome"/bin/java -cp "target/libs/adopt-shared-lib.jar" ParseVersion -s -f openjdk-semver $ADOPT_BUILD_NUMBER | tr -d '\n')
   echo $version
 }
 

--- a/sbin/common/common.sh
+++ b/sbin/common/common.sh
@@ -95,10 +95,9 @@ createOpenJDKArchive()
 
   EXT=$(getArchiveExtension)
 
-
   local fullPath
   if [[ "${BUILD_CONFIG[OS_KERNEL_NAME]}" != "darwin" ]]; then
-    fullPath=$(dirname $(readlink -f $repoDir))
+    fullPath=$(crossPlatformRealPath $repoDir)
     if [[ "$fullPath" != "${BUILD_CONFIG[WORKSPACE_DIR]}"* ]]; then
       echo "Requested to archive a dir outside of workspace"
       exit 1


### PR DESCRIPTION
- Stop generating hash json. 
- Use openjdk version for dir name. 
- Fix using readlink on solaris