### PR TITLE
Disable AIX JDK13 until upstream OpenJ9 stable on xlc16

### DIFF
--- a/pipelines/jobs/configurations/jdk13u.groovy
+++ b/pipelines/jobs/configurations/jdk13u.groovy
@@ -21,8 +21,7 @@ targetConfigurations = [
                 "hotspot"
         ],
         "ppc64Aix"    : [
-                "hotspot",
-                "openj9"
+                "hotspot"
         ],
         "ppc64leLinux": [
                 "hotspot",


### PR DESCRIPTION
Ref: https://github.com/eclipse/openj9/pull/6584
xlc16 is available on one of the build machines which has allowed HotSpot builds of JDK13 to succeed but not OpenJ9

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>