### PR TITLE
Fixed Openj9 Dockerfiles (8,11-13)

### DIFF
--- a/docker/jdk11/x86_64/ubuntu/Dockerfile-openj9
+++ b/docker/jdk11/x86_64/ubuntu/Dockerfile-openj9
@@ -10,38 +10,76 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-FROM openjdk_container
+FROM ubuntu:16.04
 
 LABEL maintainer="AdoptOpenJDK <adoption-discuss@openjdk.java.net>"
 
 # Install required OS tools
 RUN apt-get update \
+    && apt-get -y upgrade \
     && apt-get install -qq -y --no-install-recommends \
        autoconf \
        ccache \
        cpio \
+       curl \
        file \
        g++-4.8 \
        gcc-4.8 \
+       git \
+       gnupg2 \
+       libasound2-dev \
+       libcups2-dev \
        libdwarf-dev \
        libelf-dev \
-       libfontconfig \
+       libfontconfig1-dev \
        libfreetype6-dev \
        libnuma-dev \
+       libx11-dev \
+       libxext-dev \
+       libxrandr-dev \
+       libxrender-dev \
+       libxt-dev \
+       libxtst-dev \
+       make \
+       nasm \
+       openjdk-8-jdk \
        pkg-config \
        ssh \
+       software-properties-common \
+       unzip \
+       wget \
+       zip \
     && rm -rf /var/lib/apt/lists/*
 
-
 # Make sure build uses 4.8
-RUN rm /usr/bin/gcc \
-    && rm /usr/bin/g++ \
-    && rm /usr/bin/c++ \
+RUN rm -f /usr/bin/gcc \
+    && rm -f /usr/bin/g++ \
+    && rm -f /usr/bin/c++ \
     && ln -s /usr/bin/gcc-4.8 /usr/bin/gcc \
     && ln -s /usr/bin/g++-4.8 /usr/bin/g++ \
     && ln -s /usr/bin/g++-4.8 /usr/bin/c++
 
+# Pick up build instructions
+RUN mkdir -p /openjdk/target
+
+# Extract AdoptOpenJDK10 to set as JDK_BOOT_DIR.
+RUN wget 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk10?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk' -O jdk10.tar.gz
+RUN mkdir -p /usr/lib/jvm/jdk10 && tar -xvf /jdk10.tar.gz -C /usr/lib/jvm/jdk10 --strip-components=1
+RUN ln -sf /usr/lib/jvm/jdk10/bin/java /usr/bin/java
+RUN ln -sf /usr/lib/jvm/jdk10/bin/javac /usr/bin/javac
+
+COPY sbin /openjdk/sbin
+COPY workspace/config /openjdk/config
+COPY pipelines /openjdk/pipelines
+
+RUN mkdir -p /openjdk/build
+RUN useradd -ms /bin/bash build
+RUN chown -R build: /openjdk/
+USER build
+WORKDIR /openjdk/build/
+
 ARG OPENJDK_CORE_VERSION
 ENV OPENJDK_CORE_VERSION=$OPENJDK_CORE_VERSION
 ENV JDK_PATH=jdk
+ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+

--- a/docker/jdk11/x86_64/ubuntu/Dockerfile-openj9
+++ b/docker/jdk11/x86_64/ubuntu/Dockerfile-openj9
@@ -52,14 +52,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Make sure build uses 4.8
-RUN rm -f /usr/bin/gcc \
-    && rm -f /usr/bin/g++ \
-    && rm -f /usr/bin/c++ \
-    && ln -s /usr/bin/gcc-4.8 /usr/bin/gcc \
-    && ln -s /usr/bin/g++-4.8 /usr/bin/g++ \
-    && ln -s /usr/bin/g++-4.8 /usr/bin/c++
+RUN ln -sf /usr/bin/gcc-4.8 /usr/bin/gcc \
+    && ln -sf /usr/bin/g++-4.8 /usr/bin/g++ \
+    && ln -sf /usr/bin/g++-4.8 /usr/bin/c++
 
-# Pick up build instructions
 RUN mkdir -p /openjdk/target
 
 # Extract AdoptOpenJDK10 to set as JDK_BOOT_DIR.
@@ -74,7 +70,7 @@ COPY pipelines /openjdk/pipelines
 
 RUN mkdir -p /openjdk/build
 RUN useradd -ms /bin/bash build
-RUN chown -R build: /openjdk/
+RUN chown -R build /openjdk/
 USER build
 WORKDIR /openjdk/build/
 

--- a/docker/jdk12/x86_64/ubuntu/Dockerfile-openj9
+++ b/docker/jdk12/x86_64/ubuntu/Dockerfile-openj9
@@ -11,37 +11,74 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM openjdk_container
+FROM ubuntu:16.04
 
-LABEL maintainer="AdoptOpenJDK <adoption-discuss@openjdk.java.net>"
+LABEL maintainer="AdoptOpenJDK <adoption-discuss@openjdk.java.net">
 
 # Install required OS tools
 RUN apt-get update \
+    && apt-get -y upgrade \
     && apt-get install -qq -y --no-install-recommends \
        autoconf \
        ccache \
        cpio \
+       curl \
        file \
        g++-4.8 \
        gcc-4.8 \
+       git \
+       gnupg2 \
+       libasound2-dev \
+       libcups2-dev \
        libdwarf-dev \
        libelf-dev \
-       libfontconfig \
+       libfontconfig1-dev \
        libfreetype6-dev \
        libnuma-dev \
+       libx11-dev \
+       libxext-dev \
+       libxrandr-dev \
+       libxrender-dev \
+       libxt-dev \
+       libxtst-dev \
+       make \
+       nasm \
+       openjdk-8-jdk \
        pkg-config \
        ssh \
+       unzip \
+       wget \
+       zip \
     && rm -rf /var/lib/apt/lists/*
 
-
 # Make sure build uses 4.8
-RUN rm /usr/bin/gcc \
-    && rm /usr/bin/g++ \
-    && rm /usr/bin/c++ \
+RUN rm -f /usr/bin/gcc \
+    && rm -f /usr/bin/g++ \
+    && rm -f /usr/bin/c++ \
     && ln -s /usr/bin/gcc-4.8 /usr/bin/gcc \
     && ln -s /usr/bin/g++-4.8 /usr/bin/g++ \
     && ln -s /usr/bin/g++-4.8 /usr/bin/c++
 
+# Pick up build instructions
+RUN mkdir -p /openjdk/target
+
+# Extract AdoptOpenJDK11 to set as JDK_BOOT_DIR.
+RUN wget 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk11?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk' -O jdk11.tar.gz
+RUN mkdir -p /usr/lib/jvm/jdk11 && tar -xvf /jdk11.tar.gz -C /usr/lib/jvm/jdk11 --strip-components=1
+RUN ln -sf /usr/lib/jvm/jdk11/bin/javac /usr/bin/javac
+RUN ln -sf /usr/lib/jvm/jdk11/bin/javac /usr/bin/javac
+
+COPY sbin /openjdk/sbin
+COPY workspace/config /openjdk/config
+COPY pipelines /openjdk/pipelines
+
+RUN mkdir -p /openjdk/build
+RUN useradd -ms /bin/bash build
+RUN chown -R build: /openjdk/
+USER build
+WORKDIR /openjdk/build/
+
 ARG OPENJDK_CORE_VERSION
 ENV OPENJDK_CORE_VERSION=$OPENJDK_CORE_VERSION
 ENV JDK_PATH=jdk
+ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64

--- a/docker/jdk12/x86_64/ubuntu/Dockerfile-openj9
+++ b/docker/jdk12/x86_64/ubuntu/Dockerfile-openj9
@@ -52,14 +52,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Make sure build uses 4.8
-RUN rm -f /usr/bin/gcc \
-    && rm -f /usr/bin/g++ \
-    && rm -f /usr/bin/c++ \
-    && ln -s /usr/bin/gcc-4.8 /usr/bin/gcc \
-    && ln -s /usr/bin/g++-4.8 /usr/bin/g++ \
-    && ln -s /usr/bin/g++-4.8 /usr/bin/c++
+RUN ln -sf /usr/bin/gcc-4.8 /usr/bin/gcc \
+    && ln -sf /usr/bin/g++-4.8 /usr/bin/g++ \
+    && ln -sf /usr/bin/g++-4.8 /usr/bin/c++
 
-# Pick up build instructions
 RUN mkdir -p /openjdk/target
 
 # Extract AdoptOpenJDK11 to set as JDK_BOOT_DIR.
@@ -74,7 +70,7 @@ COPY pipelines /openjdk/pipelines
 
 RUN mkdir -p /openjdk/build
 RUN useradd -ms /bin/bash build
-RUN chown -R build: /openjdk/
+RUN chown -R build /openjdk/
 USER build
 WORKDIR /openjdk/build/
 

--- a/docker/jdk13/x86_64/ubuntu/Dockerfile-openj9
+++ b/docker/jdk13/x86_64/ubuntu/Dockerfile-openj9
@@ -52,14 +52,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Make sure build uses 4.8
-RUN rm -f /usr/bin/gcc \
-    && rm -f /usr/bin/g++ \
-    && rm -f /usr/bin/c++ \
-    && ln -s /usr/bin/gcc-4.8 /usr/bin/gcc \
-    && ln -s /usr/bin/g++-4.8 /usr/bin/g++ \
-    && ln -s /usr/bin/g++-4.8 /usr/bin/c++
+RUN ln -sf /usr/bin/gcc-4.8 /usr/bin/gcc \
+    && ln -sf /usr/bin/g++-4.8 /usr/bin/g++ \
+    && ln -sf /usr/bin/g++-4.8 /usr/bin/c++
 
-# Pick up build instructions
 RUN mkdir -p /openjdk/target
 
 # Extract AdoptOpenJDK12 for JDK_BOOT_DIR.
@@ -74,7 +70,7 @@ COPY pipelines /openjdk/pipelines
 
 RUN mkdir -p /openjdk/build
 RUN useradd -ms /bin/bash build
-RUN chown -R build: /openjdk/
+RUN chown -R build /openjdk/
 USER build
 WORKDIR /openjdk/build/
 

--- a/docker/jdk13/x86_64/ubuntu/Dockerfile-openj9
+++ b/docker/jdk13/x86_64/ubuntu/Dockerfile-openj9
@@ -11,37 +11,75 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM openjdk_container
+FROM ubuntu:16.04
 
 LABEL maintainer="AdoptOpenJDK <adoption-discuss@openjdk.java.net>"
 
 # Install required OS tools
 RUN apt-get update \
+    && apt-get -y upgrade \
     && apt-get install -qq -y --no-install-recommends \
        autoconf \
        ccache \
        cpio \
+       curl \
        file \
        g++-4.8 \
        gcc-4.8 \
+       git \
+       gnupg2 \
+       libasound2-dev \
+       libcups2-dev \
        libdwarf-dev \
        libelf-dev \
-       libfontconfig \
+       libfontconfig1-dev \
        libfreetype6-dev \
        libnuma-dev \
+       libx11-dev \
+       libxext-dev \
+       libxrandr-dev \
+       libxrender-dev \
+       libxt-dev \
+       libxtst-dev \
+       make \
+       nasm \
+       openjdk-8-jdk \
        pkg-config \
        ssh \
+       unzip \
+       wget \
+       zip \
     && rm -rf /var/lib/apt/lists/*
 
-
 # Make sure build uses 4.8
-RUN rm /usr/bin/gcc \
-    && rm /usr/bin/g++ \
-    && rm /usr/bin/c++ \
+RUN rm -f /usr/bin/gcc \
+    && rm -f /usr/bin/g++ \
+    && rm -f /usr/bin/c++ \
     && ln -s /usr/bin/gcc-4.8 /usr/bin/gcc \
     && ln -s /usr/bin/g++-4.8 /usr/bin/g++ \
     && ln -s /usr/bin/g++-4.8 /usr/bin/c++
 
+# Pick up build instructions
+RUN mkdir -p /openjdk/target
+
+# Extract AdoptOpenJDK12 for JDK_BOOT_DIR.
+RUN wget 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk12?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk' -O jdk12.tar.gz
+RUN mkdir -p /usr/lib/jvm/jdk12 && tar -xvf /jdk12.tar.gz -C /usr/lib/jvm/jdk12 --strip-components=1
+RUN ln -sf /usr/lib/jvm/jdk12/bin/java /usr/bin/java
+RUN ln -sf /usr/lib/jvm/jdk12/bin/javac /usr/bin/javac
+
+COPY sbin /openjdk/sbin
+COPY workspace/config /openjdk/config
+COPY pipelines /openjdk/pipelines
+
+RUN mkdir -p /openjdk/build
+RUN useradd -ms /bin/bash build
+RUN chown -R build: /openjdk/
+USER build
+WORKDIR /openjdk/build/
+
 ARG OPENJDK_CORE_VERSION
 ENV OPENJDK_CORE_VERSION=$OPENJDK_CORE_VERSION
 ENV JDK_PATH=jdk
+ENV JDK8_BOOT_DIR=/usr/lib/jvm/java-8-openjdk-amd64
+

--- a/docker/jdk8/x86_64/ubuntu/Dockerfile-openj9
+++ b/docker/jdk8/x86_64/ubuntu/Dockerfile-openj9
@@ -50,14 +50,10 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Make sure build uses 4.8
-RUN rm -f /usr/bin/gcc \
-    && rm -f /usr/bin/g++ \
-    && rm -f /usr/bin/c++ \
-    && ln -s /usr/bin/gcc-4.8 /usr/bin/gcc \
-    && ln -s /usr/bin/g++-4.8 /usr/bin/g++ \
-    && ln -s /usr/bin/g++-4.8 /usr/bin/c++
+RUN ln -sf /usr/bin/gcc-4.8 /usr/bin/gcc \
+    && ln -sf /usr/bin/g++-4.8 /usr/bin/g++ \
+    && ln -sf /usr/bin/g++-4.8 /usr/bin/c++
 
-# Pick up build instructions
 RUN mkdir -p /openjdk/target
 
 COPY sbin /openjdk/sbin
@@ -66,7 +62,7 @@ COPY pipelines /openjdk/pipelines
 
 RUN mkdir -p /openjdk/build
 RUN useradd -ms /bin/bash build
-RUN chown -R build: /openjdk/
+RUN chown -R build /openjdk/
 USER build
 WORKDIR /openjdk/build/
 

--- a/docker/jdk8/x86_64/ubuntu/Dockerfile-openj9
+++ b/docker/jdk8/x86_64/ubuntu/Dockerfile-openj9
@@ -13,7 +13,7 @@
 
 FROM ubuntu:16.04
 
-MAINTAINER AdoptOpenJDK <adoption-discuss@openjdk.java.net>
+LABEL maintainer="AdoptOpenJDK <adoption-discuss@openjdk.java.net>"
 
 # Install required OS tools
 RUN apt-get update \
@@ -73,3 +73,4 @@ WORKDIR /openjdk/build/
 ARG OPENJDK_CORE_VERSION
 ENV OPENJDK_CORE_VERSION=$OPENJDK_CORE_VERSION
 ENV JDK_PATH=jdk
+ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64


### PR DESCRIPTION
Based mostly off the JDK8 fixed openj9 dockerfile from #1171
- Added an additional dependency (on top of the JDK8 additions) that 11-13 needed.
- Set JAVA_HOME in jdk8,11 and 12 dockerfiles.
- 13 needed `JDK8_BOOT_DIR` to be set instead of `JAVA_HOME`. Not entirely sure why, but it couldn't find java 8 for Gradle to use without it.
- All of them use Ubuntu 16 in the containers, as opposed to Ubuntu 18, as this stopped a freemarker checksum issue that has occurred since updating to Freemarker 2.3.29
- Ensured `MAINTAINER` is `LABEL maintainer=...`

Tested and working on MacOS :)