### PR TITLE
Use `/usr/libexec/java_home` on macOS.

### DIFF
--- a/sbin/common/common.sh
+++ b/sbin/common/common.sh
@@ -124,7 +124,7 @@ function setBootJdk() {
 
     # shellcheck disable=SC2046,SC2230
     if [[ "${BUILD_CONFIG[OS_KERNEL_NAME]}" == "darwin" ]]; then
-      BUILD_CONFIG[JDK_BOOT_DIR]=$(dirname $(dirname $(readlink $(which javac))))
+      BUILD_CONFIG[JDK_BOOT_DIR]="$(/usr/libexec/java_home)"
     else
       BUILD_CONFIG[JDK_BOOT_DIR]=$(dirname $(dirname $(readlink -f $(which javac))))
     fi


### PR DESCRIPTION
`readlink` fails if `$(which javac)` is not a symlink.