### PR TITLE
move jdk14 and 15 to macos machine that can support notarization

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -148,7 +148,7 @@ class Build {
     def sign(VersionInfo versionInfo) {
         // Sign and archive jobs if needed
         // TODO: This version info check needs to be updated when the notarization fix gets applied to other versions.
-        if (buildConfig.TARGET_OS == "windows" || (buildConfig.TARGET_OS == "mac" && versionInfo.major != 11)) {
+        if (buildConfig.TARGET_OS == "windows" || (buildConfig.TARGET_OS == "mac" && versionInfo.major == 8) || (buildConfig.TARGET_OS == "mac" && versionInfo.major == 13)) {
             context.node('master') {
                 context.stage("sign") {
                     def filter = ""
@@ -161,7 +161,6 @@ class Build {
                         certificate = "C:\\Users\\jenkins\\windows.p12"
                         nodeFilter = "${nodeFilter}&&build"
 
-                    // TODO: This version info check needs to be updated when the notarization fix gets applied to other versions.
                     } else if (buildConfig.TARGET_OS == "mac") {
                         filter = "**/OpenJDK*_mac_*.tar.gz"
                         certificate = "\"Developer ID Application: London Jamocha Community CIC\""

--- a/pipelines/build/openjdk14_pipeline.groovy
+++ b/pipelines/build/openjdk14_pipeline.groovy
@@ -16,7 +16,7 @@ def buildConfigurations = [
         x64Mac    : [
                 os                  : 'mac',
                 arch                : 'x64',
-                additionalNodeLabels: 'macos10.12',
+                additionalNodeLabels : 'macos10.14',
                 test                : [
                         nightly: false,
                         release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
@@ -26,7 +26,7 @@ def buildConfigurations = [
         x64MacXL: [
                 os                   : 'mac',
                 arch                 : 'x64',
-                additionalNodeLabels : 'macos10.12',
+                additionalNodeLabels : 'macos10.14',
                 test                 : [
                         nightly: false,
                         release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']

--- a/pipelines/build/openjdk15_pipeline.groovy
+++ b/pipelines/build/openjdk15_pipeline.groovy
@@ -16,7 +16,7 @@ def buildConfigurations = [
         x64Mac    : [
                 os                  : 'mac',
                 arch                : 'x64',
-                additionalNodeLabels: 'macos10.12',
+                additionalNodeLabels: 'macos10.14',
                 test                : [
                         nightly: false,
                         release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']


### PR DESCRIPTION
@sxa555 this will now move all jdk14 and 15 builds to our Mojave build machine too. I suggest that we consider deprecating the macos10.12 machine and spin up an additional 10.14 machine.

We should be able to take the 10.12 machine offline as soon as we stop building jdk13 (if we haven't already)