### PR TITLE
Pull changes when working with an existing repository

### DIFF
--- a/git-hg/freebsdRepoSync.sh
+++ b/git-hg/freebsdRepoSync.sh
@@ -21,6 +21,7 @@ usage() {
 initRepo() {
 	if [ -d ${REPO} ]; then
 		cd ${REPO}
+		git pull || exit 1
 		git reset --hard origin/${SYNC_BRANCH} || exit 1
 	else
 		git clone ${CHILD_REPO_PATH}/${REPO}.git || exit 1


### PR DESCRIPTION
* In the situation where the repository already exists, pull changes
  before attempting to reset ourselves to origin/branch to ensure that
  all of the origin changes are present.  Otherwise there may be
  additional changes on the origin that will cause push to fail.