### PR TITLE
Revert "Temporarily disable aarch64 openj9 builds (#1452)"

### DIFF
--- a/pipelines/jobs/configurations/jdk11u.groovy
+++ b/pipelines/jobs/configurations/jdk11u.groovy
@@ -33,7 +33,8 @@ targetConfigurations = [
                 "openj9"
         ],
         "aarch64Linux": [
-                "hotspot"
+                "hotspot",
+                "openj9"
         ],
         "arm32Linux"  : [
                 "hotspot"


### PR DESCRIPTION
I believe the standard heap OpenJ9 builds should now work again

This reverts commit 1b2f804b733c9f97c417e81d04bb9b0106ff044f.