### PR TITLE
Dockerfiles: Changed container UID to host UID for j9 files

### DIFF
--- a/docker/jdk11/x86_64/ubuntu/Dockerfile-openj9
+++ b/docker/jdk11/x86_64/ubuntu/Dockerfile-openj9
@@ -72,7 +72,7 @@ COPY pipelines /openjdk/pipelines
 ARG HostUID
 ENV HostUID=$HostUID
 RUN mkdir -p /openjdk/build
-RUN useradd -u HostUID -ms /bin/bash build
+RUN useradd -u $HostUID -ms /bin/bash build
 RUN chown -R build /openjdk/
 USER build
 WORKDIR /openjdk/build/

--- a/docker/jdk13/x86_64/ubuntu/Dockerfile-openj9
+++ b/docker/jdk13/x86_64/ubuntu/Dockerfile-openj9
@@ -71,8 +71,8 @@ COPY pipelines /openjdk/pipelines
 # Create User "build"
 ARG HostUID
 ENV HostUID=$HostUID
-RUN mkdir -u HostUID -p /openjdk/build
-RUN useradd -ms /bin/bash build
+RUN mkdir -p /openjdk/build
+RUN useradd -u $HostUID -ms /bin/bash build
 RUN chown -R build /openjdk/
 USER build
 WORKDIR /openjdk/build/

--- a/docker/jdk8/x86_64/ubuntu/Dockerfile-openj9
+++ b/docker/jdk8/x86_64/ubuntu/Dockerfile-openj9
@@ -63,8 +63,8 @@ COPY pipelines /openjdk/pipelines
 # Create User "build"
 ARG HostUID
 ENV HostUID=$HostUID
-RUN mkdir -u $HostUID -p /openjdk/build
-RUN useradd -ms /bin/bash build
+RUN mkdir -p /openjdk/build
+RUN useradd -u $HostUID -ms /bin/bash build
 RUN chown -R build /openjdk/
 USER build
 WORKDIR /openjdk/build/


### PR DESCRIPTION
*Correctly* changing the openj9 Dockerfiles so the container user has the same UID as the user who started the Dockerfiles (or the `buildDocker` script)