### PR TITLE
enable hardened runtime support for macos

### DIFF
--- a/entitlements.plist
+++ b/entitlements.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-executable-page-protection</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+</dict>
+</plist>

--- a/entitlements_jdk8.plist
+++ b/entitlements_jdk8.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-executable-page-protection</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -138,7 +138,7 @@ class Build {
         return null
     }
 
-    def sign(VersionInfo versionInfo versionData) {
+    def sign(VersionInfo versionInfo) {
         // Sign and archive jobs if needed
         if (buildConfig.TARGET_OS == "windows" || buildConfig.TARGET_OS == "mac") {
             context.node('master') {
@@ -165,7 +165,7 @@ class Build {
                             context.string(name: 'UPSTREAM_JOB_NUMBER', value: "${env.BUILD_NUMBER}"),
                             context.string(name: 'UPSTREAM_JOB_NAME', value: "${env.JOB_NAME}"),
                             context.string(name: 'OPERATING_SYSTEM', value: "${buildConfig.TARGET_OS}"),
-                            context.string(name: 'VERSION', value: "${versionData.major}"),
+                            context.string(name: 'VERSION', value: "${versionInfo.major}"),
                             context.string(name: 'FILTER', value: "${filter}"),
                             context.string(name: 'CERTIFICATE', value: "${certificate}"),
                             ['$class': 'LabelParameterValue', name: 'NODE_LABEL', label: "${nodeFilter}"],

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -138,7 +138,7 @@ class Build {
         return null
     }
 
-    def sign(VersionInfo versionInfo) {
+    def sign(VersionInfo versionInfo versionData) {
         // Sign and archive jobs if needed
         if (buildConfig.TARGET_OS == "windows" || buildConfig.TARGET_OS == "mac") {
             context.node('master') {
@@ -146,24 +146,26 @@ class Build {
                     def filter = ""
                     def certificate = ""
 
-                    def nodeFilter = "${buildConfig.TARGET_OS}&&build"
+                    def nodeFilter = "${buildConfig.TARGET_OS}"
 
                     if (buildConfig.TARGET_OS == "windows") {
                         filter = "**/OpenJDK*_windows_*.zip"
                         certificate = "C:\\Users\\jenkins\\windows.p12"
+                        nodeFilter = "${nodeFilter}&&build"
 
                     } else if (buildConfig.TARGET_OS == "mac") {
                         filter = "**/OpenJDK*_mac_*.tar.gz"
                         certificate = "\"Developer ID Application: London Jamocha Community CIC\""
 
                         // currently only macos10.10 can sign
-                        nodeFilter = "${nodeFilter}&&macos10.10"
+                        nodeFilter = "${nodeFilter}&&macos10.14"
                     }
 
                     def params = [
                             context.string(name: 'UPSTREAM_JOB_NUMBER', value: "${env.BUILD_NUMBER}"),
                             context.string(name: 'UPSTREAM_JOB_NAME', value: "${env.JOB_NAME}"),
                             context.string(name: 'OPERATING_SYSTEM', value: "${buildConfig.TARGET_OS}"),
+                            context.string(name: 'VERSION', value: "${versionData.major}"),
                             context.string(name: 'FILTER', value: "${filter}"),
                             context.string(name: 'CERTIFICATE', value: "${certificate}"),
                             ['$class': 'LabelParameterValue', name: 'NODE_LABEL', label: "${nodeFilter}"],

--- a/sign.sh
+++ b/sign.sh
@@ -80,7 +80,7 @@ signRelease()
       security unlock-keychain -p `cat ~/.password`
       # Sign all files with the executable permission bit set.
       FILES=$(find "${TMP_DIR}" -perm +111 -type f || find "${TMP_DIR}" -perm /111 -type f)
-      echo "$FILES" | while read -r f; do codesign -s "Developer ID Application: London Jamocha Community CIC" "$f"; done
+      echo "$FILES" | while read -r f; do codesign -s "Developer ID Application: London Jamocha Community CIC" -o runtime "$f"; done
     ;;
     *)
       echo "Skipping code signing as it's not supported on $OPERATING_SYSTEM"

--- a/sign.sh
+++ b/sign.sh
@@ -94,7 +94,7 @@ signRelease()
         cd "$JMODS_DIR"
         for jmod in ./*; do
         	rm -rf tmp
-        	unzip -q $jmod -d tmp
+          7za x $jmod -otmp
         	cd tmp
           FILES=$(find bin lib -type f)
           echo "$FILES" | while read -r f; do codesign --entitlements "$ENTITLEMENTS" --options runtime --force --timestamp --sign "Developer ID Application: London Jamocha Community CIC" "$f"; done

--- a/sign.sh
+++ b/sign.sh
@@ -89,8 +89,9 @@ signRelease()
       echo "$FILES" | while read -r f; do codesign --entitlements "$ENTITLEMENTS" --options runtime --force --timestamp --sign "Developer ID Application: London Jamocha Community CIC" "$f"; done
 
       # Loop through jmods, extract, sign and repack
-      if [[ -d "$TMP_DIR/Contents/Home/jmods" ]]; then
-        cd "$TMP_DIR/Contents/Home/jmods"
+      JMODS_DIR=$(ls -d $TMP_DIR/jdk*/Contents/Home/jmods || echo "null")
+      if [[ "$JMODS_DIR" != "null" ]]; then
+        cd "$JMODS_DIR"
         for jmod in ./*; do
         	rm -rf tmp
         	unzip -q $jmod -d tmp

--- a/sign.sh
+++ b/sign.sh
@@ -89,16 +89,19 @@ signRelease()
       echo "$FILES" | while read -r f; do codesign --entitlements "$ENTITLEMENTS" --options runtime --force --timestamp --sign "Developer ID Application: London Jamocha Community CIC" "$f"; done
 
       # Loop through jmods, extract, sign and repack
-      JMODS_DIR=$(ls -d $TMP_DIR/jdk*/Contents/Home/jmods || echo "null")
-      if [[ "$JMODS_DIR" != "null" ]]; then
+      JMODS_DIR=$(ls -d $TMP_DIR/jdk*/Contents/Home/jmods || echo "")
+      if [[ -n $JMODS_DIR ]]; then
         cd "$JMODS_DIR"
         for jmod in ./*; do
         	rm -rf tmp
-          7za x $jmod -otmp
+          # Use brew install p7zip to get 7z
+          7z x $jmod -otmp
         	cd tmp
-          FILES=$(find bin lib -type f)
-          echo "$FILES" | while read -r f; do codesign --entitlements "$ENTITLEMENTS" --options runtime --force --timestamp --sign "Developer ID Application: London Jamocha Community CIC" "$f"; done
-          zip -r ../$jmod .
+          FILES=$(find bin lib -type f 2>/dev/null || echo "")
+          if [[ -n $FILES ]]; then
+            echo "$FILES" | while read -r f; do codesign --entitlements "$ENTITLEMENTS" --options runtime --force --timestamp --sign "Developer ID Application: London Jamocha Community CIC" "$f"; done
+          fi
+          7z a -r ../$jmod .
         	cd ../
         	rm -rf tmp
         done

--- a/sign.sh
+++ b/sign.sh
@@ -86,7 +86,7 @@ signRelease()
       security unlock-keychain -p `cat ~/.password`
       # Sign all files with the executable permission bit set.
       FILES=$(find "${TMP_DIR}" -perm +111 -type f -o -name '*.dylib'  -type f || find "${TMP_DIR}" -perm /111 -type f -o -name '*.dylib'  -type f)
-      echo "$FILES" | while read -r f; do codesign --entitlements "$ENTITLEMENTS" --options runtime --timestamp --sign "Developer ID Application: London Jamocha Community CIC" "$f"; done
+      echo "$FILES" | while read -r f; do codesign --entitlements "$ENTITLEMENTS" --options runtime --force --timestamp --sign "Developer ID Application: London Jamocha Community CIC" "$f"; done
 
       # Loop through jmods, extract, sign and repack
       if [[ -d "$TMP_DIR/Contents/Home/jmods" ]]; then
@@ -96,7 +96,7 @@ signRelease()
         	unzip -q $jmod -d tmp
         	cd tmp
           FILES=$(find bin lib -type f)
-          echo "$FILES" | while read -r f; do codesign --entitlements "$ENTITLEMENTS" --options runtime --timestamp --sign "Developer ID Application: London Jamocha Community CIC" "$f"; done
+          echo "$FILES" | while read -r f; do codesign --entitlements "$ENTITLEMENTS" --options runtime --force --timestamp --sign "Developer ID Application: London Jamocha Community CIC" "$f"; done
           zip -r ../$jmod .
         	cd ../
         	rm -rf tmp

--- a/sign.sh
+++ b/sign.sh
@@ -89,19 +89,19 @@ signRelease()
       echo "$FILES" | while read -r f; do codesign --entitlements "$ENTITLEMENTS" --options runtime --timestamp --sign "Developer ID Application: London Jamocha Community CIC" "$f"; done
 
       # Loop through jmods, extract, sign and repack
-      JMODS_DIR=$(ls -d $TMP_DIR/jdk*/Contents/Home/jmods || echo "")
+      JMODS_DIR=$(ls -d "$TMP_DIR/jdk*/Contents/Home/jmods" || echo "")
       if [[ -n $JMODS_DIR ]]; then
         cd "$JMODS_DIR"
         for jmod in ./*; do
           rm -rf tmp
           # Use brew install p7zip to get 7z
-          7z x $jmod -otmp
+          7z x "$jmod" -otmp
           cd tmp
           FILES=$(find bin lib -type f 2>/dev/null || echo "")
           if [[ -n $FILES ]]; then
             echo "$FILES" | while read -r f; do codesign --entitlements "$ENTITLEMENTS" --options runtime --timestamp --sign "Developer ID Application: London Jamocha Community CIC" "$f"; done
           fi
-          7z a -r ../$jmod .
+          7z a -r ../"$jmod" .
           cd ../
           rm -rf tmp
         done

--- a/sign.sh
+++ b/sign.sh
@@ -34,19 +34,19 @@ TMP_DIR_NAME="tmp"
 TMP_DIR="${WORKSPACE}/${TMP_DIR_NAME}/"
 
 checkSignConfiguration() {
-    if [[ "${OPERATING_SYSTEM}" == "windows" ]] ; then
-      if [ ! -f "${SIGNING_CERTIFICATE}" ]
-      then
-        echo "Could not find certificate at: ${SIGNING_CERTIFICATE}"
-        exit 1
-      fi
-
-      if [ -z "${SIGN_PASSWORD+x}" ]
-      then
-        echo "If signing is enabled on window you must set SIGN_PASSWORD"
-        exit 1
-      fi
+  if [[ "${OPERATING_SYSTEM}" == "windows" ]] ; then
+    if [ ! -f "${SIGNING_CERTIFICATE}" ]
+    then
+      echo "Could not find certificate at: ${SIGNING_CERTIFICATE}"
+      exit 1
     fi
+
+    if [ -z "${SIGN_PASSWORD+x}" ]
+    then
+      echo "If signing is enabled on window you must set SIGN_PASSWORD"
+      exit 1
+    fi
+  fi
 }
 
 # Sign the built binary
@@ -71,7 +71,7 @@ signRelease()
       do
         "$signToolPath" sign /f "${SIGNING_CERTIFICATE}" /p "$SIGN_PASSWORD" /fd SHA256 /t http://timestamp.verisign.com/scripts/timstamp.dll "$f";
       done
-    ;;
+      ;;
     "mac"*)
       echo "Signing OSX release"
 
@@ -86,60 +86,60 @@ signRelease()
       security unlock-keychain -p `cat ~/.password`
       # Sign all files with the executable permission bit set.
       FILES=$(find "${TMP_DIR}" -perm +111 -type f -o -name '*.dylib'  -type f || find "${TMP_DIR}" -perm /111 -type f -o -name '*.dylib'  -type f)
-      echo "$FILES" | while read -r f; do codesign --entitlements "$ENTITLEMENTS" --options runtime --force --timestamp --sign "Developer ID Application: London Jamocha Community CIC" "$f"; done
+      echo "$FILES" | while read -r f; do codesign --entitlements "$ENTITLEMENTS" --options runtime --timestamp --sign "Developer ID Application: London Jamocha Community CIC" "$f"; done
 
       # Loop through jmods, extract, sign and repack
       JMODS_DIR=$(ls -d $TMP_DIR/jdk*/Contents/Home/jmods || echo "")
       if [[ -n $JMODS_DIR ]]; then
         cd "$JMODS_DIR"
         for jmod in ./*; do
-        	rm -rf tmp
+          rm -rf tmp
           # Use brew install p7zip to get 7z
           7z x $jmod -otmp
-        	cd tmp
+          cd tmp
           FILES=$(find bin lib -type f 2>/dev/null || echo "")
           if [[ -n $FILES ]]; then
-            echo "$FILES" | while read -r f; do codesign --entitlements "$ENTITLEMENTS" --options runtime --force --timestamp --sign "Developer ID Application: London Jamocha Community CIC" "$f"; done
+            echo "$FILES" | while read -r f; do codesign --entitlements "$ENTITLEMENTS" --options runtime --timestamp --sign "Developer ID Application: London Jamocha Community CIC" "$f"; done
           fi
           7z a -r ../$jmod .
-        	cd ../
-        	rm -rf tmp
+          cd ../
+          rm -rf tmp
         done
       fi
-    ;;
+      ;;
     *)
       echo "Skipping code signing as it's not supported on $OPERATING_SYSTEM"
-    ;;
+      ;;
   esac
 }
 
 function parseArguments() {
-    parseConfigurationArguments "$@"
+  parseConfigurationArguments "$@"
 
-    while [[ $# -gt 2 ]] ; do
-      shift;
-    done
+  while [[ $# -gt 2 ]] ; do
+    shift;
+  done
 
-    SIGNING_CERTIFICATE="$1";
-    ARCHIVE="$2";
+  SIGNING_CERTIFICATE="$1";
+  ARCHIVE="$2";
 }
 
 function extractArchive {
   rm -rf "${TMP_DIR}" || true
   mkdir "${TMP_DIR}"
   if [[ "${OPERATING_SYSTEM}" == "windows" ]]; then
-      unzip "${ARCHIVE}" -d "${TMP_DIR}"
+    unzip "${ARCHIVE}" -d "${TMP_DIR}"
   elif [[ "${OPERATING_SYSTEM}" == "mac" ]]; then
-      gunzip -dc "${ARCHIVE}" | tar xf - -C "${TMP_DIR}"
+    gunzip -dc "${ARCHIVE}" | tar xf - -C "${TMP_DIR}"
   else
-      echo "could not detect archive type"
-      exit 1
+    echo "could not detect archive type"
+    exit 1
   fi
 }
 
 if [ "${OPERATING_SYSTEM}" != "windows" ] && [ "${OPERATING_SYSTEM}" != "mac" ]; then
-    echo "Skipping code signing as it's not supported on ${OPERATING_SYSTEM}"
-    exit 0;
+  echo "Skipping code signing as it's not supported on ${OPERATING_SYSTEM}"
+  exit 0;
 fi
 
 configDefaults


### PR DESCRIPTION
This allows users to bundle AdoptOpenJDK binaries into notarized macOS applications. 

This is confirmed to be fixed on JDK11+

On JDK8 we still hit the same issue that the Corretto folks do which is this error:
```
The binary uses an SDK older than the 10.9 SDK
```

My suggestion would be that we investigate shipping a JDK8 build that is optimized for bundling (i.e built on a later toolchain) This [repo](https://github.com/stooke/jdk8u-xcode10) may be usefil as it contains some patches required to get JDK8 to compile on xcode10.