### PR TITLE
Dockerfiles-J9: Use GCC7.3, not 7.4

### DIFF
--- a/docker/jdk11/x86_64/ubuntu/Dockerfile-openj9
+++ b/docker/jdk11/x86_64/ubuntu/Dockerfile-openj9
@@ -49,12 +49,17 @@ RUN apt-get update \
        zip \
     && rm -rf /var/lib/apt/lists/*
 
-# Make sure build uses GCC 7
-RUN add-apt-repository ppa:ubuntu-toolchain-r/test \
-  && apt-get update \
-  && apt-get install -y gcc-7 g++-7 \
-  && ln -sf /usr/bin/gcc-7 /usr/bin/gcc \
-  && ln -sf /usr/bin/g++-7 /usr/bin/g++
+# Make sure build uses GCC 7.3
+RUN cd /usr/local \
+  && wget -O gcc-7.tar.xz "https://ci.adoptopenjdk.net/userContent/gcc/gcc730+ccache.x86_64.tar.xz" \
+  && tar -xJf gcc-7.tar.xz --strip-components=1 \
+  && rm -rf gcc-7.tar.xz
+  
+# Create links for GCC to access the C library and gcc,g++
+RUN ln -s /usr/lib/x86_64-linux-gnu /usr/lib64 \
+  && ln -s /usr/include/x86_64-linux-gnu/* /usr/local/include \
+  && ln -s /usr/local/bin/g++-7.3 /usr/bin/g++ \
+  && ln -s /usr/local/bin/gcc-7.3 /usr/bin/gcc
 
 RUN mkdir -p /openjdk/target
 

--- a/docker/jdk13/x86_64/ubuntu/Dockerfile-openj9
+++ b/docker/jdk13/x86_64/ubuntu/Dockerfile-openj9
@@ -50,12 +50,17 @@ RUN apt-get update \
        zip \
     && rm -rf /var/lib/apt/lists/*
 
-# Make sure build uses GCC 7
-RUN add-apt-repository ppa:ubuntu-toolchain-r/test \
-  && apt-get update \
-  && apt-get install -y gcc-7 g++-7 \
-  && ln -sf /usr/bin/gcc-7 /usr/bin/gcc \
-  && ln -sf /usr/bin/g++-7 /usr/bin/g++
+# Make sure build uses GCC 7.3
+RUN cd /usr/local \
+  && wget -O gcc-7.tar.xz "https://ci.adoptopenjdk.net/userContent/gcc/gcc730+ccache.x86_64.tar.xz" \
+  && tar -xJf gcc-7.tar.xz --strip-components=1 \
+  && rm -rf gcc-7.tar.xz
+  
+# Create links for GCC to access the C library and gcc,g++
+RUN ln -s /usr/lib/x86_64-linux-gnu /usr/lib64 \
+  && ln -s /usr/include/x86_64-linux-gnu/* /usr/local/include \
+  && ln -s /usr/local/bin/g++-7.3 /usr/bin/g++ \
+  && ln -s /usr/local/bin/gcc-7.3 /usr/bin/gcc
 
 RUN mkdir -p /openjdk/target
 


### PR DESCRIPTION
JDK 11+ need GCC 7.3 specifically to build correctly- Pulling from `ppa:ubuntu-toolchain-r/test` will give it 7.4.
If not, the following error message is given:
```
VMAccess.cpp: In function 'void acquireExclusiveVMAccess(J9VMThread*)':
VMAccess.cpp:154:132: error: self-comparison always evaluates to true [-Werror=tautological-compare]
     J9_LINEAR_LINKED_LIST_ADD(exclusiveVMAccessQueueNext,exclusiveVMAccessQueuePrevious,vm->exclusiveVMAccessQueueHead,vmThread);
                                                                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ^                                  
VMAccess.cpp:154:287: error: self-comparison always evaluates to true [-Werror=tautological-compare]
     J9_LINEAR_LINKED_LIST_ADD(exclusiveVMAccessQueueNext,exclusiveVMAccessQueuePrevious,vm->exclusiveVMAccessQueueHead,vmThread);
                                                                                                                                                                                                                                                                                               ^                                  
cc1plus: all warnings being treated as errors
../makelib/targets.mk:284: recipe for target 'VMAccess.o' failed
```