### PR TITLE
OpenJ9/aarch64: --disable-warnings-as-errors

### DIFF
--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -51,6 +51,10 @@ then
   else
     export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-openssl=system"
   fi
+  # Fix for https://github.com/eclipse/openj9/issues/4486
+  if [ "${ARCHITECTURE}" == "aarch64" ]; then
+    export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-warnings-as-errors-openj9"
+  fi
 fi
 
 if [ "${ARCHITECTURE}" == "ppc64le" ]


### PR DESCRIPTION
Required for https://github.com/AdoptOpenJDK/openjdk-build/issues/966

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>