### PR TITLE
Revert "Removed erroneous tags (#1530)"

### DIFF
--- a/build-farm/platform-specific-configurations/aix.sh
+++ b/build-farm/platform-specific-configurations/aix.sh
@@ -55,7 +55,7 @@ if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
         # for the fallback mechanism, as downloading of the GA binary might
         # fail.
         set +e
-        wget -q -O - "${apiURL}" | tar xpzf --strip-components=1 -C "$bootDir"
+        wget -q -O - "${apiURL}" | tar xpzf - --strip-components=1 -C "$bootDir"
         retVal=$?
         set -e
         if [ $retVal -ne 0 ]; then
@@ -66,7 +66,7 @@ if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
           # shellcheck disable=SC2034
           releaseType="ea"
           apiURL=$(eval echo ${apiUrlTemplate})
-          wget -q -O - "${apiURL}" | tar xpzf --strip-components=1 -C "$bootDir"
+          wget -q -O - "${apiURL}" | tar xpzf - --strip-components=1 -C "$bootDir"
         fi
       fi
     fi

--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -103,7 +103,7 @@ if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
         # for the fallback mechanism, as downloading of the GA binary might
         # fail.
         set +e
-        wget -q -O - "${apiURL}" | tar xpzf --strip-components=1 -C "$bootDir"
+        wget -q -O - "${apiURL}" | tar xpzf - --strip-components=1 -C "$bootDir"
         retVal=$?
         set -e
         if [ $retVal -ne 0 ]; then
@@ -114,7 +114,7 @@ if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
           # shellcheck disable=SC2034
           releaseType="ea"
           apiURL=$(eval echo ${apiUrlTemplate})
-          wget -q -O - "${apiURL}" | tar xpzf --strip-components=1 -C "$bootDir"
+          wget -q -O - "${apiURL}" | tar xpzf - --strip-components=1 -C "$bootDir"
         fi
       fi
     fi

--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -83,7 +83,7 @@ if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
         # for the fallback mechanism, as downloading of the GA binary might
         # fail.
         set +e
-        wget -q -O - "${apiURL}" | tar xpzf --strip-components=1 -C "$bootDir"
+        wget -q -O - "${apiURL}" | tar xpzf - --strip-components=1 -C "$bootDir"
         retVal=$?
         set -e
         if [ $retVal -ne 0 ]; then
@@ -94,7 +94,7 @@ if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
           # shellcheck disable=SC2034
           releaseType="ea"
           apiURL=$(eval echo ${apiUrlTemplate})
-          wget -q -O - "${apiURL}" | tar xpzf --strip-components=1 -C "$bootDir"
+          wget -q -O - "${apiURL}" | tar xpzf - --strip-components=1 -C "$bootDir"
         fi
       fi
     fi


### PR DESCRIPTION
Breaks the builds when a boot JDK is downloaded as it doesn't include the `-` parameter to `tar` 

This reverts commit 0cba20148cb3e02f2a830f2f912be1b4febaf386.