### PR TITLE
sign builds before running tests

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -470,6 +470,9 @@ class Build {
                 }
             }
 
+            // Sign and archive jobs if needed
+            sign(versionInfo)
+
             if (enableTests && buildConfig.TEST_LIST.size() > 0) {
                 try {
                     def testStages = runTests()
@@ -478,9 +481,6 @@ class Build {
                     context.println "Failed test: ${e}"
                 }
             }
-
-            // Sign and archive jobs if needed
-            sign(versionInfo)
 
             //buildInstaller if needed
             buildInstaller(versionInfo)


### PR DESCRIPTION
This change forces the pipelines to sign the binaries before running tests 