### PR TITLE
Ensure /opt/freeware/lib is at start of LIBPATH on AIX

### DIFF
--- a/build-farm/platform-specific-configurations/aix.sh
+++ b/build-farm/platform-specific-configurations/aix.sh
@@ -20,6 +20,8 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$SCRIPT_DIR/../../sbin/common/constants.sh"
 
 export PATH="/opt/freeware/bin:/usr/local/bin:/opt/IBM/xlC/13.1.3/bin:/opt/IBM/xlc/13.1.3/bin:$PATH"
+# Without this, java adds /usr/lib to the LIBPATH of anything it forks which breaks linkage
+export LIBPATH="/opt/freeware/lib:$LIBPATH"
 export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-memory-size=18000 --with-cups-include=/opt/freeware/include"
 
 # Any version below 11


### PR DESCRIPTION
Taking an executive decision to push this through for now since it will only affect one platform and I need to test that this will fix a problem on the new machine. `wget` is failing to find it's dependent libraries properly without this on the newly set up AIX system (Same problem I had with git, but that was resolved by reverting to an older version).

Ref: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/146#issuecomment-516544918 

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>