### PR TITLE
Show BOOT JDK version string in build log for debug purposes

### DIFF
--- a/build-farm/make-adopt-build-farm.sh
+++ b/build-farm/make-adopt-build-farm.sh
@@ -68,10 +68,12 @@ esac
 
 if [ ! -d "${JDK_BOOT_DIR}" ]
 then
+  echo Setting JDK_BOOT_DIR to \$JAVA_HOME
   export JDK_BOOT_DIR="${JAVA_HOME}"
 fi
 
-echo "Boot jdk: ${JDK_BOOT_DIR}"
+echo "Boot jdk directory: ${JDK_BOOT_DIR}:"
+java -version 2>&1 | sed 's/^/BOOT JDK: /'
 
 if [ "${RELEASE}" == "true" ]; then
   OPTIONS="${OPTIONS} --release --clean-libs"


### PR DESCRIPTION
This is usually later on in the log as per the example below but will aid early diagnosis within the scripts if required:

```
checking Boot JDK version... openjdk version "12.0.2" 2019-07-16 OpenJDK Runtime Environment AdoptOpenJDK (build 12.0.2+10) OpenJDK 64-Bit Server VM AdoptOpenJDK (build 12.0.2+10, mixed mode, sharing) 
```

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>