### PR TITLE
Enable large heap OpenJ9 builds for s390xLinux and ppc64leLinux

### DIFF
--- a/pipelines/build/openjdk10_pipeline.groovy
+++ b/pipelines/build/openjdk10_pipeline.groovy
@@ -85,7 +85,7 @@ def buildConfigurations = [
                 test                : false
         ],
         */
-        "linuxXL"    : [
+        x64LinuxXL    : [
                 os                   : 'linux',
                 additionalNodeLabels : 'centos6',
                 arch                 : 'x64',

--- a/pipelines/build/openjdk11_pipeline.groovy
+++ b/pipelines/build/openjdk11_pipeline.groovy
@@ -132,10 +132,34 @@ def buildConfigurations = [
                 test                : false
         ],
         */
-        linuxXL    : [
+        x64LinuxXL    : [
                 os                   : 'linux',
                 additionalNodeLabels : 'centos6',
                 arch                 : 'x64',
+                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                additionalFileNameTag: "linuxXL",
+                configureArgs        : '--with-noncompressedrefs --disable-ccache'
+        ],
+        s390xLinuxXL    : [
+                os                   : 'linux',
+                additionalNodeLabels : 'centos6',
+                arch                 : 's390x',
+                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                additionalFileNameTag: "linuxXL",
+                configureArgs        : '--with-noncompressedrefs --disable-ccache'
+        ],
+        ppc64leLinuxXL    : [
+                os                   : 'linux',
+                additionalNodeLabels : 'centos6',
+                arch                 : 'ppc64le',
+                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                additionalFileNameTag: "linuxXL",
+                configureArgs        : '--with-noncompressedrefs --disable-ccache'
+        ],
+        aarch64LinuxXL    : [
+                os                   : 'linux',
+                additionalNodeLabels : 'centos6',
+                arch                 : 'aarch64',
                 test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
                 additionalFileNameTag: "linuxXL",
                 configureArgs        : '--with-noncompressedrefs --disable-ccache'

--- a/pipelines/build/openjdk12_pipeline.groovy
+++ b/pipelines/build/openjdk12_pipeline.groovy
@@ -129,7 +129,7 @@ def buildConfigurations = [
                 test                : false
         ],
         */
-        linuxXL    : [
+        x64LinuxXL    : [
                 os                   : 'linux',
                 additionalNodeLabels : 'centos6',
                 arch                 : 'x64',

--- a/pipelines/build/openjdk13_pipeline.groovy
+++ b/pipelines/build/openjdk13_pipeline.groovy
@@ -130,10 +130,26 @@ def buildConfigurations = [
                 test                : false
         ],
         */
-        linuxXL    : [
+        x64LinuxXL    : [
                 os                   : 'linux',
                 additionalNodeLabels : 'centos6',
                 arch                 : 'x64',
+                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                additionalFileNameTag: "linuxXL",
+                configureArgs        : '--with-noncompressedrefs --disable-ccache'
+        ],
+        s390xLinuxXL    : [
+                os                   : 'linux',
+                additionalNodeLabels : 'centos6',
+                arch                 : 's390x',
+                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                additionalFileNameTag: "linuxXL",
+                configureArgs        : '--with-noncompressedrefs --disable-ccache'
+        ],
+        ppc64leLinuxXL    : [
+                os                   : 'linux',
+                additionalNodeLabels : 'centos6',
+                arch                 : 'ppc64le',
                 test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
                 additionalFileNameTag: "linuxXL",
                 configureArgs        : '--with-noncompressedrefs --disable-ccache'

--- a/pipelines/build/openjdk8_pipeline.groovy
+++ b/pipelines/build/openjdk8_pipeline.groovy
@@ -128,10 +128,26 @@ def buildConfigurations = [
                 test                : ['sanity.openjdk', 'sanity.system', 'extended.system']
         ],
 
-        linuxXL       : [
+        x64LinuxXL       : [
                 os                   : 'linux',
                 additionalNodeLabels : 'centos6',
                 arch                 : 'x64',
+                additionalFileNameTag: "linuxXL",
+                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                configureArgs        : '--with-noncompressedrefs'
+        ],
+        s390xLinuxXL       : [
+                os                   : 'linux',
+                additionalNodeLabels : 'centos6',
+                arch                 : 's390x',
+                additionalFileNameTag: "linuxXL",
+                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                configureArgs        : '--with-noncompressedrefs'
+        ],
+        ppc64leLinuxXL       : [
+                os                   : 'linux',
+                additionalNodeLabels : 'centos6',
+                arch                 : 'ppc64le',
                 additionalFileNameTag: "linuxXL",
                 test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
                 configureArgs        : '--with-noncompressedrefs'

--- a/pipelines/build/openjdk9_pipeline.groovy
+++ b/pipelines/build/openjdk9_pipeline.groovy
@@ -77,7 +77,7 @@ def buildConfigurations = [
                 test                : ['sanity.openjdk']
         ],
 
-        linuxXL    : [
+        x64LinuxXL    : [
                 os                   : 'linux',
                 additionalNodeLabels : 'centos6',
                 arch                 : 'x64',

--- a/pipelines/build/openjdk_pipeline.groovy
+++ b/pipelines/build/openjdk_pipeline.groovy
@@ -97,10 +97,26 @@ def buildConfigurations = [
                 test                : false
         ],
         */
-        "linuxXL"    : [
+        x64LinuxXL    : [
                 os                   : 'linux',
                 additionalNodeLabels : 'centos6',
                 arch                 : 'x64',
+                test                 : false,
+                additionalFileNameTag: "linuxXL",
+                configureArgs        : '--with-noncompressedrefs'
+        ],
+        s390xLinuxXL    : [
+                os                   : 'linux',
+                additionalNodeLabels : 'centos6',
+                arch                 : 's390x',
+                test                 : false,
+                additionalFileNameTag: "linuxXL",
+                configureArgs        : '--with-noncompressedrefs'
+        ],
+        ppc64LinuxXL    : [
+                os                   : 'linux',
+                additionalNodeLabels : 'centos6',
+                arch                 : 'ppc64le',
                 test                 : false,
                 additionalFileNameTag: "linuxXL",
                 configureArgs        : '--with-noncompressedrefs'

--- a/pipelines/jobs/configurations/jdk10u.groovy
+++ b/pipelines/jobs/configurations/jdk10u.groovy
@@ -39,7 +39,7 @@ targetConfigurations = [
         "arm32Linux"  : [
                 "hotspot"
         ],
-        "linuxXL"     : [
+        "x64LinuxXL"     : [
                 "openj9"
         ]
 ]

--- a/pipelines/jobs/configurations/jdk11u.groovy
+++ b/pipelines/jobs/configurations/jdk11u.groovy
@@ -39,7 +39,16 @@ targetConfigurations = [
         "arm32Linux"  : [
                 "hotspot"
         ],
-        "linuxXL"     : [
+        "x64LinuxXL"     : [
+                "openj9"
+        ],
+        "s390xLinuxXL"     : [
+                "openj9"
+        ],
+        "ppc64leLinuxXL"     : [
+                "openj9"
+        ],
+        "aarch64LinuxXL": [
                 "openj9"
         ]
 ]

--- a/pipelines/jobs/configurations/jdk12u.groovy
+++ b/pipelines/jobs/configurations/jdk12u.groovy
@@ -38,7 +38,7 @@ targetConfigurations = [
         "arm32Linux"  : [
                 "hotspot"
         ],
-        "linuxXL"     : [
+        "x64LinuxXL"     : [
                 "openj9"
         ]
 ]

--- a/pipelines/jobs/configurations/jdk13u.groovy
+++ b/pipelines/jobs/configurations/jdk13u.groovy
@@ -38,7 +38,13 @@ targetConfigurations = [
         "arm32Linux"  : [
                 "hotspot"
         ],
-        "linuxXL"     : [
+        "x64LinuxXL"     : [
+                "openj9"
+        ],
+        "s390xLinuxXL"     : [
+                "openj9"
+        ],
+        "ppc64leLinuxXL"     : [
                 "openj9"
         ]
 ]

--- a/pipelines/jobs/configurations/jdk8u.groovy
+++ b/pipelines/jobs/configurations/jdk8u.groovy
@@ -43,7 +43,13 @@ targetConfigurations = [
         "x64Solaris": [
                 "hotspot"
         ],
-        "linuxXL"       : [
+        "x64LinuxXL"       : [
+                "openj9"
+        ],
+        "s390xLinuxXL"       : [
+                "openj9"
+        ],
+        "ppc64leLinuxXL"       : [
                 "openj9"
         ],
         "x64MacXL"      : [


### PR DESCRIPTION
Shelley - asking you to check over this in case you want a different set of tests configured for the new builds

Fixes https://github.com/AdoptOpenJDK/openjdk-build/issues/1400 and the aarch64/J9 failing builds (support for JITted builds is only in  them for large heap variants just now)