### PR TITLE
Work-around 'set -e' for the JDK N-1 fallback download

### DIFF
--- a/build-farm/platform-specific-configurations/aix.sh
+++ b/build-farm/platform-specific-configurations/aix.sh
@@ -51,8 +51,14 @@ if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
         releaseType="ga"
         apiUrlTemplate="https://api.adoptopenjdk.net/v3/binary/latest/\${BOOT_JDK_VERSION}/\${releaseType}/aix/\${ARCHITECTURE}/jdk/hotspot/normal/adoptopenjdk"
         apiURL=$(eval echo ${apiUrlTemplate})
+        # make-adopt-build-farm.sh has 'set -e'. We need to disable that
+        # for the fallback mechanism, as downloading of the GA binary might
+        # fail.
+        set +e
         wget -q -O - "${apiURL}" | tar xpzf - --strip-components=1 -C "$bootDir"
-        if [ $? -ne 0 ]; then
+        retVal=$?
+        set -e
+        if [ $retVal -ne 0 ]; then
           # We must be a JDK HEAD build for which no boot JDK exists other than
           # nightlies?
           echo "Downloading GA release of boot JDK version ${BOOT_JDK_VERSION} failed."

--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -99,8 +99,14 @@ if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
         releaseType="ga"
         apiUrlTemplate="https://api.adoptopenjdk.net/v3/binary/latest/\${BOOT_JDK_VERSION}/\${releaseType}/linux/\${ARCHITECTURE}/jdk/hotspot/normal/adoptopenjdk"
         apiURL=$(eval echo ${apiUrlTemplate})
+        # make-adopt-build-farm.sh has 'set -e'. We need to disable that
+        # for the fallback mechanism, as downloading of the GA binary might
+        # fail.
+        set +e
         wget -q -O - "${apiURL}" | tar xpzf - --strip-components=1 -C "$bootDir"
-        if [ $? -ne 0 ]; then
+        retVal=$?
+        set -e
+        if [ $retVal -ne 0 ]; then
           # We must be a JDK HEAD build for which no boot JDK exists other than
           # nightlies?
           echo "Downloading GA release of boot JDK version ${BOOT_JDK_VERSION} failed."

--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -77,8 +77,14 @@ if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
         releaseType="ga"
         apiUrlTemplate="https://api.adoptopenjdk.net/v3/binary/latest/\${BOOT_JDK_VERSION}/\${releaseType}/mac/\${ARCHITECTURE}/jdk/hotspot/normal/adoptopenjdk"
         apiURL=$(eval echo ${apiUrlTemplate})
+        # make-adopt-build-farm.sh has 'set -e'. We need to disable that
+        # for the fallback mechanism, as downloading of the GA binary might
+        # fail.
+        set +e
         wget -q -O - "${apiURL}" | tar xpzf - --strip-components=1 -C "$bootDir"
-        if [ $? -ne 0 ]; then
+        retVal=$?
+        set -e
+        if [ $retVal -ne 0 ]; then
           # We must be a JDK HEAD build for which no boot JDK exists other than
           # nightlies?
           echo "Downloading GA release of boot JDK version ${BOOT_JDK_VERSION} failed."

--- a/build-farm/platform-specific-configurations/windows.sh
+++ b/build-farm/platform-specific-configurations/windows.sh
@@ -41,8 +41,14 @@ if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
         releaseType="ga"
         apiUrlTemplate="https://api.adoptopenjdk.net/v3/binary/latest/\${BOOT_JDK_VERSION}/\${releaseType}/windows/\${ARCHITECTURE}/jdk/hotspot/normal/adoptopenjdk"
         apiURL=$(eval echo ${apiUrlTemplate})
+        # make-adopt-build-farm.sh has 'set -e'. We need to disable that
+        # for the fallback mechanism, as downloading of the GA binary might
+        # fail.
+        set +e
         wget -q "${apiURL}" -O openjdk.zip
-        if [ $? -ne 0 ]; then
+        retVal=$?
+        set -e
+        if [ $retVal -ne 0 ]; then
           # We must be a JDK HEAD build for which no boot JDK exists other than
           # nightlies?
           echo "Downloading GA release of boot JDK version ${BOOT_JDK_VERSION} failed."


### PR DESCRIPTION
This would be a (temporary) fix to actually get the JDK HEAD
pipelines building. Currently they fail with:

```
Downloading GA release of boot JDK version 14...
gzip: stdin: unexpected end of file
tar: Child returned status 1
tar: Error is not recoverable: exiting now
```

That is, 'set -e', prevents for the fallback download
using the EA version of JDK 14 to actually happen.

Signed-off-by: Severin Gehwolf <sgehwolf@redhat.com>