### PR TITLE
Fix error with gpg when ~/.gnupg does not exist

### DIFF
--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -211,6 +211,8 @@ checkFingerprint() {
 
   gpg --no-options --output /tmp/public_key.gpg --dearmor "${SCRIPT_DIR}/sig_check/${publicKey}.asc"
 
+  # If this dir does not exist, gpg 1.4.20 supplied on Ubuntu16.04 aborts
+  mkdir -p $HOME/.gnupg
   local verify=$(gpg --no-options -v --no-default-keyring --keyring "/tmp/public_key.gpg" --verify $sigFile $fileName 2>&1)
 
   echo $verify


### PR DESCRIPTION
We could get a non-default version of gpg on the box, but I prefer this to be able to keep the standard tools with the distribution in place.

Fixes https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/834