### PR TITLE
Ensure JDK8 and 11 are built on AIX xlc13-tagged machines

### DIFF
--- a/pipelines/build/openjdk11_pipeline.groovy
+++ b/pipelines/build/openjdk11_pipeline.groovy
@@ -82,6 +82,7 @@ def buildConfigurations = [
         ppc64Aix    : [
                 os                  : 'aix',
                 arch                : 'ppc64',
+                additionalNodeLabels: 'xlc13',
                 test                : [
                         nightly: false,
                         release: ['sanity.openjdk', 'sanity.system', 'extended.system']

--- a/pipelines/build/openjdk8_pipeline.groovy
+++ b/pipelines/build/openjdk8_pipeline.groovy
@@ -83,6 +83,7 @@ def buildConfigurations = [
         ppc64Aix      : [
                 os  : 'aix',
                 arch: 'ppc64',
+                additionalNodeLabels: 'xlc13',
                 test: [
                         nightly: false,
                         release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk']


### PR DESCRIPTION
Fixes https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1049

(To be fair it shouldn't be broken on the later AIX box, but I want to keep it on the older ones for now for compatibility...)

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>