### PR TITLE
Add special.openjdk to the set of jdk8's launched test targets

### DIFF
--- a/pipelines/build/openjdk8_pipeline.groovy
+++ b/pipelines/build/openjdk8_pipeline.groovy
@@ -23,14 +23,14 @@ def buildConfigurations = [
                         corretto: 'build-macstadium-macos1010-1',
                         openj9  : 'build-macstadium-macos1010-2'
                 ],
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system']
+                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk']
         ],
 
         x64MacXL      : [
                 os                   : 'mac',
                 arch                 : 'x64',
                 additionalNodeLabels : 'build-macstadium-macos1010-2',
-                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'special.openjdk'],
                 additionalFileNameTag: "macosXL",
                 configureArgs        : '--with-noncompressedrefs'
         ],
@@ -39,7 +39,7 @@ def buildConfigurations = [
                 os                  : 'linux',
                 arch                : 'x64',
                 additionalNodeLabels: 'centos6',
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external', 'special.functional'],
+                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external', 'special.functional', 'special.openjdk'],
                 configureArgs       : [
                         "hotspot-jfr" : '--enable-jfr'
                 ]
@@ -54,14 +54,14 @@ def buildConfigurations = [
                         corretto: 'win2008',
                         openj9  : 'win2012&&mingw-cygwin'
                 ],
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system']
+                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk']
         ],
 
         x64WindowsXL    : [
                 os                   : 'windows',
                 arch                 : 'x64',
                 additionalNodeLabels : 'win2012&&mingw-cygwin',
-                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk'],
                 additionalFileNameTag: "windowsXL",
                 configureArgs        : '--with-noncompressedrefs'
         ],
@@ -77,7 +77,7 @@ def buildConfigurations = [
                 buildArgs : [
                         hotspot : '--jvm-variant client,server'
                 ],
-                test                : ['sanity.openjdk']
+                test                : ['sanity.openjdk', 'special.openjdk']
         ],
 
         ppc64Aix      : [
@@ -85,14 +85,14 @@ def buildConfigurations = [
                 arch: 'ppc64',
                 test: [
                         nightly: false,
-                        release: ['sanity.openjdk', 'sanity.system', 'extended.system']
+                        release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk']
                 ]
         ],
 
         s390xLinux    : [
                 os  : 'linux',
                 arch: 's390x',
-                test: ['sanity.openjdk', 'sanity.system', 'extended.system']
+                test: ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk']
         ],
 
         sparcv9Solaris: [
@@ -110,7 +110,7 @@ def buildConfigurations = [
         ppc64leLinux  : [
                 os  : 'linux',
                 arch: 'ppc64le',
-                test: ['sanity.openjdk', 'sanity.system', 'extended.system']
+                test: ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk']
         ],
 
         arm32Linux    : [
@@ -125,7 +125,7 @@ def buildConfigurations = [
                 os                  : 'linux',
                 arch                : 'aarch64',
                 additionalNodeLabels: 'centos7',
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system']
+                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk']
         ],
 
         x64LinuxXL       : [
@@ -133,21 +133,21 @@ def buildConfigurations = [
                 additionalNodeLabels : 'centos6',
                 arch                 : 'x64',
                 additionalFileNameTag: "linuxXL",
-                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk'],
                 configureArgs        : '--with-noncompressedrefs'
         ],
         s390xLinuxXL       : [
                 os                   : 'linux',
                 arch                 : 's390x',
                 additionalFileNameTag: "linuxXL",
-                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk'],
                 configureArgs        : '--with-noncompressedrefs'
         ],
         ppc64leLinuxXL       : [
                 os                   : 'linux',
                 arch                 : 'ppc64le',
                 additionalFileNameTag: "linuxXL",
-                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk'],
                 configureArgs        : '--with-noncompressedrefs'
         ],
 ]


### PR DESCRIPTION
Currently special.openjdk target only exists in jdk8 and correspondingly only jdk8 Test_openjdk_special builds were created. https://ci.adoptopenjdk.net/view/Test_openjdk_special/ 
Will expand to other versions when needed.


Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>