### PR TITLE
fixes for building OpenJ9 using docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+workspace/build/

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -139,14 +139,14 @@ buildOpenJDKViaDocker()
   # Pass in the last important variables into the Docker container and call
   # the /openjdk/sbin/build.sh script inside
   ${BUILD_CONFIG[DOCKER]} run \
-       "${dockerMode[@]}" \
+       "${dockerMode[@]:+${dockerMode[@]}}" \
        --cpuset-cpus="${cpuSet}" \
        -v "${BUILD_CONFIG[DOCKER_SOURCE_VOLUME_NAME]}:/openjdk/build" \
        -v "${hostDir}/workspace/target":"/${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}:Z" \
-       "${gitSshAccess[@]}" \
+       "${gitSshAccess[@]:+${gitSshAccess[@]}}" \
        -e DEBUG_DOCKER_FLAG="${BUILD_CONFIG[DEBUG_DOCKER]}" \
        -e BUILD_VARIANT="${BUILD_CONFIG[BUILD_VARIANT]}" \
-       "${dockerEntrypoint[@]}"
+       "${dockerEntrypoint[@]:+${dockerEntrypoint[@]}}"
   
   # If we didn't specify to keep the container then remove it
   if [[ -z ${BUILD_CONFIG[KEEP_CONTAINER]} ]] ; then

--- a/docker/jdk8/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk8/x86_64/ubuntu/Dockerfile
@@ -43,11 +43,11 @@ RUN apt-get update \
     libxt-dev \
     libxtst-dev \
     make \
+    ssh \
     unzip \
     wget \
     zip \
     zulu-7 \
-    ssh \
 && rm -rf /var/lib/apt/lists/*
 
 # Pick up build instructions

--- a/docker/jdk8/x86_64/ubuntu/Dockerfile-openj9
+++ b/docker/jdk8/x86_64/ubuntu/Dockerfile-openj9
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM openjdk_container
+FROM ubuntu:16.04
 
 MAINTAINER AdoptOpenJDK <adoption-discuss@openjdk.java.net>
 
@@ -21,25 +21,54 @@ RUN apt-get update \
        autoconf \
        ccache \
        cpio \
+       curl \
        file \
        g++-4.8 \
        gcc-4.8 \
+       git \
+       gnupg2 \
+       libasound2-dev \
+       libcups2-dev \
        libdwarf-dev \
        libelf-dev \
-       libfontconfig \
+       libfontconfig1-dev \
        libfreetype6-dev \
        libnuma-dev \
+       libx11-dev \
+       libxext-dev \
+       libxrender-dev \
+       libxt-dev \
+       libxtst-dev \
+       make \
+       nasm \
+       openjdk-8-jdk \
        pkg-config \
        ssh \
+       unzip \
+       wget \
+       zip \
     && rm -rf /var/lib/apt/lists/*
 
 # Make sure build uses 4.8
-RUN rm /usr/bin/gcc \
-    && rm /usr/bin/g++ \
-    && rm /usr/bin/c++ \
+RUN rm -f /usr/bin/gcc \
+    && rm -f /usr/bin/g++ \
+    && rm -f /usr/bin/c++ \
     && ln -s /usr/bin/gcc-4.8 /usr/bin/gcc \
     && ln -s /usr/bin/g++-4.8 /usr/bin/g++ \
     && ln -s /usr/bin/g++-4.8 /usr/bin/c++
+
+# Pick up build instructions
+RUN mkdir -p /openjdk/target
+
+COPY sbin /openjdk/sbin
+COPY workspace/config /openjdk/config
+COPY pipelines /openjdk/pipelines
+
+RUN mkdir -p /openjdk/build
+RUN useradd -ms /bin/bash build
+RUN chown -R build: /openjdk/
+USER build
+WORKDIR /openjdk/build/
 
 ARG OPENJDK_CORE_VERSION
 ENV OPENJDK_CORE_VERSION=$OPENJDK_CORE_VERSION

--- a/sbin/common/common.sh
+++ b/sbin/common/common.sh
@@ -52,7 +52,7 @@ function crossPlatformRealPath() {
     local name=$(basename "$target")
   fi
 
-  local fullPath="$PWD/$name"
+  local fullPath="$PWD/${name:+${name}}"
   cd "$currentDir"
   echo "$fullPath"
 }

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -209,9 +209,9 @@ checkFingerprint() {
 
   rm /tmp/public_key.gpg || true
 
-  gpg --no-options --output /tmp/public_key.gpg --dearmor "${SCRIPT_DIR}/sig_check/${publicKey}.asc"
+  gpg --output /tmp/public_key.gpg --dearmor "${SCRIPT_DIR}/sig_check/${publicKey}.asc"
 
-  local verify=$(gpg --no-options -v --no-default-keyring --keyring "/tmp/public_key.gpg" --verify $sigFile $fileName 2>&1)
+  local verify=$(gpg -v --no-default-keyring --keyring "/tmp/public_key.gpg" --verify $sigFile $fileName 2>&1)
 
   echo $verify
 

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -209,7 +209,7 @@ checkFingerprint() {
 
   rm /tmp/public_key.gpg || true
 
-  gpg --output /tmp/public_key.gpg --dearmor "${SCRIPT_DIR}/sig_check/${publicKey}.asc"
+  gpg --no-options --output /tmp/public_key.gpg --dearmor "${SCRIPT_DIR}/sig_check/${publicKey}.asc"
 
   # If this dir does not exist, gpg 1.4.20 supplied on Ubuntu16.04 aborts
   mkdir -p $HOME/.gnupg


### PR DESCRIPTION
 * some shell script changes to avoid errors from `set -u`
 * separate the openj9 Dockerfile from the base dockerfile
 * remove --no-options from gpg command lines, it caused errors

These changes may be made partially or fully irrelevant by what happens with https://github.com/AdoptOpenJDK/openjdk-build/pull/913 and https://github.com/AdoptOpenJDK/openjdk-build/issues/689, but opening a PR anyways in case they're useful in the interim.