### PR TITLE
Expand use of '--with-macosx-codesign-identity'

### DIFF
--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -50,7 +50,9 @@ else
   fi
 fi
 
-if [ "${JAVA_TO_BUILD}" == "${JDK11_VERSION}" ]
+# The configure option '--with-macosx-codesign-identity' is supported in Java 11 and higher versions.
+# The OpenJ9 variant also supports that option in Java 8.
+if [ "$JAVA_FEATURE_VERSION" -ge 11 ] || [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]
 then
   export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-sysroot=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
   # Login to KeyChain


### PR DESCRIPTION
On MacOSX, jdk versions 11 and higher support code-signing and the OpenJ9 variant also supports jdk 8.