### PR TITLE
Adjust labels on new J9 XL builds to not target CentOS6

### DIFF
--- a/pipelines/build/openjdk11_pipeline.groovy
+++ b/pipelines/build/openjdk11_pipeline.groovy
@@ -142,7 +142,6 @@ def buildConfigurations = [
         ],
         s390xLinuxXL    : [
                 os                   : 'linux',
-                additionalNodeLabels : 'centos6',
                 arch                 : 's390x',
                 test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
                 additionalFileNameTag: "linuxXL",
@@ -150,7 +149,6 @@ def buildConfigurations = [
         ],
         ppc64leLinuxXL    : [
                 os                   : 'linux',
-                additionalNodeLabels : 'centos6',
                 arch                 : 'ppc64le',
                 test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
                 additionalFileNameTag: "linuxXL",
@@ -158,7 +156,7 @@ def buildConfigurations = [
         ],
         aarch64LinuxXL    : [
                 os                   : 'linux',
-                additionalNodeLabels : 'centos6',
+                additionalNodeLabels : 'centos7',
                 arch                 : 'aarch64',
                 test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
                 additionalFileNameTag: "linuxXL",

--- a/pipelines/build/openjdk13_pipeline.groovy
+++ b/pipelines/build/openjdk13_pipeline.groovy
@@ -140,7 +140,6 @@ def buildConfigurations = [
         ],
         s390xLinuxXL    : [
                 os                   : 'linux',
-                additionalNodeLabels : 'centos6',
                 arch                 : 's390x',
                 test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
                 additionalFileNameTag: "linuxXL",
@@ -148,7 +147,6 @@ def buildConfigurations = [
         ],
         ppc64leLinuxXL    : [
                 os                   : 'linux',
-                additionalNodeLabels : 'centos6',
                 arch                 : 'ppc64le',
                 test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
                 additionalFileNameTag: "linuxXL",

--- a/pipelines/build/openjdk8_pipeline.groovy
+++ b/pipelines/build/openjdk8_pipeline.groovy
@@ -138,7 +138,6 @@ def buildConfigurations = [
         ],
         s390xLinuxXL       : [
                 os                   : 'linux',
-                additionalNodeLabels : 'centos6',
                 arch                 : 's390x',
                 additionalFileNameTag: "linuxXL",
                 test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
@@ -146,7 +145,6 @@ def buildConfigurations = [
         ],
         ppc64leLinuxXL       : [
                 os                   : 'linux',
-                additionalNodeLabels : 'centos6',
                 arch                 : 'ppc64le',
                 additionalFileNameTag: "linuxXL",
                 test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],

--- a/pipelines/build/openjdk_pipeline.groovy
+++ b/pipelines/build/openjdk_pipeline.groovy
@@ -107,7 +107,6 @@ def buildConfigurations = [
         ],
         s390xLinuxXL    : [
                 os                   : 'linux',
-                additionalNodeLabels : 'centos6',
                 arch                 : 's390x',
                 test                 : false,
                 additionalFileNameTag: "linuxXL",
@@ -115,7 +114,6 @@ def buildConfigurations = [
         ],
         ppc64LinuxXL    : [
                 os                   : 'linux',
-                additionalNodeLabels : 'centos6',
                 arch                 : 'ppc64le',
                 test                 : false,
                 additionalFileNameTag: "linuxXL",


### PR DESCRIPTION
Introduced yesterday and locked the build pipelines as none of them could find a matching machine. Introduced by me cut & pasting from x64.

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>