### PR TITLE
OpenJ9: Build against system openssl on Linux and don't reship it

### DIFF
--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -39,7 +39,7 @@ then
   fi
 fi
 
-if [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]
+if [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ] && [ "${ARCHITECTURE}" != "aarch64" ]
 then
   export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-openssl=fetched"
   if [ "${JAVA_TO_BUILD}" != "${JDK12_VERSION}" ]

--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -39,12 +39,17 @@ then
   fi
 fi
 
-if [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ] && [ "${ARCHITECTURE}" != "aarch64" ]
+if [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]
 then
-  export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-openssl=fetched"
-  if [ "${JAVA_TO_BUILD}" != "${JDK12_VERSION}" ]
-  then
-    export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --enable-openssl-bundling"
+  # CentOS 6 has openssl 1.0.1 so we use a self-installed 1.0.2 from the playbooks
+  if grep 'release 6' /etc/redhat-release >/dev/null; then
+    if [ -r /usr/local/openssl-1.0.2/include/openssl/opensslconf.h ]; then
+      export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-openssl=/usr/local/openssl-1.0.2"
+    else
+      export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-openssl=fetched"
+    fi
+  else
+    export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-openssl=system"
   fi
 fi
 


### PR DESCRIPTION
This should supercede https://github.com/AdoptOpenJDK/openjdk-build/pull/1018 but I've had reports that it may cause some build failures so I want to verify it more before integrating.