### PR TITLE
Ensure JDK8 and 11 are built on AIX xlc13-tagged machines (#1451)

### DIFF
--- a/pipelines/build/openjdk11_pipeline.groovy
+++ b/pipelines/build/openjdk11_pipeline.groovy
@@ -82,6 +82,7 @@ def buildConfigurations = [
         ppc64Aix    : [
                 os                  : 'aix',
                 arch                : 'ppc64',
+                additionalNodeLabels: 'xlc13',
                 test                : [
                         nightly: false,
                         release: ['sanity.openjdk', 'sanity.system', 'extended.system']

--- a/pipelines/build/openjdk8_pipeline.groovy
+++ b/pipelines/build/openjdk8_pipeline.groovy
@@ -83,6 +83,7 @@ def buildConfigurations = [
         ppc64Aix      : [
                 os  : 'aix',
                 arch: 'ppc64',
+                additionalNodeLabels: 'xlc13',
                 test: [
                         nightly: false,
                         release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk']

--- a/pipelines/jobs/configurations/jdk13u.groovy
+++ b/pipelines/jobs/configurations/jdk13u.groovy
@@ -49,4 +49,6 @@ targetConfigurations = [
         ]
 ]
 
+disableJob = true
+
 return this


### PR DESCRIPTION
JDK13 is now out of support (And the OpenJ9 nightlies are now broken ...)

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>