### PR TITLE
Fix compilation of pipelines

### DIFF
--- a/pipelines/build/openjdk8_pipeline.groovy
+++ b/pipelines/build/openjdk8_pipeline.groovy
@@ -135,7 +135,7 @@ def buildConfigurations = [
                 additionalNodeLabels : 'centos6',
                 arch                 : 'x64',
                 additionalFileNameTag: "linuxXL",
-                configureArgs        : '--with-noncompressedrefs --enable-jitserver'
+                configureArgs        : '--with-noncompressedrefs --enable-jitserver',
                 test                 : ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk'],
         ],
         s390xLinuxXL       : [


### PR DESCRIPTION
Caused by b8ffae5cf892a7efb35714783def2fb65796079b.
ff2f113a1ee68a2fd4b3b5b70d0c7a73ea68da00 seems to have happened in
between and the revert was not clean?

Signed-off-by: Severin Gehwolf <sgehwolf@redhat.com>