### PR TITLE
Revert "Temporarily use JDK11 to boot JDK11 builds (#1411)"

### DIFF
--- a/build-farm/make-adopt-build-farm.sh
+++ b/build-farm/make-adopt-build-farm.sh
@@ -59,7 +59,7 @@ case "${JDK_BOOT_VERSION}" in
       "7")    export JDK_BOOT_DIR="${JDK_BOOT_DIR:-$JDK7_BOOT_DIR}";;
       "8")    export JDK_BOOT_DIR="${JDK_BOOT_DIR:-$JDK8_BOOT_DIR}";;
       "9")    export JDK_BOOT_DIR="${JDK_BOOT_DIR:-$JDK9_BOOT_DIR}";;
-      "10")   export JDK_BOOT_DIR="${JDK_BOOT_DIR:-$JDK11_BOOT_DIR}";;
+      "10")   export JDK_BOOT_DIR="${JDK_BOOT_DIR:-$JDK10_BOOT_DIR}";;
       "11")   export JDK_BOOT_DIR="${JDK_BOOT_DIR:-$JDK11_BOOT_DIR}";;
       "12")   export JDK_BOOT_DIR="${JDK_BOOT_DIR:-$JDK12_BOOT_DIR}";;
       "13")   export JDK_BOOT_DIR="${JDK_BOOT_DIR:-$JDK13_BOOT_DIR}";;


### PR DESCRIPTION
This reverts commit 572d554169a10c1b02a5f1440acd1657cbcb7648.

May cause issues if some of our build machines don't have a JDK10 boot JDK on them as such issues will no longer be masked after https://github.com/AdoptOpenJDK/openjdk-build/pull/1416/files was merged ... I'd prefer to sit and watch this after integrating tomorrow but I'll leave it to any reviewer as to whether to just approve or approve & merge before the automated runs tonight ;-)

Fixes https://github.com/AdoptOpenJDK/openjdk-build/issues/1409