### PR TITLE
Update parameters for create_installer_linux

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -231,15 +231,20 @@ class Build {
 
         def buildNumber = versionData.build
 
+        String releaseType = "Nightly"
+        if (buildConfig.RELEASE) {
+            releaseType = "Release"
+        }
+
         def installerJob = context.build job: "build-scripts/release/create_installer_linux",
                 propagate: true,
                 parameters: [
                         context.string(name: 'UPSTREAM_JOB_NUMBER', value: "${env.BUILD_NUMBER}"),
                         context.string(name: 'UPSTREAM_JOB_NAME', value: "${env.JOB_NAME}"),
                         context.string(name: 'FILTER', value: "${filter}"),
+                        context.string(name: 'RELEASE_TYPE', value: "${releaseType}"),
                         context.string(name: 'VERSION', value: "${versionData.version}"),
                         context.string(name: 'MAJOR_VERSION', value: "${versionData.major}"),
-                        context.string(name: 'JVM', value: "${buildConfig.VARIANT}"),
                         context.string(name: 'ARCHITECTURE', value: "${buildConfig.ARCHITECTURE}"),
                         ['$class': 'LabelParameterValue', name: 'NODE_LABEL', label: "${nodeFilter}"]
                 ]


### PR DESCRIPTION
This should fix the recent build failures with the linux installers. The Jenkins job `create_installer_linux` expects a parameter `RELEASE_TYPE`. The value should be `Release` if it's a release and `Nightly` otherwise.

It's my first change to the build pipeline, so please double check.