### PR TITLE
Changed 'libconfig' to 'libfontconfig' in jdk8 dockerfile

### DIFF
--- a/docker/jdk8/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk8/x86_64/ubuntu/Dockerfile
@@ -35,9 +35,9 @@ RUN apt-get update \
     gcc \
     git \
     libasound2-dev \
-    libconfig1-dev \ 
     libcups2-dev \
     libfreetype6-dev \
+    libfontconfig1-dev \
     libx11-dev \
     libxext-dev \
     libxrender-dev \


### PR DESCRIPTION
I mistakenly put an incorrect package name into the jdk8 Dockerfile. Changed to the correct package :-)