### PR TITLE
Add XLC16 PATH entries for JDK13/AIX

### DIFF
--- a/build-farm/platform-specific-configurations/aix.sh
+++ b/build-farm/platform-specific-configurations/aix.sh
@@ -18,8 +18,7 @@
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # shellcheck source=sbin/common/constants.sh
 source "$SCRIPT_DIR/../../sbin/common/constants.sh"
-
-export PATH="/opt/freeware/bin:/usr/local/bin:/opt/IBM/xlC/13.1.3/bin:/opt/IBM/xlc/13.1.3/bin:$PATH"
+export PATH="/opt/freeware/bin:/usr/local/bin:/opt/IBM/xlC/16.1.0/bin:/opt/IBM/xlc/16.1.0/bin:$PATH"
 # Without this, java adds /usr/lib to the LIBPATH of anything it forks which breaks linkage
 export LIBPATH="/opt/freeware/lib:$LIBPATH"
 export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-memory-size=18000 --with-cups-include=/opt/freeware/include"
@@ -68,6 +67,9 @@ then
   fi
 
   export LANG=C
-  export PATH=/opt/freeware/bin:$JAVA_HOME/bin:/usr/local/bin:/opt/IBM/xlC/13.1.3/bin:/opt/IBM/xlc/13.1.3/bin:$PATH
-
+  if [ "$JAVA_FEATURE_VERSION" -ge 11 ]; then
+    export PATH=/opt/freeware/bin:$JAVA_HOME/bin:/usr/local/bin:/opt/IBM/xlC/16.1.0/bin:/opt/IBM/xlc/16.1.0/bin:$PATH
+  else
+    export PATH=/opt/freeware/bin:$JAVA_HOME/bin:/usr/local/bin:/opt/IBM/xlC/13.1.3/bin:/opt/IBM/xlc/13.1.3/bin:$PATH
+  fi
 fi

--- a/pipelines/build/openjdk13_pipeline.groovy
+++ b/pipelines/build/openjdk13_pipeline.groovy
@@ -79,6 +79,7 @@ def buildConfigurations = [
         ppc64Aix    : [
                 os                  : 'aix',
                 arch                : 'ppc64',
+                additionalNodeLabels: 'xlc16',
                 test                : [
                         nightly: false,
                         release: ['sanity.openjdk', 'sanity.system', 'extended.system']


### PR DESCRIPTION
xlc16 is required for JDK13 - see also https://github.com/AdoptOpenJDK/openjdk-infrastructure/pull/773 which is the corresponding infrastructure issue. I have installed this on one of the AIX build machines for now and am using the `xlc16` tag to target the AIX JDK13 build to it.

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>