### PR TITLE
Enable bootJDK to overwrite to 11

### DIFF
--- a/build-farm/platform-specific-configurations/aix.sh
+++ b/build-farm/platform-specific-configurations/aix.sh
@@ -37,8 +37,12 @@ fi
 echo LDR_CNTRL=$LDR_CNTRL
 
 # Any version above 8 (11 for now due to openjdk-build#1409
-if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
-    BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION-1))"
+if [ "$JAVA_FEATURE_VERSION" -gt 8 ]; then
+	if [ "$JAVA_FEATURE_VERSION" -eq 11 ]; then
+		BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION))"
+	else
+		BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION-1))"
+	fi
     BOOT_JDK_VARIABLE="JDK$(echo $BOOT_JDK_VERSION)_BOOT_DIR"
     if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then
       export $BOOT_JDK_VARIABLE="$PWD/jdk-$BOOT_JDK_VERSION"

--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -85,8 +85,12 @@ then
 fi
 
 # Any version above 8 (11 for now due to openjdk-build#1409
-if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
-    BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION-1))"
+if [ "$JAVA_FEATURE_VERSION" -gt 8 ]; then
+	if [ "$JAVA_FEATURE_VERSION" -eq 11 ]; then
+		BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION))"
+	else
+		BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION-1))"
+	fi
     BOOT_JDK_VARIABLE="JDK$(echo $BOOT_JDK_VERSION)_BOOT_DIR"
     if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then
       export $BOOT_JDK_VARIABLE="$PWD/jdk-$BOOT_JDK_VERSION"

--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -53,8 +53,12 @@ fi
 sudo xcode-select --switch "${XCODE_SWITCH_PATH}"
 
 # Any version above 8 (11 for now due to openjdk-build#1409
-if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
-    BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION-1))"
+if [ "$JAVA_FEATURE_VERSION" -gt 8 ]; then
+	if [ "$JAVA_FEATURE_VERSION" -eq 11 ]; then
+		BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION))"
+	else	
+	    BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION-1))"
+	fi
     BOOT_JDK_VARIABLE="JDK$(echo $BOOT_JDK_VERSION)_BOOT_DIR"
     if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then
       export $BOOT_JDK_VARIABLE="$PWD/jdk-$BOOT_JDK_VERSION"

--- a/build-farm/platform-specific-configurations/windows.sh
+++ b/build-farm/platform-specific-configurations/windows.sh
@@ -28,7 +28,10 @@ export OPENJ9_NASM_VERSION=2.13.03
 TOOLCHAIN_VERSION=""
 
 # Any version above 8 (11 for now due to openjdk-build#1409
-if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
+if [ "$JAVA_FEATURE_VERSION" -gt 8 ]; then
+	if [ "$JAVA_FEATURE_VERSION" -eq 11 ]; then
+		BOOT_JDK_VERSION=11
+	fi
     BOOT_JDK_VARIABLE="JDK$(echo $BOOT_JDK_VERSION)_BOOT_DIR"
     if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then
       export $BOOT_JDK_VARIABLE="$PWD/jdk-$BOOT_JDK_VERSION"


### PR DESCRIPTION
Overwrites boot jdk to 11 when building jdk 11 since a lot of machines don't seem to have bootjdk11.
Issue: https://github.com/AdoptOpenJDK/openjdk-build/issues/1409
Thoughts? @sxa555 

Signed-off-by: Adam Thorpe <adam.thorpe@ibm.com>