### PR TITLE
Don't override JDK11 boot JDK in platform files

### DIFF
--- a/build-farm/make-adopt-build-farm.sh
+++ b/build-farm/make-adopt-build-farm.sh
@@ -59,7 +59,7 @@ case "${JDK_BOOT_VERSION}" in
       "7")    export JDK_BOOT_DIR="${JDK_BOOT_DIR:-$JDK7_BOOT_DIR}";;
       "8")    export JDK_BOOT_DIR="${JDK_BOOT_DIR:-$JDK8_BOOT_DIR}";;
       "9")    export JDK_BOOT_DIR="${JDK_BOOT_DIR:-$JDK9_BOOT_DIR}";;
-      "10")   export JDK_BOOT_DIR="${JDK_BOOT_DIR:-$JDK10_BOOT_DIR}";;
+      "10")   export JDK_BOOT_DIR="${JDK_BOOT_DIR:-$JDK11_BOOT_DIR}";;
       "11")   export JDK_BOOT_DIR="${JDK_BOOT_DIR:-$JDK11_BOOT_DIR}";;
       "12")   export JDK_BOOT_DIR="${JDK_BOOT_DIR:-$JDK12_BOOT_DIR}";;
       "13")   export JDK_BOOT_DIR="${JDK_BOOT_DIR:-$JDK13_BOOT_DIR}";;

--- a/build-farm/platform-specific-configurations/aix.sh
+++ b/build-farm/platform-specific-configurations/aix.sh
@@ -36,8 +36,8 @@ if [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]; then
 fi
 echo LDR_CNTRL=$LDR_CNTRL
 
-# Any version above 8
-if [ "$JAVA_FEATURE_VERSION" -gt 8 ]; then
+# Any version above 8 (11 for now due to openjdk-build#1409
+if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
     BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION-1))"
     BOOT_JDK_VARIABLE="JDK$(echo $BOOT_JDK_VERSION)_BOOT_DIR"
     if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then

--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -84,8 +84,8 @@ then
   fi
 fi
 
-# Any version above 8
-if [ "$JAVA_FEATURE_VERSION" -gt 8 ]; then
+# Any version above 8 (11 for now due to openjdk-build#1409
+if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
     BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION-1))"
     BOOT_JDK_VARIABLE="JDK$(echo $BOOT_JDK_VERSION)_BOOT_DIR"
     if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then

--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -52,9 +52,8 @@ fi
 
 sudo xcode-select --switch "${XCODE_SWITCH_PATH}"
 
-# Any version above 8
-if [ "$JAVA_FEATURE_VERSION" -gt 8 ]; then
-
+# Any version above 8 (11 for now due to openjdk-build#1409
+if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
     BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION-1))"
     BOOT_JDK_VARIABLE="JDK$(echo $BOOT_JDK_VERSION)_BOOT_DIR"
     if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then

--- a/build-farm/platform-specific-configurations/windows.sh
+++ b/build-farm/platform-specific-configurations/windows.sh
@@ -27,9 +27,8 @@ export OPENJ9_NASM_VERSION=2.13.03
 
 TOOLCHAIN_VERSION=""
 
-# Any version above 8
-if [ "$JAVA_FEATURE_VERSION" -gt 8 ]; then
-    BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION-1))"
+# Any version above 8 (11 for now due to openjdk-build#1409
+if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
     BOOT_JDK_VARIABLE="JDK$(echo $BOOT_JDK_VERSION)_BOOT_DIR"
     if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then
       export $BOOT_JDK_VARIABLE="$PWD/jdk-$BOOT_JDK_VERSION"


### PR DESCRIPTION
This prevented https://github.com/AdoptOpenJDK/openjdk-build/pull/1411 from activating as `JDK_BOOT_DIR` is being overridden before the section modified in that PR.

I believe this change will be ok, but it will fail if a suitable `JDK10_BOOT_DIR` is not defined as it will attempt to download one. This will at least expose any of our machines that are not configured with a suitable JDK10 boot JDK, so I'm willing to take  that hit ... I may look at stripping out that logic from the platform files universally later ...

Again this is part of mitigating https://github.com/AdoptOpenJDK/openjdk-build/issues/1409