### PR TITLE
Switch to API v3 and provide better diagnostics

### DIFF
--- a/build-farm/platform-specific-configurations/aix.sh
+++ b/build-farm/platform-specific-configurations/aix.sh
@@ -41,14 +41,17 @@ if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
     BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION-1))"
     BOOT_JDK_VARIABLE="JDK$(echo $BOOT_JDK_VERSION)_BOOT_DIR"
     if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then
-      export $BOOT_JDK_VARIABLE="$PWD/jdk-$BOOT_JDK_VERSION"
-      if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE/bin")" ]; then
-        bootDir="$(eval echo "\$$BOOT_JDK_VARIABLE")"
+      bootDir="$PWD/jdk-$BOOT_JDK_VERSION"
+      # Note we export $BOOT_JDK_VARIABLE (i.e. JDKXX_BOOT_DIR) here
+      # instead of BOOT_JDK_VARIABLE (no '$').
+      export ${BOOT_JDK_VARIABLE}="${bootDir}"
+      if [ ! -d "${bootDir}/bin" ]; then
         mkdir -p "${bootDir}"
-        wget -q -O - "https://api.adoptopenjdk.net/v2/binary/releases/openjdk${BOOT_JDK_VERSION}?os=aix&release=latest&arch=${ARCHITECTURE}&heap_size=normal&type=jdk&openjdk_impl=openj9" | tar xpzf - --strip-components=1 -C "${bootDir}"
+        wget -q -O - "https://api.adoptopenjdk.net/v3/binary/latest/${BOOT_JDK_VERSION}/ga/aix/${ARCHITECTURE}/jdk/hotspot/normal/adoptopenjdk" | tar xpzf - --strip-components=1 -C "${bootDir}"
       fi
     fi
     export JDK_BOOT_DIR="$(eval echo "\$$BOOT_JDK_VARIABLE")"
+    $JDK_BOOT_DIR/bin/java -version | sed 's/^/BOOT JDK: /'
 fi
 
 if [ "$JAVA_FEATURE_VERSION" -ge 11 ];

--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -89,13 +89,17 @@ if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
     BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION-1))"
     BOOT_JDK_VARIABLE="JDK$(echo $BOOT_JDK_VERSION)_BOOT_DIR"
     if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then
-      export $BOOT_JDK_VARIABLE="$PWD/jdk-$BOOT_JDK_VERSION"
-      if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE/bin")" ]; then
-        mkdir -p "$(eval echo "\$$BOOT_JDK_VARIABLE")"
-        wget -q -O - "https://api.adoptopenjdk.net/v2/binary/releases/openjdk${BOOT_JDK_VERSION}?os=linux&release=latest&arch=${ARCHITECTURE}&heap_size=normal&type=jdk&openjdk_impl=hotspot" | tar xpzf - --strip-components=1 -C "$(eval echo "\$$BOOT_JDK_VARIABLE")"
+      bootDir="$PWD/jdk-$BOOT_JDK_VERSION"
+      # Note we export $BOOT_JDK_VARIABLE (i.e. JDKXX_BOOT_DIR) here
+      # instead of BOOT_JDK_VARIABLE (no '$').
+      export ${BOOT_JDK_VARIABLE}="$bootDir"
+      if [ ! -d "$bootDir/bin" ]; then
+        mkdir -p "$bootDir"
+        wget -q -O - "https://api.adoptopenjdk.net/v3/binary/latest/${BOOT_JDK_VERSION}/ga/linux/${ARCHITECTURE}/jdk/hotspot/normal/adoptopenjdk" | tar xpzf - --strip-components=1 -C "$bootDir"
       fi
     fi
     export JDK_BOOT_DIR="$(eval echo "\$$BOOT_JDK_VARIABLE")"
+    $JDK_BOOT_DIR/bin/java -version | sed 's/^/BOOT JDK: /'
 fi
 
 # Any version above 10

--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -57,15 +57,17 @@ if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
     BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION-1))"
     BOOT_JDK_VARIABLE="JDK$(echo $BOOT_JDK_VERSION)_BOOT_DIR"
     if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then
-      export $BOOT_JDK_VARIABLE="$PWD/jdk-$BOOT_JDK_VERSION"
-      if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE/Contents/Home/bin")" ]; then
-        mkdir -p "$(eval echo "\$$BOOT_JDK_VARIABLE")"
-        wget -q -O - "https://api.adoptopenjdk.net/v2/binary/releases/openjdk${BOOT_JDK_VERSION}?os=mac&release=latest&arch=${ARCHITECTURE}&heap_size=normal&type=jdk&openjdk_impl=hotspot" | tar xpzf - --strip-components=1 -C "$(eval echo "\$$BOOT_JDK_VARIABLE")"
+      bootDir="$PWD/jdk-$BOOT_JDK_VERSION"
+      # Note we export $BOOT_JDK_VARIABLE (i.e. JDKXX_BOOT_DIR) here
+      # instead of BOOT_JDK_VARIABLE (no '$').
+      export ${BOOT_JDK_VARIABLE}="$bootDir/Contents/Home"
+      if [ ! -d "$bootDir/Contents/Home/bin" ]; then
+        mkdir -p "$bootDir"
+        wget -q -O - "https://api.adoptopenjdk.net/v3/binary/latest/${BOOT_JDK_VERSION}/ga/mac/${ARCHITECTURE}/jdk/hotspot/normal/adoptopenjdk" | tar xpzf - --strip-components=1 -C "$bootDir"
       fi
-      export JDK_BOOT_DIR="$(eval echo "\$$BOOT_JDK_VARIABLE/Contents/Home")"
-    else
-      export JDK_BOOT_DIR="$(eval echo "\$$BOOT_JDK_VARIABLE")"
     fi
+    export JDK_BOOT_DIR="$(eval echo "\$$BOOT_JDK_VARIABLE")"
+    $JDK_BOOT_DIR/bin/java -version | sed 's/^/BOOT JDK: /'
 fi
 
 if [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]; then

--- a/build-farm/platform-specific-configurations/windows.sh
+++ b/build-farm/platform-specific-configurations/windows.sh
@@ -31,14 +31,18 @@ TOOLCHAIN_VERSION=""
 if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
     BOOT_JDK_VARIABLE="JDK$(echo $BOOT_JDK_VERSION)_BOOT_DIR"
     if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then
-      export $BOOT_JDK_VARIABLE="$PWD/jdk-$BOOT_JDK_VERSION"
-      if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE/bin")" ]; then
-        wget -q "https://api.adoptopenjdk.net/v2/binary/releases/openjdk${BOOT_JDK_VERSION}?os=windows&release=latest&arch=x64&heap_size=normal&type=jdk&openjdk_impl=hotspot" -O openjdk.zip
+      bootDir="$PWD/jdk-$BOOT_JDK_VERSION"
+      # Note we export $BOOT_JDK_VARIABLE (i.e. JDKXX_BOOT_DIR) here
+      # instead of BOOT_JDK_VARIABLE (no '$').
+      export ${BOOT_JDK_VARIABLE}="$bootDir"
+      if [ ! -d "$bootDir/bin" ]; then
+        wget -q "https://api.adoptopenjdk.net/v3/binary/latest/${BOOT_JDK_VERSION}/ga/windows/${ARCHITECTURE}/jdk/hotspot/normal/adoptopenjdk" -O openjdk.zip
         unzip -q openjdk.zip
-        mv $(ls -d jdk-$BOOT_JDK_VERSION*) jdk-$BOOT_JDK_VERSION
+        mv $(ls -d jdk-${BOOT_JDK_VERSION}*) "$bootDir"
       fi
     fi
     export JDK_BOOT_DIR="$(eval echo "\$$BOOT_JDK_VARIABLE")"
+    $JDK_BOOT_DIR/bin/java -version | sed 's/^/BOOT JDK: /'
 fi
 
 if [ "${ARCHITECTURE}" == "x86-32" ]


### PR DESCRIPTION
Currently there is logic where when there is no directory
present pointed to by JDKxx_BOOT_DIR a fallback is in
place to download the JDK N-1 boot JDK version via the
API. If this fails for some reason, no diagnostics are
available.

This patch tries to simplify the logic a bit and adds an
additional 'java -version' output for the - potentially -
changed boot JDK the build will be using.

Signed-off-by: Severin Gehwolf <sgehwolf@redhat.com>