### PR TITLE
aix: enable openssl support on JDK8/J9

### DIFF
--- a/build-farm/platform-specific-configurations/aix.sh
+++ b/build-farm/platform-specific-configurations/aix.sh
@@ -54,14 +54,14 @@ if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
     "$JDK_BOOT_DIR/bin/java" -version 2>&1 | sed 's/^/BOOT JDK: /'
 fi
 
-if [ "$JAVA_FEATURE_VERSION" -ge 11 ];
-then
-  if [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]; then
-    export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-warnings-as-errors --with-openssl=fetched"
-  else
-    export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} DF=/usr/sysv/bin/df"
-  fi
 
+if [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]; then
+  export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-warnings-as-errors --with-openssl=fetched"
+else
+  export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} DF=/usr/sysv/bin/df"
+fi
+
+if [ "$JAVA_FEATURE_VERSION" -ge 11 ]; then
   export LANG=C
   if [ "$JAVA_FEATURE_VERSION" -ge 13 ]; then
     export PATH=/opt/freeware/bin:$JAVA_HOME/bin:/usr/local/bin:/opt/IBM/xlC/16.1.0/bin:/opt/IBM/xlc/16.1.0/bin:$PATH

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -82,7 +82,10 @@ configuringBootJDKConfigureParameter()
 # Configure the boot JDK
 configuringMacOSCodesignParameter()
 {
-  addConfigureArgIfValueIsNotEmpty "--with-macosx-codesign-identity=" "\"${BUILD_CONFIG[MACOSX_CODESIGN_IDENTITY]}\""
+  if [ ! -z "${BUILD_CONFIG[MACOSX_CODESIGN_IDENTITY]}" ]; then
+    # This commmand needs to escape the double quotes because they are needed to preserve the spaces in the codesign cert name
+    addConfigureArg "--with-macosx-codesign-identity=" "\"${BUILD_CONFIG[MACOSX_CODESIGN_IDENTITY]}\""
+  fi
 }
 
 # Get the OpenJDK update version and build version


### PR DESCRIPTION
Apparently we haven't been building JDK8 OpenJ9 builds with the OpenSSL support enabled. This PR resolves that.

Testing at https://ci.adoptopenjdk.net/view/work%20in%20progress/job/SXA-aix8j9ssl/2/console

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>