### PR TITLE
Add client variant to 32-bit hotspot builds 

### DIFF
--- a/pipelines/build/openjdk11_pipeline.groovy
+++ b/pipelines/build/openjdk11_pipeline.groovy
@@ -61,6 +61,9 @@ def buildConfigurations = [
                         hotspot: 'win2012',
                         openj9:  'win2012&&mingw-standalone'
                 ],
+                buildArgs : [
+                        hotspot : '--jvm-variant client,server'
+                ],
                 test                : ['openjdktest']
         ],
 

--- a/pipelines/build/openjdk12_pipeline.groovy
+++ b/pipelines/build/openjdk12_pipeline.groovy
@@ -58,6 +58,9 @@ def buildConfigurations = [
                         hotspot: 'win2012&&vs2017',
                         openj9:  'win2012&&mingw-standalone'
                 ],
+                buildArgs : [
+                        hotspot : '--jvm-variant client,server'
+                ],
                 test                : ['openjdktest']
         ],
 

--- a/pipelines/build/openjdk8_pipeline.groovy
+++ b/pipelines/build/openjdk8_pipeline.groovy
@@ -66,6 +66,9 @@ def buildConfigurations = [
                         corretto: 'win2008',
                         openj9  : 'win2012&&mingw-cygwin'
                 ],
+                buildArgs : [
+                        hotspot : '--jvm-variant client,server'
+                ],
                 test                : ['openjdktest']
         ],
 


### PR DESCRIPTION
This PR makes 32-bit hotspot builds (for windows) to include `client` and `server` vm's.

Fixes #871.