### PR TITLE
Add pipeline for JDK14 with OpenJ9

### DIFF
--- a/pipelines/build/openjdk14_pipeline.groovy
+++ b/pipelines/build/openjdk14_pipeline.groovy
@@ -16,11 +16,23 @@ def buildConfigurations = [
         x64Mac    : [
                 os                  : 'mac',
                 arch                : 'x64',
-                additionalNodeLabels : 'macos10.12',
+                additionalNodeLabels: 'macos10.12',
                 test                : [
                         nightly: false,
                         release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
                 ]
+        ],
+
+        x64MacXL: [
+                os                   : 'mac',
+                arch                 : 'x64',
+                additionalNodeLabels : 'macos10.12',
+                test                 : [
+                        nightly: false,
+                        release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
+                ],
+                additionalFileNameTag: "macosXL",
+                configureArgs        : '--with-noncompressedrefs'
         ],
 
         x64Linux  : [
@@ -32,6 +44,18 @@ def buildConfigurations = [
                         release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external', 'special.functional']
                 ],
                 configureArgs        : '--disable-ccache'
+        ],
+
+        x64LinuxXL    : [
+                os                   : 'linux',
+                additionalNodeLabels : 'centos6',
+                arch                 : 'x64',
+                test                 : [
+                        nightly: false,
+                        release: ['sanity.openjdk', 'sanity.system', 'extended.system']
+                ],
+                additionalFileNameTag: "linuxXL",
+                configureArgs        : '--with-noncompressedrefs --disable-ccache'
         ],
 
         // Currently we have to be quite specific about which windows to use as not all of them have freetype installed
@@ -50,6 +74,19 @@ def buildConfigurations = [
                 ]
         ],
 
+        x64WindowsXL    : [
+                os                   : 'windows',
+                arch                 : 'x64',
+                additionalNodeLabels : 'win2012&&vs2017',
+                test                 : [
+                        nightly: false,
+                        release: ['sanity.openjdk', 'sanity.perf', 'sanity.system', 'extended.system']
+                ],
+                additionalFileNameTag: "windowsXL",
+                configureArgs        : '--with-noncompressedrefs'
+        ],
+
+
         s390xLinux    : [
                 os                  : 'linux',
                 arch                : 's390x',
@@ -58,6 +95,17 @@ def buildConfigurations = [
                         release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
                 ],
                 configureArgs        : '--disable-ccache'
+        ],
+
+        s390xLinuxXL    : [
+                os                   : 'linux',
+                arch                 : 's390x',
+                test                 : [
+                        nightly: false,
+                        release: ['sanity.openjdk', 'sanity.system', 'extended.system']
+                ],
+                additionalFileNameTag: "linuxXL",
+                configureArgs        : '--with-noncompressedrefs --disable-ccache'
         ],
 
         ppc64leLinux    : [
@@ -69,6 +117,17 @@ def buildConfigurations = [
                 ],
                 configureArgs       : '--disable-ccache'
 
+        ],
+
+        ppc64leLinuxXL    : [
+                os                   : 'linux',
+                arch                 : 'ppc64le',
+                test                 : [
+                        nightly: false,
+                        release: ['sanity.openjdk', 'sanity.system', 'extended.system']
+                ],
+                additionalFileNameTag: "linuxXL",
+                configureArgs        : '--with-noncompressedrefs --disable-ccache'
         ],
 
         aarch64Linux    : [

--- a/pipelines/jobs/configurations/jdk14.groovy
+++ b/pipelines/jobs/configurations/jdk14.groovy
@@ -1,18 +1,38 @@
 targetConfigurations = [
         "x64Mac"      : [
-                "hotspot"
+                "hotspot",
+                "openj9"
+        ],
+        "x64MacXL"    : [
+                "openj9"
         ],
         "x64Linux"    : [
-                "hotspot"
+                "hotspot",
+                "openj9"
+        ],
+        "x64LinuxXL"  : [
+                "openj9"
         ],
         "x64Windows"  : [
-                "hotspot"
+                "hotspot",
+                "openj9"
+        ],
+        "x64WindowsXL": [
+                "openj9"
         ],
         "ppc64leLinux": [
-                "hotspot"
+                "hotspot",
+                "openj9"
         ],
+        "ppc64leLinuxXL": [
+                "openj9"
+        ]
         "s390xLinux"  : [
-                "hotspot"
+                "hotspot",
+                "openj9"
+        ],
+        "s390xLinuxXL": [
+                "openj9"
         ],
         "aarch64Linux": [
                 "hotspot"


### PR DESCRIPTION
Configurations for jdk14 openj9 build pipeline on most supported platforms. Disabled tests

Signed-off-by: Adam Thorpe <adam.thorpe@ibm.com>