### PR TITLE
Add jvm variant build arguments for 8, 11, 12 64-bit hotspot builds

### DIFF
--- a/pipelines/build/openjdk11_pipeline.groovy
+++ b/pipelines/build/openjdk11_pipeline.groovy
@@ -51,6 +51,9 @@ def buildConfigurations = [
                         hotspot: 'win2012',
                         openj9:  'win2012&&vs2017'
                 ],
+                buildArgs : [
+                        hotspot : '--jvm-variant client,server'
+                ],
                 test                : ['openjdktest', 'perftest', 'systemtest']
         ],
 

--- a/pipelines/build/openjdk12_pipeline.groovy
+++ b/pipelines/build/openjdk12_pipeline.groovy
@@ -48,6 +48,9 @@ def buildConfigurations = [
                         hotspot: 'win2012&&vs2017',
                         openj9:  'win2012&&vs2017'
                 ],
+                buildArgs : [
+                        hotspot : '--jvm-variant client,server'
+                ],
                 test                : ['openjdktest', 'perftest', 'systemtest']
         ],
 

--- a/pipelines/build/openjdk8_pipeline.groovy
+++ b/pipelines/build/openjdk8_pipeline.groovy
@@ -55,6 +55,9 @@ def buildConfigurations = [
                         corretto: 'win2008',
                         openj9  : 'win2012&&mingw-cygwin'
                 ],
+                buildArgs : [
+                        hotspot : '--jvm-variant client,server'
+                ],
                 test                : ['openjdktest', 'systemtest']
         ],
 


### PR DESCRIPTION
This was merged for 32 bit builds in PR #1104, can this be added to 64-bit builds too?