### PR TITLE
suppress 'which pigz' output as it looks like an error

### DIFF
--- a/sbin/common/common.sh
+++ b/sbin/common/common.sh
@@ -94,8 +94,8 @@ createOpenJDKArchive()
   fi
 
   COMPRESS=gzip
-  if which pigz; then
-    COMPRESS=pigz;
+  if which pigz > /dev/null 2>&1; then
+    COMPRESS=pigz
   fi
   echo "Archiving the build OpenJDK image and compressing with $COMPRESS"
 


### PR DESCRIPTION
This is frequently seen in the build log and has a tendancy to confuse people, when it's just checking if pigz is in place to see if it can be used in preference to gzip, which it will fall back to.

`which: no pigz in (/usr/local/gcc/bin:/usr/local/bin:/usr/bin)`

It's not an error, so suppress the output to avoid confusing people :-)



Signed-off-by: Stewart Addison <sxa@uk.ibm.com>