### PR TITLE
Remove jdk13 reference

### DIFF
--- a/pipelines/build/prTester/pr_test_pipeline.groovy
+++ b/pipelines/build/prTester/pr_test_pipeline.groovy
@@ -70,7 +70,7 @@ Map<String, ?> defaultTestConfigurations = [
         ]
 ]
 
-List<Integer> defaultJavaVersions = [8, 11, 13]
+List<Integer> defaultJavaVersions = [8, 11, 14, 15]
 
 defaultGitRepo = "https://github.com/AdoptOpenJDK/openjdk-build"
 


### PR DESCRIPTION
JDK13 pipeline still runs this might be why

Signed-off-by: Adam Thorpe <adam.thorpe@ibm.com>