### PR TITLE
Don't use Ubuntu-supplied ccache in Docker when building OpenJ9 JDK11+

### DIFF
--- a/docker/jdk11/x86_64/ubuntu/Dockerfile-openj9
+++ b/docker/jdk11/x86_64/ubuntu/Dockerfile-openj9
@@ -19,7 +19,6 @@ RUN apt-get update \
     && apt-get -y upgrade \
     && apt-get install -qq -y --no-install-recommends \
        autoconf \
-       ccache \
        cpio \
        curl \
        file \
@@ -59,7 +58,8 @@ RUN cd /usr/local \
 RUN ln -s /usr/lib/x86_64-linux-gnu /usr/lib64 \
   && ln -s /usr/include/x86_64-linux-gnu/* /usr/local/gcc/include \
   && ln -s /usr/local/gcc/bin/g++-7.3 /usr/bin/g++ \
-  && ln -s /usr/local/gcc/bin/gcc-7.3 /usr/bin/gcc
+  && ln -s /usr/local/gcc/bin/gcc-7.3 /usr/bin/gcc \
+  && ln -s /usr/local/gcc/bin/ccache /usr/local/bin/ccache
 
 RUN mkdir -p /openjdk/target
 

--- a/docker/jdk12/x86_64/ubuntu/Dockerfile-openj9
+++ b/docker/jdk12/x86_64/ubuntu/Dockerfile-openj9
@@ -20,7 +20,6 @@ RUN apt-get update \
     && apt-get -y upgrade \
     && apt-get install -qq -y --no-install-recommends \
        autoconf \
-       ccache \
        cpio \
        curl \
        file \
@@ -54,7 +53,8 @@ RUN apt-get update \
 # Make sure build uses 4.8
 RUN ln -sf /usr/bin/gcc-4.8 /usr/bin/gcc \
     && ln -sf /usr/bin/g++-4.8 /usr/bin/g++ \
-    && ln -sf /usr/bin/g++-4.8 /usr/bin/c++
+    && ln -sf /usr/bin/g++-4.8 /usr/bin/c++ \
+  && ln -s /usr/local/gcc/bin/ccache /usr/local/bin/ccache
 
 RUN mkdir -p /openjdk/target
 

--- a/docker/jdk13/x86_64/ubuntu/Dockerfile-openj9
+++ b/docker/jdk13/x86_64/ubuntu/Dockerfile-openj9
@@ -20,7 +20,6 @@ RUN apt-get update \
     && apt-get -y upgrade \
     && apt-get install -qq -y --no-install-recommends \
        autoconf \
-       ccache \
        cpio \
        curl \
        file \
@@ -60,7 +59,8 @@ RUN cd /usr/local \
 RUN ln -s /usr/lib/x86_64-linux-gnu /usr/lib64 \
   && ln -s /usr/include/x86_64-linux-gnu/* /usr/local/gcc/include \
   && ln -s /usr/local/gcc/bin/g++-7.3 /usr/bin/g++ \
-  && ln -s /usr/local/gcc/bin/gcc-7.3 /usr/bin/gcc
+  && ln -s /usr/local/gcc/bin/gcc-7.3 /usr/bin/gcc \
+  && ln -s /usr/local/gcc/bin/ccache /usr/local/bin/ccache
 
 RUN mkdir -p /openjdk/target
 

--- a/pipelines/build/openjdk10_pipeline.groovy
+++ b/pipelines/build/openjdk10_pipeline.groovy
@@ -85,7 +85,7 @@ def buildConfigurations = [
                 test                : false
         ],
         */
-        "linuxXL"    : [
+        x64LinuxXL    : [
                 os                   : 'linux',
                 additionalNodeLabels : 'centos6',
                 arch                 : 'x64',

--- a/pipelines/build/openjdk11_pipeline.groovy
+++ b/pipelines/build/openjdk11_pipeline.groovy
@@ -132,10 +132,34 @@ def buildConfigurations = [
                 test                : false
         ],
         */
-        linuxXL    : [
+        x64LinuxXL    : [
                 os                   : 'linux',
                 additionalNodeLabels : 'centos6',
                 arch                 : 'x64',
+                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                additionalFileNameTag: "linuxXL",
+                configureArgs        : '--with-noncompressedrefs --disable-ccache'
+        ],
+        s390xLinuxXL    : [
+                os                   : 'linux',
+                additionalNodeLabels : 'centos6',
+                arch                 : 's390x',
+                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                additionalFileNameTag: "linuxXL",
+                configureArgs        : '--with-noncompressedrefs --disable-ccache'
+        ],
+        ppc64leLinuxXL    : [
+                os                   : 'linux',
+                additionalNodeLabels : 'centos6',
+                arch                 : 'ppc64le',
+                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                additionalFileNameTag: "linuxXL",
+                configureArgs        : '--with-noncompressedrefs --disable-ccache'
+        ],
+        aarch64LinuxXL    : [
+                os                   : 'linux',
+                additionalNodeLabels : 'centos6',
+                arch                 : 'aarch64',
                 test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
                 additionalFileNameTag: "linuxXL",
                 configureArgs        : '--with-noncompressedrefs --disable-ccache'

--- a/pipelines/build/openjdk12_pipeline.groovy
+++ b/pipelines/build/openjdk12_pipeline.groovy
@@ -129,7 +129,7 @@ def buildConfigurations = [
                 test                : false
         ],
         */
-        linuxXL    : [
+        x64LinuxXL    : [
                 os                   : 'linux',
                 additionalNodeLabels : 'centos6',
                 arch                 : 'x64',

--- a/pipelines/build/openjdk13_pipeline.groovy
+++ b/pipelines/build/openjdk13_pipeline.groovy
@@ -130,10 +130,26 @@ def buildConfigurations = [
                 test                : false
         ],
         */
-        linuxXL    : [
+        x64LinuxXL    : [
                 os                   : 'linux',
                 additionalNodeLabels : 'centos6',
                 arch                 : 'x64',
+                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                additionalFileNameTag: "linuxXL",
+                configureArgs        : '--with-noncompressedrefs --disable-ccache'
+        ],
+        s390xLinuxXL    : [
+                os                   : 'linux',
+                additionalNodeLabels : 'centos6',
+                arch                 : 's390x',
+                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                additionalFileNameTag: "linuxXL",
+                configureArgs        : '--with-noncompressedrefs --disable-ccache'
+        ],
+        ppc64leLinuxXL    : [
+                os                   : 'linux',
+                additionalNodeLabels : 'centos6',
+                arch                 : 'ppc64le',
                 test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
                 additionalFileNameTag: "linuxXL",
                 configureArgs        : '--with-noncompressedrefs --disable-ccache'

--- a/pipelines/build/openjdk8_pipeline.groovy
+++ b/pipelines/build/openjdk8_pipeline.groovy
@@ -128,10 +128,26 @@ def buildConfigurations = [
                 test                : ['sanity.openjdk', 'sanity.system', 'extended.system']
         ],
 
-        linuxXL       : [
+        x64LinuxXL       : [
                 os                   : 'linux',
                 additionalNodeLabels : 'centos6',
                 arch                 : 'x64',
+                additionalFileNameTag: "linuxXL",
+                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                configureArgs        : '--with-noncompressedrefs'
+        ],
+        s390xLinuxXL       : [
+                os                   : 'linux',
+                additionalNodeLabels : 'centos6',
+                arch                 : 's390x',
+                additionalFileNameTag: "linuxXL",
+                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                configureArgs        : '--with-noncompressedrefs'
+        ],
+        ppc64leLinuxXL       : [
+                os                   : 'linux',
+                additionalNodeLabels : 'centos6',
+                arch                 : 'ppc64le',
                 additionalFileNameTag: "linuxXL",
                 test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
                 configureArgs        : '--with-noncompressedrefs'

--- a/pipelines/build/openjdk9_pipeline.groovy
+++ b/pipelines/build/openjdk9_pipeline.groovy
@@ -77,7 +77,7 @@ def buildConfigurations = [
                 test                : ['sanity.openjdk']
         ],
 
-        linuxXL    : [
+        x64LinuxXL    : [
                 os                   : 'linux',
                 additionalNodeLabels : 'centos6',
                 arch                 : 'x64',

--- a/pipelines/build/openjdk_pipeline.groovy
+++ b/pipelines/build/openjdk_pipeline.groovy
@@ -97,10 +97,26 @@ def buildConfigurations = [
                 test                : false
         ],
         */
-        "linuxXL"    : [
+        x64LinuxXL    : [
                 os                   : 'linux',
                 additionalNodeLabels : 'centos6',
                 arch                 : 'x64',
+                test                 : false,
+                additionalFileNameTag: "linuxXL",
+                configureArgs        : '--with-noncompressedrefs'
+        ],
+        s390xLinuxXL    : [
+                os                   : 'linux',
+                additionalNodeLabels : 'centos6',
+                arch                 : 's390x',
+                test                 : false,
+                additionalFileNameTag: "linuxXL",
+                configureArgs        : '--with-noncompressedrefs'
+        ],
+        ppc64LinuxXL    : [
+                os                   : 'linux',
+                additionalNodeLabels : 'centos6',
+                arch                 : 'ppc64le',
                 test                 : false,
                 additionalFileNameTag: "linuxXL",
                 configureArgs        : '--with-noncompressedrefs'

--- a/pipelines/jobs/configurations/jdk10u.groovy
+++ b/pipelines/jobs/configurations/jdk10u.groovy
@@ -39,7 +39,7 @@ targetConfigurations = [
         "arm32Linux"  : [
                 "hotspot"
         ],
-        "linuxXL"     : [
+        "x64LinuxXL"     : [
                 "openj9"
         ]
 ]

--- a/pipelines/jobs/configurations/jdk11u.groovy
+++ b/pipelines/jobs/configurations/jdk11u.groovy
@@ -39,7 +39,16 @@ targetConfigurations = [
         "arm32Linux"  : [
                 "hotspot"
         ],
-        "linuxXL"     : [
+        "x64LinuxXL"     : [
+                "openj9"
+        ],
+        "s390xLinuxXL"     : [
+                "openj9"
+        ],
+        "ppc64leLinuxXL"     : [
+                "openj9"
+        ],
+        "aarch64LinuxXL": [
                 "openj9"
         ]
 ]

--- a/pipelines/jobs/configurations/jdk12u.groovy
+++ b/pipelines/jobs/configurations/jdk12u.groovy
@@ -38,7 +38,7 @@ targetConfigurations = [
         "arm32Linux"  : [
                 "hotspot"
         ],
-        "linuxXL"     : [
+        "x64LinuxXL"     : [
                 "openj9"
         ]
 ]

--- a/pipelines/jobs/configurations/jdk13u.groovy
+++ b/pipelines/jobs/configurations/jdk13u.groovy
@@ -38,7 +38,13 @@ targetConfigurations = [
         "arm32Linux"  : [
                 "hotspot"
         ],
-        "linuxXL"     : [
+        "x64LinuxXL"     : [
+                "openj9"
+        ],
+        "s390xLinuxXL"     : [
+                "openj9"
+        ],
+        "ppc64leLinuxXL"     : [
                 "openj9"
         ]
 ]

--- a/pipelines/jobs/configurations/jdk8u.groovy
+++ b/pipelines/jobs/configurations/jdk8u.groovy
@@ -43,7 +43,13 @@ targetConfigurations = [
         "x64Solaris": [
                 "hotspot"
         ],
-        "linuxXL"       : [
+        "x64LinuxXL"       : [
+                "openj9"
+        ],
+        "s390xLinuxXL"       : [
+                "openj9"
+        ],
+        "ppc64leLinuxXL"       : [
                 "openj9"
         ],
         "x64MacXL"      : [


### PR DESCRIPTION
Without this fix the build detects and uses `/usr/bin/ccache` (3.2.4) instead of `/usr/local/gcc/bin/ccache` (3.4.2) and comes up with this error:

````
VMAccess.cpp: In function 'void acquireExclusiveVMAccess(J9VMThread*)':
VMAccess.cpp:154:132: error: self-comparison always evaluates to true [-Werror=tautological-compare]
     J9_LINEAR_LINKED_LIST_ADD(exclusiveVMAccessQueueNext,exclusiveVMAccessQueuePrevious,vm->exclusiveVMAccessQueueHead,vmThread);
                                                                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ^                                  
VMAccess.cpp:154:287: error: self-comparison always evaluates to true [-Werror=tautological-compare]
     J9_LINEAR_LINKED_LIST_ADD(exclusiveVMAccessQueueNext,exclusiveVMAccessQueuePrevious,vm->exclusiveVMAccessQueueHead,vmThread);
                                                                                                                                                                                                                                                                                               ^                                  
cc1plus: all warnings being treated as errors
../makelib/targets.mk:283: recipe for target 'VMAccess.o' failed
make[5]: *** [VMAccess.o] Error 1
```

I believe this was introduced in https://github.com/AdoptOpenJDK/openjdk-build/pull/1379/files where `/usr/local/bin/ccache` would have ceased to exist.