### PR TITLE
Reduce AIX memory usage due to fork failures

### DIFF
--- a/build-farm/platform-specific-configurations/aix.sh
+++ b/build-farm/platform-specific-configurations/aix.sh
@@ -21,7 +21,7 @@ source "$SCRIPT_DIR/../../sbin/common/constants.sh"
 export PATH="/opt/freeware/bin:/usr/local/bin:/opt/IBM/xlC/13.1.3/bin:/opt/IBM/xlc/13.1.3/bin:$PATH"
 # Without this, java adds /usr/lib to the LIBPATH of anything it forks which breaks linkage
 export LIBPATH="/opt/freeware/lib:$LIBPATH"
-export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-memory-size=10000 --with-cups-include=/opt/freeware/include"
+export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-cups-include=/opt/freeware/include"
 
 # Any version below 11
 if  [ "$JAVA_FEATURE_VERSION" -lt 11 ]
@@ -49,7 +49,7 @@ if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
         mkdir -p "${bootDir}"
         echo "Downloading GA release of boot JDK version ${BOOT_JDK_VERSION}..."
         releaseType="ga"
-        apiUrlTemplate="https://api.adoptopenjdk.net/v3/binary/latest/\${BOOT_JDK_VERSION}/\${releaseType}/aix/\${ARCHITECTURE}/jdk/hotspot/normal/adoptopenjdk"
+        apiUrlTemplate="https://api.adoptopenjdk.net/v3/binary/latest/\${BOOT_JDK_VERSION}/\${releaseType}/aix/\${ARCHITECTURE}/jdk/openj9/normal/adoptopenjdk"
         apiURL=$(eval echo ${apiUrlTemplate})
         # make-adopt-build-farm.sh has 'set -e'. We need to disable that
         # for the fallback mechanism, as downloading of the GA binary might
@@ -90,4 +90,12 @@ if [ "$JAVA_FEATURE_VERSION" -ge 11 ]; then
   else
     export PATH=/opt/freeware/bin:$JAVA_HOME/bin:/usr/local/bin:/opt/IBM/xlC/13.1.3/bin:/opt/IBM/xlc/13.1.3/bin:$PATH
   fi
+fi
+
+# J9 JDK14 builds seem to be chewing up more RAM than the others, so restrict it
+# Ref: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1151
+if [ "$JAVA_FEATURE_VERSION" -ge 14 ] && [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]; then
+  export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-memory-size=7000"
+else
+  export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-memory-size=10000"
 fi


### PR DESCRIPTION
Reducing this value appears to make it a bit more reliable. Going forward we should probably use `--with-jobs` but in the absence of extra testing for now, this should suffice

I'm vaguely optimistic that this fixes https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1151

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>