### PR TITLE
Fix datestamps on last week of the year

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -278,7 +278,7 @@ class Builder implements Serializable {
             return
         }
 
-        def timestamp = new Date().format("YYYY-MM-dd-HH-mm", TimeZone.getTimeZone("UTC"))
+        def timestamp = new Date().format("yyyy-MM-dd-HH-mm", TimeZone.getTimeZone("UTC"))
         def tag = "${javaToBuild}-${timestamp}"
 
         if (publishName) {

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -409,7 +409,7 @@ class Build {
 
             fileName = "${fileName}_${nameTag}"
         } else {
-            def timestamp = new Date().format("YYYY-MM-dd-HH-mm", TimeZone.getTimeZone("UTC"))
+            def timestamp = new Date().format("yyyy-MM-dd-HH-mm", TimeZone.getTimeZone("UTC"))
 
             fileName = "${fileName}_${timestamp}"
         }


### PR DESCRIPTION
Somewhat belated since it's the last day of 2019, but this fixes https://github.com/AdoptOpenJDK/openjdk-build/issues/1456

Ref https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html for the datestamp formats

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>