### PR TITLE
If signing of a file fails, back off for 10 seconds and retry

### DIFF
--- a/sign.sh
+++ b/sign.sh
@@ -69,7 +69,11 @@ signRelease()
       FILES=$(find . -type f -name '*.dll')
       echo "$FILES" | while read -r f;
       do
-        "$signToolPath" sign /f "${SIGNING_CERTIFICATE}" /p "$SIGN_PASSWORD" /fd SHA256 /t http://timestamp.verisign.com/scripts/timstamp.dll "$f";
+        if ! "$signToolPath" sign /f "${SIGNING_CERTIFICATE}" /p "$SIGN_PASSWORD" /fd SHA256 /t http://timestamp.verisign.com/scripts/timstamp.dll "$f"; then
+          echo "WARNING: Failed to sign $f at $(date +%T): Possible timestamp server error - RC $? ... Retrying in 10 seconds"
+          sleep 10
+          "$signToolPath" sign /f "${SIGNING_CERTIFICATE}" /p "$SIGN_PASSWORD" /fd SHA256 /t http://timestamp.verisign.com/scripts/timstamp.dll "$f"
+        fi
       done
       ;;
     "mac"*)


### PR DESCRIPTION
Fixes https://github.com/AdoptOpenJDK/openjdk-build/issues/1235 (or at least makes mitigation more likely)

Hit three instances of this last night:
- https://ci.adoptopenjdk.net/view/Failing%20Builds/job/build-scripts/job/jobs/job/jdk13u/job/jdk13u-windows-x86-32-hotspot/109/console
- https://ci.adoptopenjdk.net/view/Failing%20Builds/job/build-scripts/job/jobs/job/jdk8u/job/jdk8u-windows-x64-openj9/517/console
- https://ci.adoptopenjdk.net/view/Failing%20Builds/job/build-scripts/job/jobs/job/jdk8u/job/jdk8u-windows-x64-openj9-windowsXL/124/console

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>