### PR TITLE
docker-build.sh: Fixed removal of containers; Works when running in parallel

### DIFF
--- a/docker-build.sh
+++ b/docker-build.sh
@@ -157,10 +157,11 @@ buildOpenJDKViaDocker()
   fi
 
   # Run the command string in Docker
-  ${BUILD_CONFIG[DOCKER]} run "${commandString[@]}"
+  ${BUILD_CONFIG[DOCKER]} run --name "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" "${commandString[@]}"
  
   # If we didn't specify to keep the container then remove it
-  if [[ -z ${BUILD_CONFIG[KEEP_CONTAINER]} ]] ; then
-    ${BUILD_CONFIG[DOCKER]} ps -a | awk '{ print $1,$2 }' | grep "${BUILD_CONFIG[CONTAINER_NAME]}" | awk '{print $1 }' | xargs -I {} "${BUILD_CONFIG[DOCKER]}" rm {}
+  if [[ "${BUILD_CONFIG[KEEP_CONTAINER]}" == "false" ]] ; then
+	  echo "Removing container ${BUILD_CONFIG[OPENJDK_CORE_VERSION]}"
+	  ${BUILD_CONFIG[DOCKER]} ps -a | awk '{ print $1,$(NF) }' | grep "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" | awk '{print $1 }' | xargs -I {} "${BUILD_CONFIG[DOCKER]}" rm {}
   fi
 }


### PR DESCRIPTION
Initially looked at due to the `build-scaleway-x64-ubuntu-16-04-2` machine constantly filling up. 
- The `if` statement at the end always returned false, as `-z` checks if the variable is `null`, however it was `false`.
- The script now looks for the name of the container instead of the image's name `openjdk_container`. 
- When building the container, the name is specified to be whatever version of openjdk the container will be building.

This was done to allow multiple instances of `buildDocker.sh` to run on the same computer, in the case of the Jenkins job `SXA-DockerfileCheck`. Before, the container was removed based off the image name `openjdk_container`. However, when running multiple docker builds, only the latest container would have that image's name, the other container's images would be renamed to a random string. This would result in only the latest container being removed.