### PR TITLE
buildDocker: Remove Eclipse container once running build

### DIFF
--- a/docker/buildDocker.sh
+++ b/docker/buildDocker.sh
@@ -136,6 +136,8 @@ sharedEclipseDockerCommands()
 	docker run -it -u root -d --name=${jdk}-Eclipse $jdk
 	docker exec -u root -i ${jdk}-Eclipse sh -c "git clone https://github.com/ibmruntimes/openj9-openjdk-${jdk%?}"
 	docker exec -u root -i ${jdk}-Eclipse sh -c "cd openj9-openjdk-${jdk%?} && bash ./get_source.sh && bash ./configure --with-freemarker-jar=/root/freemarker.jar && make all"
+	docker stop ${jdk}-Eclipse
+	docker rm ${jdk}-Eclipse
 }
 
 buildDocker()


### PR DESCRIPTION
@sxa555 noticed in https://ci.adoptopenjdk.net/job/DockerfileCheck/label=infra-vagrant-T541,variant=eclipsej9,version=jdk8u/85/ that some builds would complete in a few minutes.  

This was because the container was not being removed once the build had finished, so this PR will stop and destroy the containers once building. 