### PR TITLE
DockerBuild: Made sure variables are named appropriately

### DIFF
--- a/docker-build.sh
+++ b/docker-build.sh
@@ -157,11 +157,11 @@ buildOpenJDKViaDocker()
   fi
 
   # Run the command string in Docker
-  ${BUILD_CONFIG[DOCKER]} run --name "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" "${commandString[@]}"
+  ${BUILD_CONFIG[DOCKER]} run --name "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}-${BUILD_CONFIG[BUILD_VARIANT]}" "${commandString[@]}"
  
   # If we didn't specify to keep the container then remove it
   if [[ "${BUILD_CONFIG[KEEP_CONTAINER]}" == "false" ]] ; then
-	  echo "Removing container ${BUILD_CONFIG[OPENJDK_CORE_VERSION]}"
-	  ${BUILD_CONFIG[DOCKER]} ps -a | awk '{ print $1,$(NF) }' | grep "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" | awk '{print $1 }' | xargs -I {} "${BUILD_CONFIG[DOCKER]}" rm {}
+	  echo "Removing container ${BUILD_CONFIG[OPENJDK_CORE_VERSION]}-${BUILD_CONFIG[BUILD_VARIANT]}"
+	  ${BUILD_CONFIG[DOCKER]} ps -a | awk '{ print $1,$(NF) }' | grep "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}-${BUILD_CONFIG[BUILD_VARIANT]}" | awk '{print $1 }' | xargs -I {} "${BUILD_CONFIG[DOCKER]}" rm {}
   fi
 }

--- a/sbin/common/common.sh
+++ b/sbin/common/common.sh
@@ -58,7 +58,7 @@ function crossPlatformRealPath() {
 }
 
 function setDockerVolumeSuffix() {
-  local suffix=$1
+  local suffix="$1-${BUILD_CONFIG[BUILD_VARIANT]}"
   if [[ "${BUILD_CONFIG[DOCKER_SOURCE_VOLUME_NAME]}" != *"-${suffix}" ]]; then
     BUILD_CONFIG[DOCKER_SOURCE_VOLUME_NAME]="${BUILD_CONFIG[DOCKER_SOURCE_VOLUME_NAME]}-${suffix}"
   fi


### PR DESCRIPTION
This change will more appropriately name the volume sources for the docker containers, and the containers themselves. This change will make it so when running `./makejdk-any-platform.sh --docker` and `./buildDocker.sh` , there will be unique volumes for the J9 and Hotspot variants. Without this, Jenkins jobs that run 2 instances of `./buildDocker.sh` on the same OS but different build variants at the same time, result in one of the two containers outputting: 
```
Incorrect Source Code for <jdk_version>.  This is an error, please check what is in /openjdk/build and manually remove, exiting...
```
as it's detecting the other build variant's source code.