### PR TITLE
Add extended.system/special.functional to the set of launched test targets

### DIFF
--- a/pipelines/build/openjdk11_pipeline.groovy
+++ b/pipelines/build/openjdk11_pipeline.groovy
@@ -20,14 +20,14 @@ def buildConfigurations = [
                         hotspot: 'build-macstadium-macos1010-1',
                         openj9:  'build-macstadium-macos1010-2'
                 ],
-                test                : ['sanity.openjdk', 'sanity.system', 'sanity.perf']
+                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
         ],
 
         x64MacXL    : [
                 os                   : 'mac',
                 arch                 : 'x64',
                 additionalNodeLabels : 'build-macstadium-macos1010-2',
-                test                 : ['sanity.openjdk', 'sanity.system', 'sanity.perf'],
+                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
                 additionalFileNameTag: "macosXL",
                 configureArgs        : '--with-noncompressedrefs'
         ],
@@ -37,8 +37,8 @@ def buildConfigurations = [
                 arch                : 'x64',
                 additionalNodeLabels: 'centos6',
                 test                : [
-                        nightly: ['sanity.openjdk', 'sanity.system', 'sanity.perf', 'sanity.external'],
-                        release: ['sanity.openjdk', 'sanity.system', 'sanity.perf', 'sanity.external']
+                        nightly: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external'],
+                        release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external', 'special.functional']
                 ],
                 configureArgs        : '--disable-ccache'
         ],
@@ -54,14 +54,14 @@ def buildConfigurations = [
                 buildArgs : [
                         hotspot : '--jvm-variant client,server'
                 ],
-                test                : ['sanity.openjdk', 'sanity.perf', 'sanity.system']
+                test                : ['sanity.openjdk', 'sanity.perf', 'sanity.system', 'extended.system']
         ],
 
         x64WindowsXL    : [
                 os                   : 'windows',
                 arch                 : 'x64',
                 additionalNodeLabels : 'win2012&&vs2017',
-                test                 : ['sanity.openjdk', 'sanity.perf', 'sanity.system'],
+                test                 : ['sanity.openjdk', 'sanity.system'],
                 additionalFileNameTag: "windowsXL",
                 configureArgs        : '--with-noncompressedrefs'
         ],
@@ -84,14 +84,14 @@ def buildConfigurations = [
                 arch                : 'ppc64',
                 test                : [
                         nightly: false,
-                        release: ['sanity.openjdk', 'sanity.system']
+                        release: ['sanity.openjdk', 'sanity.system', 'extended.system']
                 ]
         ],
 
         s390xLinux    : [
                 os                  : 'linux',
                 arch                : 's390x',
-                test                : ['sanity.openjdk', 'sanity.system', 'sanity.perf'],
+                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
                 configureArgs        : '--disable-ccache'
         ],
 
@@ -104,7 +104,7 @@ def buildConfigurations = [
         ppc64leLinux    : [
                 os                  : 'linux',
                 arch                : 'ppc64le',
-                test                : ['sanity.openjdk', 'sanity.system', 'sanity.perf'],
+                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
                 configureArgs       : '--disable-ccache'
 
         ],
@@ -121,7 +121,7 @@ def buildConfigurations = [
                 os                  : 'linux',
                 arch                : 'aarch64',
                 additionalNodeLabels: 'centos7',
-                test                : ['sanity.openjdk', 'sanity.system', 'sanity.perf']
+                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
         ],
 
         /*
@@ -136,7 +136,7 @@ def buildConfigurations = [
                 os                   : 'linux',
                 additionalNodeLabels : 'centos6',
                 arch                 : 'x64',
-                test                 : ['sanity.openjdk', 'sanity.system'],
+                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
                 additionalFileNameTag: "linuxXL",
                 configureArgs        : '--with-noncompressedrefs --disable-ccache'
         ],

--- a/pipelines/build/openjdk12_pipeline.groovy
+++ b/pipelines/build/openjdk12_pipeline.groovy
@@ -35,7 +35,7 @@ def buildConfigurations = [
                 additionalNodeLabels: 'centos6',
                 test                : [
                         nightly: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external'],
-                        release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external']
+                        release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external', 'special.functional']
                 ],
                 configureArgs        : '--disable-ccache'
         ],

--- a/pipelines/build/openjdk12_pipeline.groovy
+++ b/pipelines/build/openjdk12_pipeline.groovy
@@ -17,14 +17,14 @@ def buildConfigurations = [
                 os                  : 'mac',
                 arch                : 'x64',
                 additionalNodeLabels : 'macos10.12',
-                test                : ['sanity.openjdk', 'sanity.system', 'sanity.perf']
+                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
         ],
 
         x64MacXL    : [
                 os                   : 'mac',
                 arch                 : 'x64',
                 additionalNodeLabels : 'macos10.12',
-                test                 : ['sanity.openjdk', 'sanity.system', 'sanity.perf'],
+                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
                 additionalFileNameTag: "macosXL",
                 configureArgs        : '--with-noncompressedrefs'
         ],
@@ -34,8 +34,8 @@ def buildConfigurations = [
                 arch                : 'x64',
                 additionalNodeLabels: 'centos6',
                 test                : [
-                        nightly: ['sanity.openjdk', 'sanity.system', 'sanity.perf', 'sanity.external'],
-                        release: ['sanity.openjdk', 'sanity.system', 'sanity.perf', 'sanity.external']
+                        nightly: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external'],
+                        release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external']
                 ],
                 configureArgs        : '--disable-ccache'
         ],
@@ -51,14 +51,14 @@ def buildConfigurations = [
                 buildArgs : [
                         hotspot : '--jvm-variant client,server'
                 ],
-                test                : ['sanity.openjdk', 'sanity.perf', 'sanity.system']
+                test                : ['sanity.openjdk', 'sanity.perf', 'sanity.system', 'extended.system']
         ],
 
         x64WindowsXL    : [
                 os                   : 'windows',
                 arch                 : 'x64',
                 additionalNodeLabels : 'win2012&&vs2017',
-                test                 : ['sanity.openjdk', 'sanity.perf', 'sanity.system'],
+                test                 : ['sanity.openjdk', 'sanity.perf', 'sanity.system', 'extended.system'],
                 additionalFileNameTag: "windowsXL",
                 configureArgs        : '--with-noncompressedrefs'
         ],
@@ -81,14 +81,14 @@ def buildConfigurations = [
                 arch                : 'ppc64',
                 test                : [
                         nightly: false,
-                        release: ['sanity.openjdk', 'sanity.system']
+                        release: ['sanity.openjdk', 'sanity.system', 'extended.system']
                 ]
         ],
 
         s390xLinux    : [
                 os                  : 'linux',
                 arch                : 's390x',
-                test                : ['sanity.openjdk', 'sanity.system', 'sanity.perf'],
+                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
                 configureArgs        : '--disable-ccache'
         ],
 
@@ -101,7 +101,7 @@ def buildConfigurations = [
         ppc64leLinux    : [
                 os                  : 'linux',
                 arch                : 'ppc64le',
-                test                : ['sanity.openjdk', 'sanity.system', 'sanity.perf'],
+                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
                 configureArgs       : '--disable-ccache'
 
         ],
@@ -118,7 +118,7 @@ def buildConfigurations = [
                 os                  : 'linux',
                 arch                : 'aarch64',
                 additionalNodeLabels: 'centos7',
-                test                : ['sanity.openjdk', 'sanity.system', 'sanity.perf']
+                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
         ],
 
         /*
@@ -133,7 +133,7 @@ def buildConfigurations = [
                 os                   : 'linux',
                 additionalNodeLabels : 'centos6',
                 arch                 : 'x64',
-                test                 : ['sanity.openjdk', 'sanity.system'],
+                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
                 additionalFileNameTag: "linuxXL",
                 configureArgs        : '--with-noncompressedrefs --disable-ccache'
         ],

--- a/pipelines/build/openjdk13_pipeline.groovy
+++ b/pipelines/build/openjdk13_pipeline.groovy
@@ -17,14 +17,14 @@ def buildConfigurations = [
                 os                  : 'mac',
                 arch                : 'x64',
                 additionalNodeLabels : 'macos10.12',
-                test                : ['openjdktest', 'systemtest', 'perftest']
+                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
         ],
 
         x64MacXL    : [
                 os                   : 'mac',
                 arch                 : 'x64',
                 additionalNodeLabels : 'macos10.12',
-                test                 : ['openjdktest', 'systemtest', 'perftest'],
+                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
                 additionalFileNameTag: "macosXL",
                 configureArgs        : '--with-noncompressedrefs'
         ],
@@ -34,8 +34,8 @@ def buildConfigurations = [
                 arch                : 'x64',
                 additionalNodeLabels: 'centos6',
                 test                : [
-                        nightly: ['openjdktest', 'systemtest', 'perftest', 'externaltest'],
-                        release: ['openjdktest', 'systemtest', 'perftest', 'externaltest']
+                        nightly: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external'],
+                        release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external', 'special.functional']
                 ],
                 configureArgs        : '--disable-ccache'
         ],
@@ -51,14 +51,14 @@ def buildConfigurations = [
                 buildArgs : [
                         hotspot : '--jvm-variant client,server'
                 ],
-                test                : ['openjdktest', 'perftest', 'systemtest']
+                test                : ['sanity.openjdk', 'sanity.perf', 'sanity.system', 'extended.system']
         ],
 
         x64WindowsXL    : [
                 os                   : 'windows',
                 arch                 : 'x64',
                 additionalNodeLabels : 'win2012&&vs2017',
-                test                 : ['openjdktest', 'perftest', 'systemtest'],
+                test                 : ['sanity.openjdk', 'sanity.perf', 'sanity.system', 'extended.system'],
                 additionalFileNameTag: "windowsXL",
                 configureArgs        : '--with-noncompressedrefs'
         ],
@@ -73,7 +73,7 @@ def buildConfigurations = [
                 buildArgs : [
                         hotspot : '--jvm-variant client,server'
                 ],
-                test                : ['openjdktest']
+                test                : ['sanity.openjdk']
         ],
 
         ppc64Aix    : [
@@ -81,14 +81,14 @@ def buildConfigurations = [
                 arch                : 'ppc64',
                 test                : [
                         nightly: false,
-                        release: ['openjdktest', 'systemtest']
+                        release: ['sanity.openjdk', 'sanity.system', 'extended.system']
                 ]
         ],
 
         s390xLinux    : [
                 os                  : 'linux',
                 arch                : 's390x',
-                test                : ['openjdktest', 'systemtest', 'perftest'],
+                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
                 configureArgs        : '--disable-ccache'
         ],
 
@@ -101,7 +101,7 @@ def buildConfigurations = [
         ppc64leLinux    : [
                 os                  : 'linux',
                 arch                : 'ppc64le',
-                test                : ['openjdktest', 'systemtest', 'perftest'],
+                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
                 configureArgs       : '--disable-ccache'
 
         ],
@@ -110,7 +110,7 @@ def buildConfigurations = [
                 os                  : 'linux',
                 arch                : 'arm',
                 // TODO Temporarily remove the ARM tests because we don't have fast enough hardware
-                //test                : ['openjdktest', 'perftest']
+                //test                : ['sanity.openjdk', 'sanity.perf']
                 test                : false
         ],
 
@@ -118,7 +118,7 @@ def buildConfigurations = [
                 os                  : 'linux',
                 arch                : 'aarch64',
                 additionalNodeLabels: 'centos7',
-                test                : ['openjdktest', 'systemtest', 'perftest']
+                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
         ],
 
         /*
@@ -133,7 +133,7 @@ def buildConfigurations = [
                 os                   : 'linux',
                 additionalNodeLabels : 'centos6',
                 arch                 : 'x64',
-                test                 : ['openjdktest', 'systemtest'],
+                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
                 additionalFileNameTag: "linuxXL",
                 configureArgs        : '--with-noncompressedrefs --disable-ccache'
         ],

--- a/pipelines/build/openjdk8_pipeline.groovy
+++ b/pipelines/build/openjdk8_pipeline.groovy
@@ -23,14 +23,14 @@ def buildConfigurations = [
                         corretto: 'build-macstadium-macos1010-1',
                         openj9  : 'build-macstadium-macos1010-2'
                 ],
-                test                : ['sanity.openjdk', 'sanity.system']
+                test                : ['sanity.openjdk', 'sanity.system', 'extended.system']
         ],
 
         x64MacXL      : [
                 os                   : 'mac',
                 arch                 : 'x64',
                 additionalNodeLabels : 'build-macstadium-macos1010-2',
-                test                 : ['sanity.openjdk', 'sanity.system', 'sanity.perf'],
+                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
                 additionalFileNameTag: "macosXL",
                 configureArgs        : '--with-noncompressedrefs'
         ],
@@ -43,7 +43,7 @@ def buildConfigurations = [
                         corretto: 'centos6',
                         openj9  : 'build-joyent-centos69-x64-1'
                 ],
-                test                : ['sanity.openjdk', 'sanity.system', 'sanity.perf', 'sanity.external']
+                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external']
         ],
 
         // Currently we have to be quite specific about which windows to use as not all of them have freetype installed
@@ -55,14 +55,14 @@ def buildConfigurations = [
                         corretto: 'win2008',
                         openj9  : 'win2012&&mingw-cygwin'
                 ],
-                test                : ['sanity.openjdk', 'sanity.system']
+                test                : ['sanity.openjdk', 'sanity.system', 'extended.system']
         ],
 
         x64WindowsXL    : [
                 os                   : 'windows',
                 arch                 : 'x64',
                 additionalNodeLabels : 'win2012&&mingw-cygwin',
-                test                 : ['sanity.openjdk', 'sanity.system'],
+                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
                 additionalFileNameTag: "windowsXL",
                 configureArgs        : '--with-noncompressedrefs'
         ],
@@ -86,14 +86,14 @@ def buildConfigurations = [
                 arch: 'ppc64',
                 test: [
                         nightly: false,
-                        release: ['sanity.openjdk', 'sanity.system']
+                        release: ['sanity.openjdk', 'sanity.system', 'extended.system']
                 ]
         ],
 
         s390xLinux    : [
                 os  : 'linux',
                 arch: 's390x',
-                test: ['sanity.openjdk', 'sanity.system']
+                test: ['sanity.openjdk', 'sanity.system', 'extended.system']
         ],
 
         sparcv9Solaris: [
@@ -111,7 +111,7 @@ def buildConfigurations = [
         ppc64leLinux  : [
                 os  : 'linux',
                 arch: 'ppc64le',
-                test: ['sanity.openjdk', 'sanity.system']
+                test: ['sanity.openjdk', 'sanity.system', 'extended.system']
         ],
 
         arm32Linux    : [
@@ -126,7 +126,7 @@ def buildConfigurations = [
                 os                  : 'linux',
                 arch                : 'aarch64',
                 additionalNodeLabels: 'centos7',
-                test                : ['sanity.openjdk', 'sanity.system']
+                test                : ['sanity.openjdk', 'sanity.system', 'extended.system']
         ],
 
         linuxXL       : [
@@ -134,7 +134,7 @@ def buildConfigurations = [
                 additionalNodeLabels : 'centos6',
                 arch                 : 'x64',
                 additionalFileNameTag: "linuxXL",
-                test                 : ['sanity.openjdk', 'sanity.system'],
+                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
                 configureArgs        : '--with-noncompressedrefs'
         ],
 ]

--- a/pipelines/build/openjdk8_pipeline.groovy
+++ b/pipelines/build/openjdk8_pipeline.groovy
@@ -43,7 +43,7 @@ def buildConfigurations = [
                         corretto: 'centos6',
                         openj9  : 'build-joyent-centos69-x64-1'
                 ],
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external']
+                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external', 'special.functional']
         ],
 
         // Currently we have to be quite specific about which windows to use as not all of them have freetype installed

--- a/pipelines/build/openjdk_pipeline.groovy
+++ b/pipelines/build/openjdk_pipeline.groovy
@@ -23,7 +23,7 @@ def buildConfigurations = [
                 os                  : 'linux',
                 arch                : 'x64',
                 additionalNodeLabels: 'centos6',
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.external']
+                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.external', 'special.functional']
         ],
 
         // Currently we have to be quite specific about which windows to use as not all of them have freetype installed

--- a/pipelines/build/openjdk_pipeline.groovy
+++ b/pipelines/build/openjdk_pipeline.groovy
@@ -17,13 +17,13 @@ def buildConfigurations = [
                 os                  : 'mac',
                 arch                : 'x64',
                 additionalNodeLabels: 'build-macstadium-macos1010-1',
-                test                : ['sanity.openjdk', 'sanity.system']
+                test                : ['sanity.openjdk', 'sanity.system', 'extended.system']
         ],
         x64Linux  : [
                 os                  : 'linux',
                 arch                : 'x64',
                 additionalNodeLabels: 'centos6',
-                test                : ['sanity.openjdk', 'sanity.system', 'sanity.external']
+                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.external']
         ],
 
         // Currently we have to be quite specific about which windows to use as not all of them have freetype installed
@@ -71,7 +71,7 @@ def buildConfigurations = [
                 os                  : 'linux',
                 arch                : 'ppc64le',
                 additionalNodeLabels: 'centos7',
-                test                : ['sanity.openjdk', 'sanity.system']
+                test                : ['sanity.openjdk', 'sanity.system', 'extended.system']
         ],
 
         arm32Linux    : [
@@ -86,7 +86,7 @@ def buildConfigurations = [
                 os                  : 'linux',
                 arch                : 'aarch64',
                 additionalNodeLabels: 'centos7',
-                test                : ['sanity.openjdk']
+                test                : ['sanity.openjdk', 'sanity.system']
         ],
 
         /*


### PR DESCRIPTION
Additional test targets to launch via build pipelines (did not update jdk9/jdk10 as they are no longer run).

