### PR TITLE
Disable hotspot-jfr build trigger sanity.external test job

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -91,8 +91,13 @@ class Build {
 
     def runTests() {
         def testStages = [:]
-
-        List testList = buildConfig.TEST_LIST
+        List testList = []
+        
+        if (buildConfig.VARIANT == "hotspot-jfr") {
+        	testList = buildConfig.TEST_LIST.minus(['sanity.external'])
+        } else {
+        	testList = buildConfig.TEST_LIST
+        }
         testList.each { testType ->
             // For each requested test, i.e 'sanity.openjdk', 'sanity.system', 'sanity.perf', 'sanity.external', call test job
             try {


### PR DESCRIPTION
Disable hotspot-jfr build trigger sanity.external test job. Those test jobs are already triggered by hotspot build.

Close #1468 

Signed-off-by: Sophia Guo <sophiag@ca.ibm.com>