### PR TITLE
buildDocker: Specify Eclipse in container names

### DIFF
--- a/docker/buildDocker.sh
+++ b/docker/buildDocker.sh
@@ -107,7 +107,7 @@ useEclipseDockerFiles()
 	do
 		# ${jdk%?} will remove the 'u' from 'jdk__u' when needed.
 		curl -o Dockerfile.$jdk https://raw.githubusercontent.com/eclipse/openj9/master/buildenv/docker/${jdk%?}/x86_64/ubuntu16/Dockerfile;
-		sharedDockerCommands $jdk
+		sharedEclipseDockerCommands $jdk
 	done
 }
 
@@ -125,11 +125,11 @@ useEclipseDockerSlavesFiles()
 	for jdk in $jdkVersion
 	do
 		cp Dockerfile $PWD/Dockerfile.$jdk
-		sharedDockerCommands $jdk
+		sharedEclipseDockerCommands $jdk
 	done
 }
 
-sharedDockerCommands()
+sharedEclipseDockerCommands()
 {
 	local jdk=$1
 	docker build -t $jdk -f Dockerfile.$jdk .

--- a/docker/buildDocker.sh
+++ b/docker/buildDocker.sh
@@ -133,7 +133,7 @@ sharedDockerCommands()
 {
 	local jdk=$1
 	docker build -t $jdk -f Dockerfile.$jdk .
-	docker run -it -u root -d --name=$jdk $jdk
+	docker run -it -u root -d --name=${jdk}-Eclipse $jdk
 	docker exec -u root -it $jdk sh -c "git clone https://github.com/ibmruntimes/openj9-openjdk-${jdk%?}"
 	docker exec -u root -it $jdk sh -c "cd openj9-openjdk-${jdk%?} && bash ./get_source.sh && bash ./configure --with-freemarker-jar=/root/freemarker.jar && make all"
 }


### PR DESCRIPTION
ref: https://adoptopenjdk.slack.com/archives/C09NW3L2J/p1575304389184900

Ensures the name of the docker containers reflect if the dockerfiles are from Eclipse. Should stop any conflicts of docker container names, as seen here:
https://ci.adoptopenjdk.net/job/DockerfileCheck/75/console