### PR TITLE
buildDocker: Changed git function to use absolute paths

### DIFF
--- a/docker/buildDocker.sh
+++ b/docker/buildDocker.sh
@@ -156,11 +156,11 @@ buildDocker()
 
 setupGit()
 {
-	if [ ! -d "$jdkVersion-$buildVariant/docker" ]; then
+	if [ ! -d "$WORKSPACE/DockerBuildFolder/$jdkVersion-$buildVariant/docker" ]; then
 		git clone https://github.com/adoptopenjdk/openjdk-build $WORKSPACE/DockerBuildFolder/$jdkVersion-$buildVariant
 	else
-		cd $jdkVersion-$buildVariant
-		git pull https://github.com/adoptopenjdk/openjdk-build
+		cd $WORKSPACE/DockerBuildFolder/$jdkVersion-$buildVariant
+		git pull
 	fi
 }
 parseCommandLineArgs $@


### PR DESCRIPTION
fixes: #1406 

Git wasn't pulling changes due to the if statement equalling `true`, then failing to git clone a repo that was already there. Change to absolute paths and it works :-)