### PR TITLE
Stop pulling cacerts from jdk11u for jdk8u builds

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -314,10 +314,6 @@ configureCommandParameters()
   echo "Configuring jvm variants if provided"
   addConfigureArgIfValueIsNotEmpty "--with-jvm-variants=" "${BUILD_CONFIG[JVM_VARIANT]}"
 
-  if [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK8_CORE_VERSION}" ] || [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK9_CORE_VERSION}" ]; then
-    addConfigureArgIfValueIsNotEmpty "--with-cacerts-file=" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/cacerts_area/security/cacerts"
-  fi
-
   # Now we add any configure arguments the user has specified on the command line.
   CONFIGURE_ARGS="${CONFIGURE_ARGS} ${BUILD_CONFIG[USER_SUPPLIED_CONFIGURE_ARGS]}"
 

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -368,7 +368,7 @@ checkingAndDownloadCaCerts()
 {
   cd "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}" || exit
 
-  echo "Retrieving cacerts file"
+  echo "Retrieving cacerts file if needed"
   # Ensure it's the latest we pull in
   rm -rf "cacerts_area"
   mkdir "cacerts_area" || exit
@@ -378,15 +378,8 @@ checkingAndDownloadCaCerts()
   if [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_CORRETTO}" ]; then
       local caLink="https://github.com/corretto/corretto-8/blob/preview-release/cacerts?raw=true";
       downloadCerts "$caLink"
-  elif [ "${BUILD_CONFIG[USE_JEP319_CERTS]}" == "true" ];
+  elif [ "${BUILD_CONFIG[USE_JEP319_CERTS]}" != "true" ];
   then
-    if [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK8_CORE_VERSION}" ] || [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK9_CORE_VERSION}" ]
-    then
-      echo "Requested use of JEP319 certs"
-      local caLink="https://github.com/AdoptOpenJDK/openjdk-jdk11u/blob/dev/src/java.base/share/lib/security/cacerts?raw=true";
-      downloadCerts "$caLink"
-    fi
-  else
     git init
     git remote add origin -f https://github.com/AdoptOpenJDK/openjdk-build.git
     git config core.sparsecheckout true


### PR DESCRIPTION
Causing a build break now. Fixes https://github.com/AdoptOpenJDK/openjdk-build/issues/1086 (assuming it works and hasn't got any other side effects ...)

Reviews welcome but please do not merge until I've had a chance to test it [EDIT: I'm comfortable that this is putting an identical `cacerts` in the same place as before, so this is good to go]

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>