### PR TITLE
Add JDK8 dependency to Dockerfile

### DIFF
--- a/docker/jdk8/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk8/x86_64/ubuntu/Dockerfile
@@ -35,6 +35,7 @@ RUN apt-get update \
     gcc \
     git \
     libasound2-dev \
+    libconfig1-dev \ 
     libcups2-dev \
     libfreetype6-dev \
     libx11-dev \


### PR DESCRIPTION
Forgotten from the last PR;

Error message from last JDK8 DockerfileCheck run say it's required.
https://ci.adoptopenjdk.net/view/work%20in%20progress/job/SXA-DockerfileCheck/label=build-scaleway-x64-ubuntu-16-04-2,version=jdk8u/lastBuild/console