### PR TITLE
Update support for building JDK head

### DIFF
--- a/build-farm/make-adopt-build-farm.sh
+++ b/build-farm/make-adopt-build-farm.sh
@@ -29,7 +29,7 @@ JAVA_FEATURE_VERSION=$(echo "${JAVA_TO_BUILD}" | tr -d "[:alpha:]")
 if [ -z "${JAVA_FEATURE_VERSION}" ]
 then
     # THIS NEEDS TO BE UPDATED WHEN HEAD UPDATES (the latest tag that jdk/jdk contains)
-    JAVA_FEATURE_VERSION=14
+    JAVA_FEATURE_VERSION=15
 fi
 
 echo "BUILD TYPE: "

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -619,7 +619,15 @@ getFirstTagFromOpenJDKGitRepo()
     else
       git fetch --tags "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}"
       revList=$(git rev-list --tags --topo-order --max-count=$GIT_TAGS_TO_SEARCH)
-      firstMatchingNameFromRepo=$(git describe --tags $revList | grep jdk | grep -v openj9 | grep -v _adopt | grep -v "\-ga" | head -1)
+      if [[ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDKHEAD_VERSION}" ]]; then
+        # For the development tree jdk/jdk, there might be two major versions in development
+        # in parallel. One in stabilization mode, and the currently active developement line
+        # Thus, add an explicit grep on the specified FEATURE_VERSION so as to appropriately
+	# set the correct build number later on.
+        firstMatchingNameFromRepo=$(git describe --tags $revList | grep "jdk-${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" | grep -v openj9 | grep -v _adopt | grep -v "\-ga" | head -1)
+      else
+        firstMatchingNameFromRepo=$(git describe --tags $revList | grep jdk | grep -v openj9 | grep -v _adopt | grep -v "\-ga" | head -1)
+      fi
       # this may not find the correct tag if there are multiples on the commit so find commit
       # that contains this tag and then use `git tag` to find the real tag
       revList=$(git rev-list -n 1 $firstMatchingNameFromRepo --)

--- a/sbin/common/common.sh
+++ b/sbin/common/common.sh
@@ -35,7 +35,7 @@ function setOpenJdkVersion() {
   local featureNumber=$(echo "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" | tr -d "[:alpha:]")
 
   # feature number e.g. 11
-  BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]=${featureNumber:-14}
+  BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]=${featureNumber:-15}
 
 }
 


### PR DESCRIPTION
- Bump latest JDK feature version to 15
  See:
  https://github.com/AdoptOpenJDK/openjdk-jdk/blob/dev/make/autoconf/version-numbers#L29
- Fix tag lookup scheme so as to detect the
  appropriate major version originally specified.

Signed-off-by: Severin Gehwolf <sgehwolf@redhat.com>