### PR TITLE
Updated JavaVersionNumber method to use matches()

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -54,17 +54,18 @@ class Build {
     }
 
 
-    Integer getJavaVersionNumber() {
+	Integer getJavaVersionNumber() {
+		def javaToBuild = buildConfig.JAVA_TO_BUILD
         // version should be something like "jdk8u" or "jdk" for HEAD
-        def matcher = (buildConfig.JAVA_TO_BUILD =~ /(\d+)/)
-        if (matcher.find()) {
-            List<String> list = matcher[0] as List
-            return Integer.parseInt(list[1] as String)
-        } else if ("jdk".equalsIgnoreCase(buildConfig.JAVA_TO_BUILD.trim())) {
+        Matcher matcher = javaToBuild =~ /.*?(?<version>\d+).*?/
+        if (matcher.matches()) {
+            return Integer.parseInt(matcher.group('version'))
+        } else if ("jdk".equalsIgnoreCase(javaToBuild.trim())) {
             // This needs to get updated when JDK HEAD version updates
             return Integer.valueOf("15")
         } else {
-            return Integer.valueOf("-1")
+            context.error("Failed to read java version '${javaToBuild}'")
+            throw new Exception()
         }
     }
 


### PR DESCRIPTION
Needed because configuration of groovy scripts don't allow `matches.find()`
Just copied the method from build_base_file.groovy and accounted for `buildConfig.JAVA_TO_BUILD`
FYI @jerboaa

Signed-off-by: Adam Thorpe <adam.thorpe@ibm.com>