### PR TITLE
FreeBSD sync: Push changes as well as tags

### DIFF
--- a/git-hg/freebsdRepoSync.sh
+++ b/git-hg/freebsdRepoSync.sh
@@ -53,6 +53,7 @@ mergeRepo() {
 
 # Push
 pushMerge() {
+	git push || exit 1
 	git push --tags || exit 1
 }
 


### PR DESCRIPTION
* Issuing 'git push --tags' will only push the tags, so also do a regular
  'git push' as well to push the changes.

  Interestingly, 'git fetch --tags' fetches both the changes and the tags