### PR TITLE
Set UID/GID to root/root (0/0) in the tarball contents when using gnu tar

### DIFF
--- a/sbin/common/common.sh
+++ b/sbin/common/common.sh
@@ -114,7 +114,12 @@ createOpenJDKArchive()
   if [[ "${BUILD_CONFIG[OS_KERNEL_NAME]}" = *"cygwin"* ]]; then
       zip -r -q "${fileName}.zip" ./"${repoDir}"
   else
-      tar -cf - "${repoDir}"/ | GZIP=-9 $COMPRESS -c > $fileName.tar.gz
+      # Create archive with UID/GID 0 for root if using GNU tar
+      if tar --version 2>&1 | grep GNU > /dev/null; then
+          tar -cf - --owner=root --group=root "${repoDir}"/ | GZIP=-9 $COMPRESS -c > $fileName.tar.gz
+      else
+          tar -cf - "${repoDir}"/ | GZIP=-9 $COMPRESS -c > $fileName.tar.gz
+      fi
   fi
 }
 


### PR DESCRIPTION
This has been raised by a user in the slack channel and I think it's probably a good idea for security purposes to have a consistent user used on the files inside the tarballs we produce.

Am testing this out at https://ci.adoptopenjdk.net/view/work%20in%20progress/job/SXA-xlinux-build and https://ci.adoptopenjdk.net/view/work%20in%20progress/job/SXA-aix-build to verify that it works before getting a full review/merge.