### PR TITLE
Fix bash syntax error for builds on jdk/jdk

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -346,7 +346,7 @@ buildTemplatedFile() {
 
   # If it's Java 9+ then we also make test-image to build the native test libraries
   JDK_PREFIX="jdk"
-  JDK_VERSION_NUMBER="${BUILD_CONFIG[OPENJDK_CORE_VERSION]#$JDK_PREFIX}"
+  JDK_VERSION_NUMBER="${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}"
   if [ "$JDK_VERSION_NUMBER" -gt 8 ] || [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDKHEAD_VERSION}" ]; then
     MAKE_TEST_IMAGE=" test-image" # the added white space is deliberate as it's the last arg
   fi


### PR DESCRIPTION
When invoking the build via './makejdk-any-platform.sh [...] jdk' the
BUILD_CONFIG[OPENJDK_CORE_VERSION] ends up being set to the same value
as JDK_PREFIX, namely 'jdk'. This results in
${BUILD_CONFIG[OPENJDK_CORE_VERSION]#$JDK_PREFIX} evaluating to the empty
string. Thus, the if statement:

if [ "$JDK_VERSION_NUMBER" -gt 8 ] ...

ends up being evaluated as 'if [ "" -gt 8 ] ... resulting in:

bash: [...] integer expression expected

Use BUILD_CONFIG[OPENJDK_FEATURE_NUMBER] instead which should always
be a numeric value.

Signed-off-by: Severin Gehwolf <sgehwolf@redhat.com>