### PR TITLE
Add sanity.openjdk testing to AIX JDK8/11 pipelines

### DIFF
--- a/pipelines/build/openjdk11_pipeline.groovy
+++ b/pipelines/build/openjdk11_pipeline.groovy
@@ -87,7 +87,7 @@ def buildConfigurations = [
                 arch                : 'ppc64',
                 additionalNodeLabels: 'xlc13',
                 test                : [
-                        nightly: false,
+                        nightly: ['sanity.openjdk'],
                         release: ['sanity.openjdk', 'sanity.system', 'extended.system']
                 ]
         ],

--- a/pipelines/build/openjdk8_pipeline.groovy
+++ b/pipelines/build/openjdk8_pipeline.groovy
@@ -86,7 +86,7 @@ def buildConfigurations = [
                 arch: 'ppc64',
                 additionalNodeLabels: 'xlc13',
                 test: [
-                        nightly: false,
+                        nightly: ['sanity.openjdk'],
                         release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk']
                 ]
         ],


### PR DESCRIPTION
We have a bit more AIX capacity and while the machines aren't fully verified as working, we should now be able to run at least the sanity testing nightly

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>