### PR TITLE
aix: Use OpenJ9 VM as boot JDK to avoid crashes

### DIFF
--- a/build-farm/platform-specific-configurations/aix.sh
+++ b/build-farm/platform-specific-configurations/aix.sh
@@ -49,7 +49,7 @@ if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
         mkdir -p "${bootDir}"
         echo "Downloading GA release of boot JDK version ${BOOT_JDK_VERSION}..."
         releaseType="ga"
-        apiUrlTemplate="https://api.adoptopenjdk.net/v3/binary/latest/\${BOOT_JDK_VERSION}/\${releaseType}/aix/\${ARCHITECTURE}/jdk/hotspot/normal/adoptopenjdk"
+        apiUrlTemplate="https://api.adoptopenjdk.net/v3/binary/latest/\${BOOT_JDK_VERSION}/\${releaseType}/aix/\${ARCHITECTURE}/jdk/openj9/normal/adoptopenjdk"
         apiURL=$(eval echo ${apiUrlTemplate})
         # make-adopt-build-farm.sh has 'set -e'. We need to disable that
         # for the fallback mechanism, as downloading of the GA binary might


### PR DESCRIPTION
The current HotSpot JDK13 was built on a later version of AIX than the current build machines and is causing a crash when we try to use it as the boot JDK for JDK14:

```
Downloading GA release of boot JDK version 13...
BOOT JDK: #
BOOT JDK: # A fatal error has been detected by the Java Runtime Environment:
BOOT JDK: #
BOOT JDK: #  Internal Error (threadCritical_aix.cpp:45), pid=7405590, tid=258
BOOT JDK: #  guarantee(ret == 0) failed: fatal error with pthread_mutex_lock()
BOOT JDK: #
BOOT JDK: # JRE version:  (13.0+33) (build )
BOOT JDK: # Java VM: OpenJDK 64-Bit Server VM (13+33, mixed mode, tiered, compressed oops, g1 gc, aix-ppc64)
BOOT JDK: # Core dump will be written. Default location: /ramdisk0/build/workspace/build-scripts/jobs/jdk14/jdk14-aix-ppc64-openj9/core or core.7405590
BOOT JDK: #
BOOT JDK: # An error report file with more information is saved as:
BOOT JDK: # /ramdisk0/build/workspace/build-scripts/jobs/jdk14/jdk14-aix-ppc64-openj9/hs_err_pid7405590.log
BOOT JDK: #
BOOT JDK: # If you would like to submit a bug report, please visit:
BOOT JDK: #   https://github.com/AdoptOpenJDK/openjdk-build/issues
BOOT JDK: #
```

This switches to the OpenJ9 version as a boot JDK

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>