### PR TITLE
Temporarily use JDK11 to boot JDK11 builds

### DIFF
--- a/build-farm/make-adopt-build-farm.sh
+++ b/build-farm/make-adopt-build-farm.sh
@@ -59,7 +59,7 @@ case "${JDK_BOOT_VERSION}" in
       "7")    export JDK_BOOT_DIR="${JDK_BOOT_DIR:-$JDK7_BOOT_DIR}";;
       "8")    export JDK_BOOT_DIR="${JDK_BOOT_DIR:-$JDK8_BOOT_DIR}";;
       "9")    export JDK_BOOT_DIR="${JDK_BOOT_DIR:-$JDK9_BOOT_DIR}";;
-      "10")   export JDK_BOOT_DIR="${JDK_BOOT_DIR:-$JDK10_BOOT_DIR}";;
+      "10")   export JDK_BOOT_DIR="${JDK_BOOT_DIR:-$JDK11_BOOT_DIR}";;
       "11")   export JDK_BOOT_DIR="${JDK_BOOT_DIR:-$JDK11_BOOT_DIR}";;
       "12")   export JDK_BOOT_DIR="${JDK_BOOT_DIR:-$JDK12_BOOT_DIR}";;
       "13")   export JDK_BOOT_DIR="${JDK_BOOT_DIR:-$JDK13_BOOT_DIR}";;


### PR DESCRIPTION
If the issue described in https://github.com/AdoptOpenJDK/openjdk-build/issues/1409 continues we can integrate this is a (hopefully) temporary workaround. At the moment this will change it (unnecessarily) for OpenJ9 builds as well as HotSpot, but it is the smallest change that will have the desired effect and be easy to roll back.

Leaving it to anyone with an interest to decide whether to merge this or not. I suspect if it's not resolved upstream in a few days we make the change to avoid us going too long without being able to test (FYI @smlambert as you've expressed concerns in this area.)

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>