### PR TITLE
env: Fix detection of failed macos boot jdk download

### DIFF
--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -83,7 +83,7 @@ if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
         # for the fallback mechanism, as downloading of the GA binary might
         # fail.
         set +e
-        wget -q -O - "${apiURL}" | tar xpzf - --strip-components=1 -C "$bootDir"
+        wget -q -O "${BOOT_JDK_VERSION}.tgz" "${apiURL}" && tar xpzf "${BOOT_JDK_VERSION}.tgz" --strip-components=1 -C "$bootDir" && rm "${BOOT_JDK_VERSION}.tgz"
         retVal=$?
         set -e
         if [ $retVal -ne 0 ]; then


### PR DESCRIPTION
On macos the error code from wget | tar does not get correctly detected
This will do it in a way that will correctly cause a failure code if
they wget does not work.

FYI @adam-thorpe 