### PR TITLE
Add custom  commands accessible from makejdk-any-platform

### DIFF
--- a/makejdk-any-platform.1
+++ b/makejdk-any-platform.1
@@ -119,7 +119,7 @@ the one you are trying to build.
 .BR \-k ", " \-\-keep
 if using docker, keep the container after the build.
 .TP
-.BR \-C ", " \-\-make-args " " \fI<args>\fR
+.BR \-\-make-args " " \fI<args>\fR
 specify any custom user make arguments.
 .TP
 .BR \-\-no\-adopt\-patches

--- a/makejdk-any-platform.1
+++ b/makejdk-any-platform.1
@@ -119,6 +119,9 @@ the one you are trying to build.
 .BR \-k ", " \-\-keep
 if using docker, keep the container after the build.
 .TP
+.BR \-C ", " \-\-make-args " " \fI<args>\fR
+specify any custom user make arguments.
+.TP
 .BR \-\-no\-adopt\-patches
 This indicates to the build script that the build does not have AdoptOpenJDKs additional patches applied.
 .TP

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -355,7 +355,7 @@ buildTemplatedFile() {
     MAKE_TEST_IMAGE=" test-image" # the added white space is deliberate as it's the last arg
   fi
 
-  FULL_MAKE_COMMAND="${BUILD_CONFIG[MAKE_COMMAND_NAME]} ${BUILD_CONFIG[MAKE_ARGS_FOR_ANY_PLATFORM]} ${MAKE_TEST_IMAGE}"
+  FULL_MAKE_COMMAND="${BUILD_CONFIG[MAKE_COMMAND_NAME]} ${BUILD_CONFIG[MAKE_ARGS_FOR_ANY_PLATFORM]} ${BUILD_CONFIG[USER_SUPPLIED_MAKE_ARGS]} ${MAKE_TEST_IMAGE}"
 
   # shellcheck disable=SC2002
   cat "$SCRIPT_DIR/build.template" | \

--- a/sbin/common/config_init.sh
+++ b/sbin/common/config_init.sh
@@ -410,7 +410,7 @@ function configDefaults() {
   # JVM variant, e.g. client or server, defaults to server
   BUILD_CONFIG[JVM_VARIANT]=${BUILD_CONFIG[JVM_VARIANT]:-""}
 
-    # Any extra config/make args provided by the user
+    # Any extra config / make args provided by the user
   BUILD_CONFIG[USER_SUPPLIED_CONFIGURE_ARGS]=${BUILD_CONFIG[USER_SUPPLIED_CONFIGURE_ARGS]:-""}
   BUILD_CONFIG[USER_SUPPLIED_MAKE_ARGS]=${BUILD_CONFIG[USER_SUPPLIED_MAKE_ARGS]:-""}
 

--- a/sbin/common/config_init.sh
+++ b/sbin/common/config_init.sh
@@ -84,6 +84,7 @@ USE_DOCKER
 USE_JEP319_CERTS
 USE_SSH
 USER_SUPPLIED_CONFIGURE_ARGS
+USER_SUPPLIED_MAKE_ARGS
 WORKING_DIR
 WORKSPACE_DIR
 )
@@ -181,6 +182,9 @@ function parseConfigurationArguments() {
 
         "--configure-args"  | "-C" )
         BUILD_CONFIG[USER_SUPPLIED_CONFIGURE_ARGS]="$1"; shift;;
+
+        "--make-args" )
+        BUILD_CONFIG[USER_SUPPLIED_MAKE_ARGS]="$1"; shift;;
 
         "--clean-docker-build" | "-c" )
         BUILD_CONFIG[CLEAN_DOCKER_BUILD]=true;;
@@ -406,8 +410,9 @@ function configDefaults() {
   # JVM variant, e.g. client or server, defaults to server
   BUILD_CONFIG[JVM_VARIANT]=${BUILD_CONFIG[JVM_VARIANT]:-""}
 
-  # Any extra args provided by the user
+    # Any extra config/make args provided by the user
   BUILD_CONFIG[USER_SUPPLIED_CONFIGURE_ARGS]=${BUILD_CONFIG[USER_SUPPLIED_CONFIGURE_ARGS]:-""}
+  BUILD_CONFIG[USER_SUPPLIED_MAKE_ARGS]=${BUILD_CONFIG[USER_SUPPLIED_MAKE_ARGS]:-""}
 
   BUILD_CONFIG[DOCKER]=${BUILD_CONFIG[DOCKER]:-"docker"}
 

--- a/sbin/common/config_init.sh
+++ b/sbin/common/config_init.sh
@@ -410,7 +410,7 @@ function configDefaults() {
   # JVM variant, e.g. client or server, defaults to server
   BUILD_CONFIG[JVM_VARIANT]=${BUILD_CONFIG[JVM_VARIANT]:-""}
 
-    # Any extra config / make args provided by the user
+  # Any extra config / make args provided by the user
   BUILD_CONFIG[USER_SUPPLIED_CONFIGURE_ARGS]=${BUILD_CONFIG[USER_SUPPLIED_CONFIGURE_ARGS]:-""}
   BUILD_CONFIG[USER_SUPPLIED_MAKE_ARGS]=${BUILD_CONFIG[USER_SUPPLIED_MAKE_ARGS]:-""}
 


### PR DESCRIPTION
Add the command line --make-args, similar to --config-args but for `make`

Fix for #1283