### PR TITLE
concurrentBuild is deprecated

### DIFF
--- a/pipelines/build/common/create_job_from_template.groovy
+++ b/pipelines/build/common/create_job_from_template.groovy
@@ -48,8 +48,8 @@ pipelineJob("$buildFolder/$JOB_NAME") {
             scriptPath('pipelines/build/common/kick_off_build.groovy')
         }
     }
-    concurrentBuild(false)
     properties {
+	disableConcurrentBuilds()
         copyArtifactPermissionProperty {
             projectNames('*')
         }

--- a/pipelines/jobs/pipeline_job_template.groovy
+++ b/pipelines/jobs/pipeline_job_template.groovy
@@ -37,7 +37,6 @@ pipelineJob("${BUILD_FOLDER}/${JOB_NAME}") {
         }
     }
     disabled(disableJob)
-    concurrentBuild(false)
     triggers {
         cron(triggerSchedule)
     }
@@ -47,6 +46,7 @@ pipelineJob("${BUILD_FOLDER}/${JOB_NAME}") {
     }
 
     properties {
+	disableConcurrentBuilds()
         copyArtifactPermissionProperty {
             projectNames('*')
         }


### PR DESCRIPTION
concurrentBuild is deprecated since DSL 1.76. Replace with new disableConcurrentBuilds() property. 

Signed-off-by: Morgan Davies <morgan.davies@ibm.com>