### PR TITLE
sign.sh: Allow retries on EXE signing as well as DLLs

### DIFF
--- a/sign.sh
+++ b/sign.sh
@@ -62,15 +62,20 @@ signRelease()
       echo "$FILES" | while read -r f;
       do
         echo "Signing ${f}"
-        "$signToolPath" sign /f "${SIGNING_CERTIFICATE}" /p "$SIGN_PASSWORD" /fd SHA256 /t http://timestamp.verisign.com/scripts/timstamp.dll "$f";
+        if ! "$signToolPath" sign /f "${SIGNING_CERTIFICATE}" /p "$SIGN_PASSWORD" /fd SHA256 /t http://timestamp.verisign.com/scripts/timstamp.dll "$f"; then
+          echo "WARNING: Failed to sign ${f} at $(date +%T): Possible timestamp server error - RC $? ... Retrying in 10 seconds"
+          sleep 10
+          "$signToolPath" sign /f "${SIGNING_CERTIFICATE}" /p "$SIGN_PASSWORD" /fd SHA256 /t http://timestamp.verisign.com/scripts/timstamp.dll "$f"
+        fi        
       done
 
       # Sign .dll files
       FILES=$(find . -type f -name '*.dll')
       echo "$FILES" | while read -r f;
       do
+        echo "Signing ${f}"
         if ! "$signToolPath" sign /f "${SIGNING_CERTIFICATE}" /p "$SIGN_PASSWORD" /fd SHA256 /t http://timestamp.verisign.com/scripts/timstamp.dll "$f"; then
-          echo "WARNING: Failed to sign $f at $(date +%T): Possible timestamp server error - RC $? ... Retrying in 10 seconds"
+          echo "WARNING: Failed to sign ${f} at $(date +%T): Possible timestamp server error - RC $? ... Retrying in 10 seconds"
           sleep 10
           "$signToolPath" sign /f "${SIGNING_CERTIFICATE}" /p "$SIGN_PASSWORD" /fd SHA256 /t http://timestamp.verisign.com/scripts/timstamp.dll "$f"
         fi


### PR DESCRIPTION
Follow on from https://github.com/AdoptOpenJDK/openjdk-build/commit/8860634d93597f9a423c7d38b581ddb08d34bbfd