### PR TITLE
Use gmake on *BSD

### DIFF
--- a/sbin/common/config_init.sh
+++ b/sbin/common/config_init.sh
@@ -324,11 +324,14 @@ function configDefaults() {
   BUILD_CONFIG[FREETYPE_FONT_VERSION]="2.9.1"
   BUILD_CONFIG[FREETYPE_FONT_BUILD_TYPE_PARAM]=""
 
-  if [ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "aix" ] || [ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "sunos" ]; then
-    BUILD_CONFIG[MAKE_COMMAND_NAME]="gmake"
-  else
-    BUILD_CONFIG[MAKE_COMMAND_NAME]="make"
-  fi
+  case "${BUILD_CONFIG[OS_KERNEL_NAME]}" in
+    aix | sunos | *bsd )
+      BUILD_CONFIG[MAKE_COMMAND_NAME]="gmake"
+      ;;
+    * )
+      BUILD_CONFIG[MAKE_COMMAND_NAME]="make"
+      ;;
+  esac
 
   BUILD_CONFIG[SIGN]="false"
   BUILD_CONFIG[JDK_BOOT_DIR]=""


### PR DESCRIPTION
Like Solaris and AIX, *BSD also has GNU make installed as gmake.  Switch to using a case statement so it's easier to incorporate additional OSes here and also so we can use *bsd rather than separately listing FreeBSD, NetBSD, and OpenBSD.