### PR TITLE
Store more (artifact-free) build trend history

### DIFF
--- a/pipelines/build/common/create_job_from_template.groovy
+++ b/pipelines/build/common/create_job_from_template.groovy
@@ -55,7 +55,7 @@ pipelineJob("$buildFolder/$JOB_NAME") {
         }
     }
     logRotator {
-        numToKeep(10)
+        numToKeep(30)
         artifactNumToKeep(1)
     }
 

--- a/pipelines/jobs/pipeline_job_template.groovy
+++ b/pipelines/jobs/pipeline_job_template.groovy
@@ -44,7 +44,7 @@ pipelineJob("${BUILD_FOLDER}/${JOB_NAME}") {
         cron(triggerSchedule)
     }
     logRotator {
-        numToKeep(10)
+        numToKeep(60)
         artifactNumToKeep(2)
     }
 


### PR DESCRIPTION
We've had some issues on AIX where the builds have become slower at times but by the time it's been noticed the older builds have "fallen off the end" of the 10 builds that we keep. Increasing this number to about a month worth of builds, and two months worth of pipelines should use a fairly small amount of space (since we're only keeping artifacts  for one or two of them) but should allow us to gain more ability to analyse when issues are occurring and have an improved ability to diagnose them.