### PR TITLE
Reset before pull

### DIFF
--- a/git-hg/freebsdRepoSync.sh
+++ b/git-hg/freebsdRepoSync.sh
@@ -21,8 +21,10 @@ usage() {
 initRepo() {
 	if [ -d ${REPO} ]; then
 		cd ${REPO}
-		git pull || exit 1
+		# Some local changes may prevent a pull from succeeding
+		# To avoid that, reset the repo here
 		git reset --hard origin/${SYNC_BRANCH} || exit 1
+		git pull || exit 1
 	else
 		git clone ${CHILD_REPO_PATH}/${REPO}.git || exit 1
 		cd ${REPO}


### PR DESCRIPTION
* Reset to the upstream state before doing a pull instead of after.  If
  there were conflicts during the previous merge then the pull will fail
  otherwise.  Since we've done a reset prior to the pull, there is no need
  to do so after, since local changes were wiped out by the initial reset.

Sponsored by:	The FreeBSD Foundation