### PR TITLE
Disable JDK13 nightly builds

### DIFF
--- a/pipelines/jobs/configurations/jdk13u.groovy
+++ b/pipelines/jobs/configurations/jdk13u.groovy
@@ -49,4 +49,6 @@ targetConfigurations = [
         ]
 ]
 
+disableJob = true
+
 return this


### PR DESCRIPTION
JDK13 now out of support, and the OpenJ9 repositories no longer can no longer build it.

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>