### PR TITLE
Set --with-jvm-variants if provided by user

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -241,8 +241,6 @@ buildingTheRestOfTheConfigParameters()
     addConfigureArg "--enable-ccache" ""
   fi
 
-  addConfigureArgIfValueIsNotEmpty "--with-jvm-variants=" "${BUILD_CONFIG[JVM_VARIANT]}"
-
   addConfigureArg "--with-alsa=" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/installedalsa"
 
   # Point-in-time dependency for openj9 only
@@ -305,6 +303,9 @@ configureCommandParameters()
     echo "Building up the configure command..."
     buildingTheRestOfTheConfigParameters
   fi
+
+  echo "Configuring jvm variants if provided"
+  addConfigureArgIfValueIsNotEmpty "--with-jvm-variants=" "${BUILD_CONFIG[JVM_VARIANT]}"
 
   if [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK8_CORE_VERSION}" ] || [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK9_CORE_VERSION}" ]; then
     addConfigureArgIfValueIsNotEmpty "--with-cacerts-file=" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/cacerts_area/security/cacerts"


### PR DESCRIPTION
Previously `--jvm-variant` args passed to our build scripts were not processed when building on `cygwin` or `msys`, i.e. on windows.

This PR extracts the configuration of `--with-jvm-variants` configure args to the shared code path so that it'll be processed in all build environments.

Part of changes related to #871.