### PR TITLE
docker: Add Dockerfiles for JDK14

### DIFF
--- a/docker/jdk14/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk14/x86_64/ubuntu/Dockerfile
@@ -1,0 +1,92 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ubuntu:18.04
+
+LABEL maintainer="AdoptOpenJDK <adoption-discuss@openjdk.java.net>"
+
+# Install required OS tools
+# dirmngr, gpg-agent & coreutils are all required for the apt-add repository command
+RUN apt-get update \
+  && apt-get install -qq -y --no-install-recommends \
+    software-properties-common \
+    dirmngr \
+    gpg-agent \
+    coreutils \
+  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 \
+  && add-apt-repository 'deb http://repos.azulsystems.com/ubuntu stable main' \
+  && apt-get update \
+  && apt-get -y upgrade \
+  && apt-get install -qq -y --no-install-recommends \
+    autoconf \
+    ccache \
+    cpio \
+    curl \
+    file \
+    g++ \
+    gcc \
+    git \
+    libasound2-dev \
+    libcups2-dev \
+    libelf-dev \
+    libfontconfig1-dev \
+    libfreetype6-dev \
+    libx11-dev \
+    libxext-dev \
+    libxrandr-dev \
+    libxrender-dev \
+    libxt-dev \
+    libxtst-dev \
+    make \
+    systemtap-sdt-dev \
+    unzip \
+    wget \
+    zip \
+    ssh \
+&& rm -rf /var/lib/apt/lists/*
+
+# Pick up build instructions
+RUN mkdir -p /openjdk/target
+
+# Extract AdoptOpenJDK8 to run Gradle.
+RUN wget 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk8?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk' -O jdk8.tar.gz
+RUN mkdir -p /usr/lib/jvm/jdk8 && tar -xvf /jdk8.tar.gz -C /usr/lib/jvm/jdk8 --strip-components=1
+
+# Extract AdoptOpenJDK13 for JDK_BOOT_DIR.
+RUN wget 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk13?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk' -O jdk13.tar.gz
+RUN mkdir -p /usr/lib/jvm/jdk13 && tar -xvf /jdk13.tar.gz -C /usr/lib/jvm/jdk13 --strip-components=1
+RUN ln -sf /usr/lib/jvm/jdk13/bin/java /usr/bin/java
+RUN ln -sf /usr/lib/jvm/jdk13/bin/javac /usr/bin/javac
+
+
+COPY sbin /openjdk/sbin
+COPY workspace/config /openjdk/config
+
+# Create User "build"
+ARG HostUID
+ENV HostUID=$HostUID
+RUN mkdir -p /openjdk/build
+RUN useradd -u $HostUID -ms /bin/bash build
+RUN chown -R build: /openjdk/
+USER build
+WORKDIR /openjdk/build/
+
+# Default actions
+ENTRYPOINT ["/openjdk/sbin/build.sh"]
+
+CMD ["images"]
+
+ARG OPENJDK_VERSION
+ENV OPENJDK_VERSION=$OPENJDK_VERSION
+ENV JDK_PATH=jdk
+ENV JAVA_HOME=/usr/lib/jvm/jdk8

--- a/docker/jdk14/x86_64/ubuntu/Dockerfile-openj9
+++ b/docker/jdk14/x86_64/ubuntu/Dockerfile-openj9
@@ -1,0 +1,90 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ubuntu:16.04
+
+LABEL maintainer="AdoptOpenJDK <adoption-discuss@openjdk.java.net>"
+
+# Install required OS tools
+RUN apt-get update \
+    && apt-get -y upgrade \
+    && apt-get install -qq -y --no-install-recommends \
+       autoconf \
+       cpio \
+       curl \
+       file \
+       git \
+       gnupg2 \
+       libasound2-dev \
+       libcups2-dev \
+       libdwarf-dev \
+       libelf-dev \
+       libfontconfig1-dev \
+       libfreetype6-dev \
+       libnuma-dev \
+       libx11-dev \
+       libxext-dev \
+       libxrandr-dev \
+       libxrender-dev \
+       libxt-dev \
+       libxtst-dev \
+       make \
+       nasm \
+       openjdk-8-jdk \
+       pkg-config \
+       software-properties-common \
+       ssh \
+       unzip \
+       wget \
+       zip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Make sure build uses GCC 7.3
+RUN cd /usr/local \
+  && wget -O gcc-7.tar.xz "https://ci.adoptopenjdk.net/userContent/gcc/gcc730+ccache.x86_64.tar.xz" \
+  && tar -xJf gcc-7.tar.xz \
+  && rm -rf gcc-7.tar.xz
+
+# Create links for GCC to access the C library and gcc,g++
+RUN ln -s /usr/lib/x86_64-linux-gnu /usr/lib64 \
+  && ln -s /usr/include/x86_64-linux-gnu/* /usr/local/gcc/include \
+  && ln -s /usr/local/gcc/bin/g++-7.3 /usr/bin/g++ \
+  && ln -s /usr/local/gcc/bin/gcc-7.3 /usr/bin/gcc \
+  && ln -s /usr/local/gcc/bin/ccache /usr/local/bin/ccache
+
+RUN mkdir -p /openjdk/target
+
+# Extract AdoptOpenJDK13 for JDK_BOOT_DIR.
+RUN wget 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk13?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk' -O jdk13.tar.gz
+RUN mkdir -p /usr/lib/jvm/jdk13 && tar -xvf /jdk13.tar.gz -C /usr/lib/jvm/jdk13 --strip-components=1
+RUN ln -sf /usr/lib/jvm/jdk13/bin/java /usr/bin/java
+RUN ln -sf /usr/lib/jvm/jdk13/bin/javac /usr/bin/javac
+
+COPY sbin /openjdk/sbin
+COPY workspace/config /openjdk/config
+COPY pipelines /openjdk/pipelines
+
+# Create User "build"
+ARG HostUID
+ENV HostUID=$HostUID
+RUN mkdir -p /openjdk/build
+RUN useradd -u $HostUID -ms /bin/bash build
+RUN chown -R build /openjdk/
+USER build
+WORKDIR /openjdk/build/
+
+ARG OPENJDK_CORE_VERSION
+ENV OPENJDK_CORE_VERSION=$OPENJDK_CORE_VERSION
+ENV JDK_PATH=jdk
+ENV JDK8_BOOT_DIR=/usr/lib/jvm/java-8-openjdk-amd64
+

--- a/docker/jdk14/x86_64/ubuntu/dockerConfiguration.sh
+++ b/docker/jdk14/x86_64/ubuntu/dockerConfiguration.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# shellcheck disable=SC2034
+# Disable for whole file
+
+# This config is read in by configureBuild
+BUILD_CONFIG[OS_KERNEL_NAME]="linux"
+BUILD_CONFIG[OS_ARCHITECTURE]="x86_64"
+BUILD_CONFIG[BUILD_FULL_NAME]="linux-x86_64-normal-server-release"


### PR DESCRIPTION
Based entirely off the JDK13 ones, having ran `sed 's/jdk13/jdk14/g'` on a copy of them. 
I'll replace JDK13 with JDK14 in the `DockerfileCheck` Job once merged :-)