### PR TITLE
Added JDK 11-13 Dockerfiles

### DIFF
--- a/docker/jdk11/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk11/x86_64/ubuntu/Dockerfile
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 MAINTAINER AdoptOpenJDK <adoption-discuss@openjdk.java.net>
 

--- a/docker/jdk11/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk11/x86_64/ubuntu/Dockerfile
@@ -1,0 +1,74 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ubuntu:16.04
+
+MAINTAINER AdoptOpenJDK <adoption-discuss@openjdk.java.net>
+
+# Install required OS tools
+RUN apt-get update \
+  && apt-get install -qq -y --no-install-recommends \
+    software-properties-common \
+    python-software-properties \
+  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 \
+  && add-apt-repository 'deb http://repos.azulsystems.com/ubuntu stable main' \
+  && apt-get update \
+  && apt-get -y upgrade \
+  && apt-get install -qq -y --no-install-recommends \
+    ccache \
+    cpio \
+    curl \
+    file \
+    g++ \
+    gcc \
+    git \
+    libasound2-dev \
+    libcups2-dev \
+    libelf-dev \
+    libfontconfig1-dev \
+    libfreetype6-dev \
+    libx11-dev \
+    libxext-dev \
+    libxrender-dev \
+    libxt-dev \
+    libxtst-dev \
+    make \
+    realpath \
+    systemtap-sdt-dev \
+    unzip \
+    wget \
+    zip \
+    ssh \
+&& rm -rf /var/lib/apt/lists/*
+
+# Pick up build instructions
+RUN mkdir -p /openjdk/target
+# wget and extract JDK10
+RUN wget 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk10?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk' -O - | tar -xz
+COPY sbin /openjdk/sbin
+COPY workspace/config /openjdk/config
+
+RUN mkdir -p /openjdk/build
+RUN useradd -ms /bin/bash build
+RUN chown -R build: /openjdk/
+USER build
+WORKDIR /openjdk/build/
+
+# Default actions
+ENTRYPOINT ["/openjdk/sbin/build.sh"]
+
+CMD ["images"]
+
+ARG OPENJDK_VERSION
+ENV OPENJDK_VERSION=$OPENJDK_VERSION
+ENV JDK_PATH=jdk

--- a/docker/jdk11/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk11/x86_64/ubuntu/Dockerfile
@@ -13,7 +13,7 @@
 
 FROM ubuntu:18.04
 
-MAINTAINER AdoptOpenJDK <adoption-discuss@openjdk.java.net>
+LABEL maintainer="AdoptOpenJDK <adoption-discuss@openjdk.java.net>"
 
 # Install required OS tools
 RUN apt-get update \

--- a/docker/jdk11/x86_64/ubuntu/Dockerfile-openj9
+++ b/docker/jdk11/x86_64/ubuntu/Dockerfile-openj9
@@ -13,7 +13,7 @@
 
 FROM openjdk_container
 
-MAINTAINER AdoptOpenJDK <adoption-discuss@openjdk.java.net>
+LABEL maintainer="AdoptOpenJDK <adoption-discuss@openjdk.java.net>"
 
 # Install required OS tools
 RUN apt-get update \

--- a/docker/jdk11/x86_64/ubuntu/Dockerfile-openj9
+++ b/docker/jdk11/x86_64/ubuntu/Dockerfile-openj9
@@ -1,0 +1,47 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM openjdk_container
+
+MAINTAINER AdoptOpenJDK <adoption-discuss@openjdk.java.net>
+
+# Install required OS tools
+RUN apt-get update \
+    && apt-get install -qq -y --no-install-recommends \
+       autoconf \
+       ccache \
+       cpio \
+       file \
+       g++-4.8 \
+       gcc-4.8 \
+       libdwarf-dev \
+       libelf-dev \
+       libfontconfig \
+       libfreetype6-dev \
+       libnuma-dev \
+       pkg-config \
+       ssh \
+    && rm -rf /var/lib/apt/lists/*
+
+
+# Make sure build uses 4.8
+RUN rm /usr/bin/gcc \
+    && rm /usr/bin/g++ \
+    && rm /usr/bin/c++ \
+    && ln -s /usr/bin/gcc-4.8 /usr/bin/gcc \
+    && ln -s /usr/bin/g++-4.8 /usr/bin/g++ \
+    && ln -s /usr/bin/g++-4.8 /usr/bin/c++
+
+ARG OPENJDK_CORE_VERSION
+ENV OPENJDK_CORE_VERSION=$OPENJDK_CORE_VERSION
+ENV JDK_PATH=jdk

--- a/docker/jdk11/x86_64/ubuntu/dockerConfiguration.sh
+++ b/docker/jdk11/x86_64/ubuntu/dockerConfiguration.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# shellcheck disable=SC2034
+# Disable for whole file
+
+# This config is read in by configureBuild
+BUILD_CONFIG[OS_KERNEL_NAME]="linux"
+BUILD_CONFIG[OS_ARCHITECTURE]="x86_64"
+BUILD_CONFIG[BUILD_FULL_NAME]="linux-x86_64-normal-server-release"

--- a/docker/jdk12/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk12/x86_64/ubuntu/Dockerfile
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 MAINTAINER AdoptOpenJDK <adoption-discuss@openjdk.java.net>
 

--- a/docker/jdk12/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk12/x86_64/ubuntu/Dockerfile
@@ -13,7 +13,7 @@
 
 FROM ubuntu:18.04
 
-MAINTAINER AdoptOpenJDK <adoption-discuss@openjdk.java.net>
+LABEL maintainer="AdoptOpenJDK <adoption-discuss@openjdk.java.net>"
 
 # Install required OS tools
 RUN apt-get update \

--- a/docker/jdk12/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk12/x86_64/ubuntu/Dockerfile
@@ -1,0 +1,74 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ubuntu:16.04
+
+MAINTAINER AdoptOpenJDK <adoption-discuss@openjdk.java.net>
+
+# Install required OS tools
+RUN apt-get update \
+  && apt-get install -qq -y --no-install-recommends \
+    software-properties-common \
+    python-software-properties \
+  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 \
+  && add-apt-repository 'deb http://repos.azulsystems.com/ubuntu stable main' \
+  && apt-get update \
+  && apt-get -y upgrade \
+  && apt-get install -qq -y --no-install-recommends \
+    ccache \
+    cpio \
+    curl \
+    file \
+    g++ \
+    gcc \
+    git \
+    libasound2-dev \
+    libcups2-dev \
+    libelf-dev \
+    libfontconfig1-dev \
+    libfreetype6-dev \
+    libx11-dev \
+    libxext-dev \
+    libxrender-dev \
+    libxt-dev \
+    libxtst-dev \
+    make \
+    realpath \
+    systemtap-sdt-dev \
+    unzip \
+    wget \
+    zip \
+    ssh \
+&& rm -rf /var/lib/apt/lists/*
+
+# Pick up build instructions
+RUN mkdir -p /openjdk/target
+# wget and extract JDK11
+RUN wget 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk11?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk' -O - | tar -xz
+COPY sbin /openjdk/sbin
+COPY workspace/config /openjdk/config
+
+RUN mkdir -p /openjdk/build
+RUN useradd -ms /bin/bash build
+RUN chown -R build: /openjdk/
+USER build
+WORKDIR /openjdk/build/
+
+# Default actions
+ENTRYPOINT ["/openjdk/sbin/build.sh"]
+
+CMD ["images"]
+
+ARG OPENJDK_VERSION
+ENV OPENJDK_VERSION=$OPENJDK_VERSION
+ENV JDK_PATH=jdk

--- a/docker/jdk12/x86_64/ubuntu/Dockerfile-openj9
+++ b/docker/jdk12/x86_64/ubuntu/Dockerfile-openj9
@@ -13,7 +13,7 @@
 
 FROM openjdk_container
 
-MAINTAINER AdoptOpenJDK <adoption-discuss@openjdk.java.net>
+LABEL maintainer="AdoptOpenJDK <adoption-discuss@openjdk.java.net>"
 
 # Install required OS tools
 RUN apt-get update \

--- a/docker/jdk12/x86_64/ubuntu/Dockerfile-openj9
+++ b/docker/jdk12/x86_64/ubuntu/Dockerfile-openj9
@@ -1,0 +1,47 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM openjdk_container
+
+MAINTAINER AdoptOpenJDK <adoption-discuss@openjdk.java.net>
+
+# Install required OS tools
+RUN apt-get update \
+    && apt-get install -qq -y --no-install-recommends \
+       autoconf \
+       ccache \
+       cpio \
+       file \
+       g++-4.8 \
+       gcc-4.8 \
+       libdwarf-dev \
+       libelf-dev \
+       libfontconfig \
+       libfreetype6-dev \
+       libnuma-dev \
+       pkg-config \
+       ssh \
+    && rm -rf /var/lib/apt/lists/*
+
+
+# Make sure build uses 4.8
+RUN rm /usr/bin/gcc \
+    && rm /usr/bin/g++ \
+    && rm /usr/bin/c++ \
+    && ln -s /usr/bin/gcc-4.8 /usr/bin/gcc \
+    && ln -s /usr/bin/g++-4.8 /usr/bin/g++ \
+    && ln -s /usr/bin/g++-4.8 /usr/bin/c++
+
+ARG OPENJDK_CORE_VERSION
+ENV OPENJDK_CORE_VERSION=$OPENJDK_CORE_VERSION
+ENV JDK_PATH=jdk

--- a/docker/jdk12/x86_64/ubuntu/dockerConfiguration.sh
+++ b/docker/jdk12/x86_64/ubuntu/dockerConfiguration.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# shellcheck disable=SC2034
+# Disable for whole file
+
+# This config is read in by configureBuild
+BUILD_CONFIG[OS_KERNEL_NAME]="linux"
+BUILD_CONFIG[OS_ARCHITECTURE]="x86_64"
+BUILD_CONFIG[BUILD_FULL_NAME]="linux-x86_64-normal-server-release"

--- a/docker/jdk13/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk13/x86_64/ubuntu/Dockerfile
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 MAINTAINER AdoptOpenJDK <adoption-discuss@openjdk.java.net>
 

--- a/docker/jdk13/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk13/x86_64/ubuntu/Dockerfile
@@ -1,0 +1,74 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ubuntu:16.04
+
+MAINTAINER AdoptOpenJDK <adoption-discuss@openjdk.java.net>
+
+# Install required OS tools
+RUN apt-get update \
+  && apt-get install -qq -y --no-install-recommends \
+    software-properties-common \
+    python-software-properties \
+  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 \
+  && add-apt-repository 'deb http://repos.azulsystems.com/ubuntu stable main' \
+  && apt-get update \
+  && apt-get -y upgrade \
+  && apt-get install -qq -y --no-install-recommends \
+    ccache \
+    cpio \
+    curl \
+    file \
+    g++ \
+    gcc \
+    git \
+    libasound2-dev \
+    libcups2-dev \
+    libelf-dev \
+    libfontconfig1-dev \
+    libfreetype6-dev \
+    libx11-dev \
+    libxext-dev \
+    libxrender-dev \
+    libxt-dev \
+    libxtst-dev \
+    make \
+    realpath \
+    systemtap-sdt-dev \
+    unzip \
+    wget \
+    zip \
+    ssh \
+&& rm -rf /var/lib/apt/lists/*
+
+# Pick up build instructions
+RUN mkdir -p /openjdk/target
+# wget and extract JDK12
+RUN wget 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk12?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk' -O - | tar -xz
+COPY sbin /openjdk/sbin
+COPY workspace/config /openjdk/config
+
+RUN mkdir -p /openjdk/build
+RUN useradd -ms /bin/bash build
+RUN chown -R build: /openjdk/
+USER build
+WORKDIR /openjdk/build/
+
+# Default actions
+ENTRYPOINT ["/openjdk/sbin/build.sh"]
+
+CMD ["images"]
+
+ARG OPENJDK_VERSION
+ENV OPENJDK_VERSION=$OPENJDK_VERSION
+ENV JDK_PATH=jdk

--- a/docker/jdk13/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk13/x86_64/ubuntu/Dockerfile
@@ -13,7 +13,7 @@
 
 FROM ubuntu:18.04
 
-MAINTAINER AdoptOpenJDK <adoption-discuss@openjdk.java.net>
+LABEL maintainer="AdoptOpenJDK <adoption-discuss@openjdk.java.net>"
 
 # Install required OS tools
 RUN apt-get update \

--- a/docker/jdk13/x86_64/ubuntu/Dockerfile-openj9
+++ b/docker/jdk13/x86_64/ubuntu/Dockerfile-openj9
@@ -13,7 +13,7 @@
 
 FROM openjdk_container
 
-MAINTAINER AdoptOpenJDK <adoption-discuss@openjdk.java.net>
+LABEL maintainer="AdoptOpenJDK <adoption-discuss@openjdk.java.net>"
 
 # Install required OS tools
 RUN apt-get update \

--- a/docker/jdk13/x86_64/ubuntu/Dockerfile-openj9
+++ b/docker/jdk13/x86_64/ubuntu/Dockerfile-openj9
@@ -1,0 +1,47 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM openjdk_container
+
+MAINTAINER AdoptOpenJDK <adoption-discuss@openjdk.java.net>
+
+# Install required OS tools
+RUN apt-get update \
+    && apt-get install -qq -y --no-install-recommends \
+       autoconf \
+       ccache \
+       cpio \
+       file \
+       g++-4.8 \
+       gcc-4.8 \
+       libdwarf-dev \
+       libelf-dev \
+       libfontconfig \
+       libfreetype6-dev \
+       libnuma-dev \
+       pkg-config \
+       ssh \
+    && rm -rf /var/lib/apt/lists/*
+
+
+# Make sure build uses 4.8
+RUN rm /usr/bin/gcc \
+    && rm /usr/bin/g++ \
+    && rm /usr/bin/c++ \
+    && ln -s /usr/bin/gcc-4.8 /usr/bin/gcc \
+    && ln -s /usr/bin/g++-4.8 /usr/bin/g++ \
+    && ln -s /usr/bin/g++-4.8 /usr/bin/c++
+
+ARG OPENJDK_CORE_VERSION
+ENV OPENJDK_CORE_VERSION=$OPENJDK_CORE_VERSION
+ENV JDK_PATH=jdk

--- a/docker/jdk13/x86_64/ubuntu/dockerConfiguration.sh
+++ b/docker/jdk13/x86_64/ubuntu/dockerConfiguration.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# shellcheck disable=SC2034
+# Disable for whole file
+
+# This config is read in by configureBuild
+BUILD_CONFIG[OS_KERNEL_NAME]="linux"
+BUILD_CONFIG[OS_ARCHITECTURE]="x86_64"
+BUILD_CONFIG[BUILD_FULL_NAME]="linux-x86_64-normal-server-release"


### PR DESCRIPTION
These were based heavily on the JDK10 Dockerfile, the only difference between them being the different JDK versions they install to build the JDK on the docker container.
