### PR TITLE
Disable JDK 10u pipeline job

### DIFF
--- a/pipelines/jobs/configurations/jdk10u.groovy
+++ b/pipelines/jobs/configurations/jdk10u.groovy
@@ -44,4 +44,6 @@ targetConfigurations = [
         ]
 ]
 
+disableJob = true
+
 return this


### PR DESCRIPTION
This would be a step towards auto-detecting new pipelines and
generating them.

JDK 10u is deprecated anyway.