### PR TITLE
Changed scripts to fix broken Docker builds

### DIFF
--- a/docker-build.sh
+++ b/docker-build.sh
@@ -132,56 +132,34 @@ buildOpenJDKViaDocker()
   local dockerEntrypoint=(--entrypoint /openjdk/sbin/build.sh "${BUILD_CONFIG[CONTAINER_NAME]}")
   if [[ "${BUILD_CONFIG[DEBUG_DOCKER]}" == "true" ]] ; then
      dockerMode=(-t -i)
-     dockerEntrypoint=(--entrypoint "/bin/sh" "${BUILD_CONFIG[CONTAINER_NAME]}" -c "echo 'DEBUG DOCKER BUILD\\nTo build jdk run\\n/openjdk/sbin/build.sh'; /bin/bash")
+     dockerEntrypoint=(--entrypoint "/bin/sh" "${BUILD_CONFIG[CONTAINER_NAME]}")
   fi
 
-  #if both dockerMode and gitSshAccess are unbounded
-  if [ ! -n "${dockerMode[@]:-}" ]  && [ ! -n "${gitSshAccess[@]:-}" ]; then
-    ${BUILD_CONFIG[DOCKER]} run \
+  # Command without gitSshAccess or dockerMode arrays
+  local commandString="
          --cpuset-cpus="${cpuSet}" \
          -v "${BUILD_CONFIG[DOCKER_SOURCE_VOLUME_NAME]}:/openjdk/build" \
          -v "${hostDir}/workspace/target":"/${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}:Z" \
          -v "${hostDir}/pipelines":/openjdk/pipelines \
          -e DEBUG_DOCKER_FLAG="${BUILD_CONFIG[DEBUG_DOCKER]}" \
-         -e BUILD_VARIANT="${BUILD_CONFIG[BUILD_VARIANT]}"
-         "${dockerEntrypoint[@]}"
-  #if just dockerMode is unbounded
-  elif [ ! -n "${dockerMode[@]:-}" ]; then
-    ${BUILD_CONFIG[DOCKER]} run \
-       --cpuset-cpus="${cpuSet}" \
-       -v "${BUILD_CONFIG[DOCKER_SOURCE_VOLUME_NAME]}:/openjdk/build" \
-       -v "${hostDir}/workspace/target":"/${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}:Z" \
-       -v "${hostDir}/pipelines":/openjdk/pipelines \
-        "${gitSshAccess[@]}" \
-       -e DEBUG_DOCKER_FLAG="${BUILD_CONFIG[DEBUG_DOCKER]}" \
-       -e BUILD_VARIANT="${BUILD_CONFIG[BUILD_VARIANT]}" \
-       "${dockerEntrypoint[@]}"
-  #if just gitSshAccess is unbounded
-  elif [ ! -n "${gitSshAccess[@]:-}" ]; then
-    ${BUILD_CONFIG[DOCKER]} run \
-       "${dockerMode[@]}" \
-       --cpuset-cpus="${cpuSet}" \
-       -v "${BUILD_CONFIG[DOCKER_SOURCE_VOLUME_NAME]}:/openjdk/build" \
-       -v "${hostDir}/workspace/target":"/${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}:Z" \
-       -v "${hostDir}/pipelines":/openjdk/pipelines \
-       -e DEBUG_DOCKER_FLAG="${BUILD_CONFIG[DEBUG_DOCKER]}" \
-       -e BUILD_VARIANT="${BUILD_CONFIG[BUILD_VARIANT]}" \
-       "${dockerEntrypoint[@]}"
-  else
-    # shellcheck disable=SC2140
-    # Pass in the last important variables into the Docker container and call
-    # the /openjdk/sbin/build.sh script inside
-    ${BUILD_CONFIG[DOCKER]} run \
-       "${dockerMode[@]}" \
-       --cpuset-cpus="${cpuSet}" \
-       -v "${BUILD_CONFIG[DOCKER_SOURCE_VOLUME_NAME]}:/openjdk/build" \
-       -v "${hostDir}/workspace/target":"/${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}:Z" \
-       -v "${hostDir}/pipelines":/openjdk/pipelines \
-       "${gitSshAccess[@]}" \
-       -e DEBUG_DOCKER_FLAG="${BUILD_CONFIG[DEBUG_DOCKER]}" \
-       -e BUILD_VARIANT="${BUILD_CONFIG[BUILD_VARIANT]}" \
-       "${dockerEntrypoint[@]}"
-  fi 
+         -e BUILD_VARIANT="${BUILD_CONFIG[BUILD_VARIANT]}" \
+         "${dockerEntrypoint[@]}""
+
+  # If build specifies --ssh, add array to the command string
+  if [[ "${BUILD_CONFIG[USE_SSH]}" == "true" ]] ; then
+	commandString="${gitSshAccess[@]}"' '$commandString
+  fi
+
+  # If build specifies --debug-docker, add array to the command string
+  if [[ "${BUILD_CONFIG[DEBUG_DOCKER]}" == "true" ]] ; then
+	commandString="${dockerMode[@]}"' '$commandString
+	echo "DEBUG DOCKER MODE. To build jdk run /openjdk/sbin/build.sh"
+	commandString=$commandString' -c /bin/bash'
+  fi
+
+  # Run the command string in Docker
+  ${BUILD_CONFIG[DOCKER]} run $commandString
+
  
   # If we didn't specify to keep the container then remove it
   if [[ -z ${BUILD_CONFIG[KEEP_CONTAINER]} ]] ; then

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -132,34 +132,32 @@ buildOpenJDKViaDocker()
   local dockerEntrypoint=(--entrypoint /openjdk/sbin/build.sh "${BUILD_CONFIG[CONTAINER_NAME]}")
   if [[ "${BUILD_CONFIG[DEBUG_DOCKER]}" == "true" ]] ; then
      dockerMode=(-t -i)
-     dockerEntrypoint=(--entrypoint "/bin/sh" "${BUILD_CONFIG[CONTAINER_NAME]}")
+     dockerEntrypoint=(--entrypoint "/bin/sh" "${BUILD_CONFIG[CONTAINER_NAME]}" -c "/bin/bash")
   fi
 
   # Command without gitSshAccess or dockerMode arrays
-  local commandString="
-         --cpuset-cpus="${cpuSet}" \
-         -v "${BUILD_CONFIG[DOCKER_SOURCE_VOLUME_NAME]}:/openjdk/build" \
-         -v "${hostDir}/workspace/target":"/${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}:Z" \
-         -v "${hostDir}/pipelines":/openjdk/pipelines \
-         -e DEBUG_DOCKER_FLAG="${BUILD_CONFIG[DEBUG_DOCKER]}" \
-         -e BUILD_VARIANT="${BUILD_CONFIG[BUILD_VARIANT]}" \
-         "${dockerEntrypoint[@]}""
+  local commandString=(
+         "--cpuset-cpus=${cpuSet}" 
+         -v "${BUILD_CONFIG[DOCKER_SOURCE_VOLUME_NAME]}:/openjdk/build"
+         -v "${hostDir}"/workspace/target:/"${BUILD_CONFIG[WORKSPACE_DIR]}"/"${BUILD_CONFIG[TARGET_DIR]}":Z 
+         -v "${hostDir}"/pipelines:/openjdk/pipelines 
+         -e "DEBUG_DOCKER_FLAG=${BUILD_CONFIG[DEBUG_DOCKER]}" 
+         -e "BUILD_VARIANT=${BUILD_CONFIG[BUILD_VARIANT]}"
+          "${dockerEntrypoint[@]}")
 
   # If build specifies --ssh, add array to the command string
   if [[ "${BUILD_CONFIG[USE_SSH]}" == "true" ]] ; then
-	commandString="${gitSshAccess[@]}"' '$commandString
+        commandString=("${gitSshAccess[@]}" "${commandString[@]}")
   fi
 
   # If build specifies --debug-docker, add array to the command string
   if [[ "${BUILD_CONFIG[DEBUG_DOCKER]}" == "true" ]] ; then
-	commandString="${dockerMode[@]}"' '$commandString
-	echo "DEBUG DOCKER MODE. To build jdk run /openjdk/sbin/build.sh"
-	commandString=$commandString' -c /bin/bash'
+        commandString=("${dockerMode[@]}" "${commandString[@]}")
+        echo "DEBUG DOCKER MODE. To build jdk run /openjdk/sbin/build.sh"
   fi
 
   # Run the command string in Docker
-  ${BUILD_CONFIG[DOCKER]} run $commandString
-
+  ${BUILD_CONFIG[DOCKER]} run "${commandString[@]}"
  
   # If we didn't specify to keep the container then remove it
   if [[ -z ${BUILD_CONFIG[KEEP_CONTAINER]} ]] ; then

--- a/docker/jdk10/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk10/x86_64/ubuntu/Dockerfile
@@ -48,13 +48,21 @@ RUN apt-get update \
     unzip \
     wget \
     zip \
-    zulu-8 \
-    zulu-9 \
     ssh \
 && rm -rf /var/lib/apt/lists/*
 
 # Pick up build instructions
 RUN mkdir -p /openjdk/target
+
+# Extract AdoptOpenJDK8 to run Gradle.
+RUN wget 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk8?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk' -O jdk8.tar.gz
+RUN mkdir -p /usr/lib/jvm/jdk8 && tar -xvf /jdk8.tar.gz -C /usr/lib/jvm/jdk8 --strip-components=1
+
+# Extract AdoptOpenJDK9 to set as JDK_BOOT_DIR.
+RUN wget 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk9?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk' -O jdk9.tar.gz
+RUN mkdir -p /usr/lib/jvm/jdk9 && tar -xvf /jdk9.tar.gz -C /usr/lib/jvm/jdk9 --strip-components=1
+RUN ln -sf /usr/lib/jvm/jdk9/bin/java /usr/bin/java
+RUN ln -sf /usr/lib/jvm/jdk9/bin/javac /usr/bin/javac
 
 COPY sbin /openjdk/sbin
 COPY workspace/config /openjdk/config
@@ -73,4 +81,4 @@ CMD ["images"]
 ARG OPENJDK_VERSION
 ENV OPENJDK_VERSION=$OPENJDK_VERSION
 ENV JDK_PATH=jdk
-ENV JAVA_HOME=/usr/lib/jvm/zulu-8-amd64
+ENV JAVA_HOME=/usr/lib/jvm/jdk8

--- a/docker/jdk10/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk10/x86_64/ubuntu/Dockerfile
@@ -48,6 +48,7 @@ RUN apt-get update \
     unzip \
     wget \
     zip \
+    zulu-8 \
     zulu-9 \
     ssh \
 && rm -rf /var/lib/apt/lists/*
@@ -72,3 +73,4 @@ CMD ["images"]
 ARG OPENJDK_VERSION
 ENV OPENJDK_VERSION=$OPENJDK_VERSION
 ENV JDK_PATH=jdk
+ENV JAVA_HOME=/usr/lib/jvm/zulu-8-amd64

--- a/docker/jdk11/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk11/x86_64/ubuntu/Dockerfile
@@ -47,15 +47,23 @@ RUN apt-get update \
     systemtap-sdt-dev \
     unzip \
     wget \
-    zulu-8 \
     zip \
     ssh \
 && rm -rf /var/lib/apt/lists/*
 
 # Pick up build instructions
 RUN mkdir -p /openjdk/target
-# wget and extract JDK10
-RUN wget 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk10?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk' -O - | tar -xz
+
+# Extract AdoptOpenJDK8 to run Gradle.
+RUN wget 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk8?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk' -O jdk8.tar.gz
+RUN mkdir -p /usr/lib/jvm/jdk8 && tar -xvf /jdk8.tar.gz -C /usr/lib/jvm/jdk8 --strip-components=1
+
+# Extract AdoptOpenJDK10 to set as JDK_BOOT_DIR.
+RUN wget 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk10?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk' -O jdk10.tar.gz
+RUN mkdir -p /usr/lib/jvm/jdk10 && tar -xvf /jdk10.tar.gz -C /usr/lib/jvm/jdk10 --strip-components=1
+RUN ln -sf /usr/lib/jvm/jdk10/bin/java /usr/bin/java
+RUN ln -sf /usr/lib/jvm/jdk10/bin/javac /usr/bin/javac
+
 COPY sbin /openjdk/sbin
 COPY workspace/config /openjdk/config
 
@@ -73,4 +81,4 @@ CMD ["images"]
 ARG OPENJDK_VERSION
 ENV OPENJDK_VERSION=$OPENJDK_VERSION
 ENV JDK_PATH=jdk
-ENV JAVA_HOME=/usr/lib/jvm/zulu-8-amd64
+ENV JAVA_HOME=/usr/lib/jvm/jdk8

--- a/docker/jdk11/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk11/x86_64/ubuntu/Dockerfile
@@ -47,6 +47,7 @@ RUN apt-get update \
     systemtap-sdt-dev \
     unzip \
     wget \
+    zulu-8 \
     zip \
     ssh \
 && rm -rf /var/lib/apt/lists/*
@@ -72,3 +73,4 @@ CMD ["images"]
 ARG OPENJDK_VERSION
 ENV OPENJDK_VERSION=$OPENJDK_VERSION
 ENV JDK_PATH=jdk
+ENV JAVA_HOME=/usr/lib/jvm/zulu-8-amd64

--- a/docker/jdk12/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk12/x86_64/ubuntu/Dockerfile
@@ -48,6 +48,7 @@ RUN apt-get update \
     unzip \
     wget \
     zip \
+    zulu-8 \
     ssh \
 && rm -rf /var/lib/apt/lists/*
 
@@ -72,3 +73,4 @@ CMD ["images"]
 ARG OPENJDK_VERSION
 ENV OPENJDK_VERSION=$OPENJDK_VERSION
 ENV JDK_PATH=jdk
+ENV JAVA_HOME=/usr/lib/jvm/zulu-8-amd64

--- a/docker/jdk12/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk12/x86_64/ubuntu/Dockerfile
@@ -48,14 +48,22 @@ RUN apt-get update \
     unzip \
     wget \
     zip \
-    zulu-8 \
     ssh \
 && rm -rf /var/lib/apt/lists/*
 
 # Pick up build instructions
 RUN mkdir -p /openjdk/target
-# wget and extract JDK11
-RUN wget 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk11?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk' -O - | tar -xz
+
+# Extract AdoptOpenJDK8 to run Gradle.
+RUN wget 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk8?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk' -O jdk8.tar.gz
+RUN mkdir -p /usr/lib/jvm/jdk8 && tar -xvf /jdk8.tar.gz -C /usr/lib/jvm/jdk8 --strip-components=1
+
+# Extract AdoptOpenJDK11 to set as JDK_BOOT_DIR.
+RUN wget 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk11?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk' -O jdk11.tar.gz
+RUN mkdir -p /usr/lib/jvm/jdk11 && tar -xvf /jdk11.tar.gz -C /usr/lib/jvm/jdk11 --strip-components=1
+RUN ln -sf /usr/lib/jvm/jdk11/bin/javac /usr/bin/javac
+RUN ln -sf /usr/lib/jvm/jdk11/bin/javac /usr/bin/javac
+
 COPY sbin /openjdk/sbin
 COPY workspace/config /openjdk/config
 
@@ -73,4 +81,4 @@ CMD ["images"]
 ARG OPENJDK_VERSION
 ENV OPENJDK_VERSION=$OPENJDK_VERSION
 ENV JDK_PATH=jdk
-ENV JAVA_HOME=/usr/lib/jvm/zulu-8-amd64
+ENV JAVA_HOME=/usr/lib/jvm/jdk8

--- a/docker/jdk13/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk13/x86_64/ubuntu/Dockerfile
@@ -48,14 +48,23 @@ RUN apt-get update \
     unzip \
     wget \
     zip \
-    zulu-8 \
     ssh \
 && rm -rf /var/lib/apt/lists/*
 
 # Pick up build instructions
 RUN mkdir -p /openjdk/target
-# wget and extract JDK12
-RUN wget 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk12?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk' -O - | tar -xz
+
+# Extract AdoptOpenJDK8 to run Gradle.
+RUN wget 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk8?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk' -O jdk8.tar.gz
+RUN mkdir -p /usr/lib/jvm/jdk8 && tar -xvf /jdk8.tar.gz -C /usr/lib/jvm/jdk8 --strip-components=1
+
+# Extract AdoptOpenJDK12 for JDK_BOOT_DIR.
+RUN wget 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk12?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk' -O jdk12.tar.gz
+RUN mkdir -p /usr/lib/jvm/jdk12 && tar -xvf /jdk12.tar.gz -C /usr/lib/jvm/jdk12 --strip-components=1
+RUN ln -sf /usr/lib/jvm/jdk12/bin/java /usr/bin/java
+RUN ln -sf /usr/lib/jvm/jdk12/bin/javac /usr/bin/javac
+
+
 COPY sbin /openjdk/sbin
 COPY workspace/config /openjdk/config
 
@@ -73,4 +82,4 @@ CMD ["images"]
 ARG OPENJDK_VERSION
 ENV OPENJDK_VERSION=$OPENJDK_VERSION
 ENV JDK_PATH=jdk
-ENV JAVA_HOME=/usr/lib/jvm/zulu-8-amd64
+ENV JAVA_HOME=/usr/lib/jvm/jdk8

--- a/docker/jdk13/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk13/x86_64/ubuntu/Dockerfile
@@ -48,6 +48,7 @@ RUN apt-get update \
     unzip \
     wget \
     zip \
+    zulu-8 \
     ssh \
 && rm -rf /var/lib/apt/lists/*
 
@@ -72,3 +73,4 @@ CMD ["images"]
 ARG OPENJDK_VERSION
 ENV OPENJDK_VERSION=$OPENJDK_VERSION
 ENV JDK_PATH=jdk
+ENV JAVA_HOME=/usr/lib/jvm/zulu-8-amd64

--- a/docker/jdk8/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk8/x86_64/ubuntu/Dockerfile
@@ -47,13 +47,17 @@ RUN apt-get update \
     unzip \
     wget \
     zip \
-    zulu-7 \
-    zulu-8 \
     ssh \
 && rm -rf /var/lib/apt/lists/*
 
 # Pick up build instructions
 RUN mkdir -p /openjdk/target
+
+# Extract AdoptOpenJDK8 to run Gradle with, and set to default Java/Javac.
+RUN wget 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk8?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk' -O jdk8.tar.gz
+RUN mkdir -p /usr/lib/jvm/jdk8 && tar -xvf /jdk8.tar.gz -C /usr/lib/jvm/jdk8 --strip-components=1
+RUN ln -sf /usr/lib/jvm/jdk8/bin/java /usr/bin/java
+RUN ln -sf /usr/lib/jvm/jdk8/bin/javac /usr/bin/javac
 
 COPY sbin /openjdk/sbin
 COPY workspace/config /openjdk/config
@@ -73,4 +77,4 @@ ARG OPENJDK_CORE_VERSION
 ENV OPENJDK_CORE_VERSION=$OPENJDK_CORE_VERSION
 ENV JDK_PATH=j2sdk-image
 ENV JRE_PATH=j2re-image
-ENV JAVA_HOME=/usr/lib/jvm/zulu-8-amd64
+ENV JAVA_HOME=/usr/lib/jvm/jdk8

--- a/docker/jdk8/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk8/x86_64/ubuntu/Dockerfile
@@ -48,6 +48,7 @@ RUN apt-get update \
     wget \
     zip \
     zulu-7 \
+    zulu-8 \
     ssh \
 && rm -rf /var/lib/apt/lists/*
 
@@ -72,3 +73,4 @@ ARG OPENJDK_CORE_VERSION
 ENV OPENJDK_CORE_VERSION=$OPENJDK_CORE_VERSION
 ENV JDK_PATH=j2sdk-image
 ENV JRE_PATH=j2re-image
+ENV JAVA_HOME=/usr/lib/jvm/zulu-8-amd64

--- a/docker/jdk9/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk9/x86_64/ubuntu/Dockerfile
@@ -41,19 +41,23 @@ RUN apt-get update \
     libxt-dev \
     libxtst-dev \
     make \
-    openjdk-8-jdk \
     realpath \
     systemtap-sdt-dev \
     unzip \
     wget \
     zip \
-    zulu-8 \
     ssh \
 
 && rm -rf /var/lib/apt/lists/*
 
 # Pick up build instructions
 RUN mkdir -p /openjdk/target
+
+# Extract AdoptOpenJDK8 and set as default Java/Javac
+RUN wget 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk8?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk' -O jdk8.tar.gz
+RUN mkdir -p /usr/lib/jvm/jdk8 && tar -xvf /jdk8.tar.gz -C /usr/lib/jvm/jdk8 --strip-components=1
+RUN ln -sf /usr/lib/jvm/jdk8/bin/java /usr/bin/java
+RUN ln -sf /usr/lib/jvm/jdk8/bin/javac /usr/bin/javac
 
 COPY sbin /openjdk/sbin
 COPY workspace/config /openjdk/config
@@ -72,4 +76,4 @@ CMD ["images"]
 ARG OPENJDK_CORE_VERSION
 ENV OPENJDK_CORE_VERSION=$OPENJDK_CORE_VERSION
 ENV JDK_PATH=jdk
-ENV JAVA_HOME=/usr/lib/jvm/zulu-8-amd64
+ENV JAVA_HOME=/usr/lib/jvm/jdk8

--- a/docker/jdk9/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk9/x86_64/ubuntu/Dockerfile
@@ -17,6 +17,10 @@ MAINTAINER AdoptOpenJDK <adoption-discuss@openjdk.java.net>
 
 # Install required OS tools
 RUN apt-get update \
+  && apt-get install -y software-properties-common \
+  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 \
+  && apt-add-repository 'deb http://repos.azulsystems.com/ubuntu stable main' \
+  && apt-get update \
   && apt-get -y upgrade \
   && apt-get install -qq -y --no-install-recommends \
     ccache \
@@ -43,6 +47,7 @@ RUN apt-get update \
     unzip \
     wget \
     zip \
+    zulu-8 \
     ssh \
 
 && rm -rf /var/lib/apt/lists/*
@@ -67,3 +72,4 @@ CMD ["images"]
 ARG OPENJDK_CORE_VERSION
 ENV OPENJDK_CORE_VERSION=$OPENJDK_CORE_VERSION
 ENV JDK_PATH=jdk
+ENV JAVA_HOME=/usr/lib/jvm/zulu-8-amd64

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -390,10 +390,6 @@ getGradleHome() {
     gradleJavaHome=${JAVA_HOME}
   fi
 
-  if [ -d "${BUILD_CONFIG[JDK_BOOT_DIR]}" ]; then
-    gradleJavaHome=${BUILD_CONFIG[JDK_BOOT_DIR]}
-  fi
-
   if [ ${JDK8_BOOT_DIR+x} ] && [ -d "${JDK8_BOOT_DIR}" ]; then
     gradleJavaHome=${JDK8_BOOT_DIR}
   fi


### PR DESCRIPTION
Fixes: #1216  
Ref: #1073 

These changes should allow for the Docker Builds to work, and subsequently the `buildDocker.sh` script.
The unbounded variables problem has been fixed by the `if` statements in `docker-build.sh`. It's not a very clean way of fixing it, but it works if the variables haven't been used in the case of not using `--debug-docker` or `--ssh` with `make-any-platform.sh`.
The problem of the `./gradlew` script no being found has been fixed by adding that into the Docker container, in `docker-build.sh` by the addition of `-v "${hostDir}/pipelines":/openjdk/pipelines \ `.

With the current version of Gradle that is put onto the containers, it can only be executed with Java-8. Therefore, all Dockerfiles have `zulu-8`, along with the JDK version needed for the `JDK_BOOT_DIR` var, with `zulu-8` being set to their `JAVA_HOME` variable. 

`build.sh` had to be changed slightly, as in its current form it is putting `JAVA_HOME` to be what the `JDK_BOOT_DIR` is.