### PR TITLE
Configure path variables accordingly when choosing to build in Docker containers

### DIFF
--- a/docker-build.sh
+++ b/docker-build.sh
@@ -82,6 +82,41 @@ buildOpenJDKViaDocker()
   # shellcheck disable=SC1090
   source "${BUILD_CONFIG[DOCKER_FILE_PATH]}/dockerConfiguration.sh"
 
+    local openjdk_core_version=${BUILD_CONFIG[OPENJDK_CORE_VERSION]}
+    local openjdk_test_image_path=""
+    local jdk_path=""
+    local jre_path=""
+
+    if [ "$openjdk_core_version" == "${JDK8_CORE_VERSION}" ]; then
+      case "${BUILD_CONFIG[OS_KERNEL_NAME]}" in
+      "darwin")
+        jdk_path="j2sdk-bundle/jdk*.jdk"
+        jre_path="j2re-bundle/jre*.jre"
+      ;;
+      *)
+        jdk_path="j2sdk-image"
+        jre_path="j2re-image"
+      ;;
+      esac
+    else
+      case "${BUILD_CONFIG[OS_KERNEL_NAME]}" in
+      "darwin")
+        jdk_path="jdk-bundle/jdk-*.jdk"
+        jre_path="jre-bundle/jre-*.jre"
+      ;;
+      *)
+        jdk_path="jdk"
+        jre_path="jre"
+      ;;
+      esac
+    # Set the test image path for JDK 11+
+      openjdk_test_image_path="test"
+    fi
+
+    BUILD_CONFIG[JDK_PATH]=$jdk_path
+    BUILD_CONFIG[JRE_PATH]=$jre_path
+    BUILD_CONFIG[TEST_IMAGE_PATH]=$openjdk_test_image_path
+
   if [ -z "$(command -v docker)" ]; then
      # shellcheck disable=SC2154
     echo "Error, please install docker and ensure that it is in your path and running!"

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -84,37 +84,37 @@ buildOpenJDKViaDocker()
 
     local openjdk_core_version=${BUILD_CONFIG[OPENJDK_CORE_VERSION]}
     local openjdk_test_image_path=""
-    local jdk_path=""
-    local jre_path=""
+    local jdk_directory=""
+    local jre_directory=""
 
     if [ "$openjdk_core_version" == "${JDK8_CORE_VERSION}" ]; then
       case "${BUILD_CONFIG[OS_KERNEL_NAME]}" in
       "darwin")
-        jdk_path="j2sdk-bundle/jdk*.jdk"
-        jre_path="j2re-bundle/jre*.jre"
+        jdk_directory="j2sdk-bundle/jdk*.jdk"
+        jre_directory="j2re-bundle/jre*.jre"
       ;;
       *)
-        jdk_path="j2sdk-image"
-        jre_path="j2re-image"
+        jdk_directory="j2sdk-image"
+        jre_directory="j2re-image"
       ;;
       esac
     else
       case "${BUILD_CONFIG[OS_KERNEL_NAME]}" in
       "darwin")
-        jdk_path="jdk-bundle/jdk-*.jdk"
-        jre_path="jre-bundle/jre-*.jre"
+        jdk_directory="jdk-bundle/jdk-*.jdk"
+        jre_directory="jre-bundle/jre-*.jre"
       ;;
       *)
-        jdk_path="jdk"
-        jre_path="jre"
+        jdk_directory="jdk"
+        jre_directory="jre"
       ;;
       esac
     # Set the test image path for JDK 11+
       openjdk_test_image_path="test"
     fi
 
-    BUILD_CONFIG[JDK_PATH]=$jdk_path
-    BUILD_CONFIG[JRE_PATH]=$jre_path
+    BUILD_CONFIG[JDK_PATH]=$jdk_directory
+    BUILD_CONFIG[JRE_PATH]=$jre_directory
     BUILD_CONFIG[TEST_IMAGE_PATH]=$openjdk_test_image_path
 
   if [ -z "$(command -v docker)" ]; then

--- a/sbin/common/config_init.sh
+++ b/sbin/common/config_init.sh
@@ -318,6 +318,9 @@ function configDefaults() {
     arch=$(uname -p | sed 's/powerpc/ppc/')
   fi
 
+  BUILD_CONFIG[JDK_PATH]=""
+  BUILD_CONFIG[JRE_PATH]=""
+
   # The O/S architecture, e.g. x86_64 for a modern intel / Mac OS X
   BUILD_CONFIG[OS_ARCHITECTURE]=${arch}
 


### PR DESCRIPTION
This PR is a solution to issue #1293 
The JRE_PATH and JDK_PATH variables are configured according to the OS of the docker container, not the native host.