### PR TITLE
buildDocker: Use only option -i for docker exec commands

### DIFF
--- a/docker/buildDocker.sh
+++ b/docker/buildDocker.sh
@@ -134,8 +134,8 @@ sharedEclipseDockerCommands()
 	local jdk=$1
 	docker build -t $jdk -f Dockerfile.$jdk .
 	docker run -it -u root -d --name=${jdk}-Eclipse $jdk
-	docker exec -u root -it $jdk sh -c "git clone https://github.com/ibmruntimes/openj9-openjdk-${jdk%?}"
-	docker exec -u root -it $jdk sh -c "cd openj9-openjdk-${jdk%?} && bash ./get_source.sh && bash ./configure --with-freemarker-jar=/root/freemarker.jar && make all"
+	docker exec -u root -i ${jdk}-Eclipse sh -c "git clone https://github.com/ibmruntimes/openj9-openjdk-${jdk%?}"
+	docker exec -u root -i ${jdk}-Eclipse sh -c "cd openj9-openjdk-${jdk%?} && bash ./get_source.sh && bash ./configure --with-freemarker-jar=/root/freemarker.jar && make all"
 }
 
 buildDocker()


### PR DESCRIPTION
This will stop the`the input device is not a TTY` error message found in https://ci.adoptopenjdk.net/job/DockerfileCheck/78/ in the `eclipsej9` section.
Further to #1423 , I've also made sure the docker containers specified have the correct name.