### PR TITLE
Fix enable dtrace option to be compatible with JDK15 and later

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -271,7 +271,7 @@ buildingTheRestOfTheConfigParameters()
   else
     addConfigureArg "--with-debug-level=" "release"
     addConfigureArg "--with-native-debug-symbols=" "none"
-    addConfigureArg "--enable-dtrace=" "auto"
+    addConfigureArg "--enable-dtrace" ""
   fi
 }
 


### PR DESCRIPTION
Previous syntax was causing build failures. Since `auto` was the default in earlier versions, and I've verified that using this option in JDK15 still causes auto-detection (so it won't fail where dtrace, or an equivalent, does not exist) this should be safe. Error message that this shoudl resolve is:
```
configure: error: Invalid value for --enable-jvm-feature-dtrace: 'auto'
configure exiting with result code 1
```