### PR TITLE
Dockerfiles: Made container user UID and host UID the same

### DIFF
--- a/docker-build.sh
+++ b/docker-build.sh
@@ -66,7 +66,7 @@ buildDockerContainer()
 
   writeConfigToFile
 
-  ${BUILD_CONFIG[DOCKER]} build -t "${BUILD_CONFIG[CONTAINER_NAME]}" -f "${dockerFile}" . --build-arg "OPENJDK_CORE_VERSION=${BUILD_CONFIG[OPENJDK_CORE_VERSION]}"
+  ${BUILD_CONFIG[DOCKER]} build -t "${BUILD_CONFIG[CONTAINER_NAME]}" -f "${dockerFile}" . --build-arg "OPENJDK_CORE_VERSION=${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" --build-arg "HostUID=${UID}"
 }
 
 # Execute the (Adopt) OpenJDK build inside the Docker Container

--- a/docker/jdk11/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk11/x86_64/ubuntu/Dockerfile
@@ -71,8 +71,11 @@ RUN ln -sf /usr/lib/jvm/jdk10/bin/javac /usr/bin/javac
 COPY sbin /openjdk/sbin
 COPY workspace/config /openjdk/config
 
+# Create User "build"
+ARG HostUID
+ENV HostUID=$HostUID
 RUN mkdir -p /openjdk/build
-RUN useradd -ms /bin/bash build
+RUN useradd -u $HostUID -ms /bin/bash build
 RUN chown -R build: /openjdk/
 USER build
 WORKDIR /openjdk/build/

--- a/docker/jdk13/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk13/x86_64/ubuntu/Dockerfile
@@ -72,8 +72,11 @@ RUN ln -sf /usr/lib/jvm/jdk12/bin/javac /usr/bin/javac
 COPY sbin /openjdk/sbin
 COPY workspace/config /openjdk/config
 
+# Create User "build"
+ARG HostUID
+ENV HostUID=$HostUID
 RUN mkdir -p /openjdk/build
-RUN useradd -ms /bin/bash build
+RUN useradd -u $HostUID -ms /bin/bash build
 RUN chown -R build: /openjdk/
 USER build
 WORKDIR /openjdk/build/

--- a/docker/jdk8/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk8/x86_64/ubuntu/Dockerfile
@@ -64,8 +64,11 @@ RUN ln -sf /usr/lib/jvm/jdk8/bin/javac /usr/bin/javac
 COPY sbin /openjdk/sbin
 COPY workspace/config /openjdk/config
 
+# Create User "build"
+ARG HostUID
+ENV HostUID=$HostUID
 RUN mkdir -p /openjdk/build
-RUN useradd -ms /bin/bash build
+RUN useradd -u $HostUID -ms /bin/bash build
 RUN chown -R build: /openjdk/
 USER build
 WORKDIR /openjdk/build/


### PR DESCRIPTION
An issue found whilst I was attempting to setup the `SXA-DockerfileCheck` job onto `infra-vagrant-1`. Every job failed due to an inability to find a file that was there, whenever running from the `buildDocker` script as the Jenkins user, however worked for the main user.
Some digging showed that inside the container, the files that were shared between the host system and the container were owned by UID 1001, which was not owned by any user in the container, but did correspond to the Jenkins UID of the host machine.
As such, I've changed it so the user made within the docker container ("build") will have the same UID from the person that started the `buildDocker.sh` script.