### PR TITLE
Ensure Debian is built with openssl-1.0.2

### DIFF
--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -43,7 +43,7 @@ fi
 if [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]
 then
   # CentOS 6 has openssl 1.0.1 so we use a self-installed 1.0.2 from the playbooks
-  if grep 'release 6' /etc/redhat-release >/dev/null; then
+  if grep 'release 6' /etc/redhat-release >/dev/null 2>&1 || grep 'jessie' /etc/os-release >/dev/null 2>&1; then
     if [ -r /usr/local/openssl-1.0.2/include/openssl/opensslconf.h ]; then
       export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-openssl=/usr/local/openssl-1.0.2"
     else


### PR DESCRIPTION
With https://github.com/AdoptOpenJDK/openjdk-infrastructure/pull/1021 , I changed the OpenSSL102 role to include Debian8 - therefore the build script needs to be updated to change the build configuration when building on Debian 8.
I checked this wouldn't break CentOS6 too.