### PR TITLE
Fix core usage on ARM32 systems if NUM_PROCESSORS set

### DIFF
--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -56,6 +56,10 @@ fi
 if [ "${ARCHITECTURE}" == "arm" ]
 then
   export CONFIGURE_ARGS_FOR_ANY_PLATFORM="--with-jobs=4 --with-memory-size=2000 --disable-warnings-as-errors"
+  if [ ! -z "${NUM_PROCESSORS}" ]
+  then
+    export BUILD_ARGS="${BUILD_ARGS} --processors $NUM_PROCESSORS"
+  fi
 fi
 
 if [ "${ARCHITECTURE}" == "s390x" ] || [ "${ARCHITECTURE}" == "ppc64le" ]


### PR DESCRIPTION
Currently (after https://github.com/AdoptOpenJDK/openjdk-build/pull/1035 was merged) the number of parallel processes on arm32 builds is always being set to 1. With this, it will honour the `NUM_PROCESSORS` definition if we have one in the jenkins definition.

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>