### PR TITLE
Codesign not jdk13

### DIFF
--- a/build-farm/platform-specific-configurations/aix.sh
+++ b/build-farm/platform-specific-configurations/aix.sh
@@ -21,7 +21,7 @@ source "$SCRIPT_DIR/../../sbin/common/constants.sh"
 export PATH="/opt/freeware/bin:/usr/local/bin:/opt/IBM/xlC/13.1.3/bin:/opt/IBM/xlc/13.1.3/bin:$PATH"
 # Without this, java adds /usr/lib to the LIBPATH of anything it forks which breaks linkage
 export LIBPATH="/opt/freeware/lib:$LIBPATH"
-export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-memory-size=10000 --with-cups-include=/opt/freeware/include"
+export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-cups-include=/opt/freeware/include"
 
 # Any version below 11
 if  [ "$JAVA_FEATURE_VERSION" -lt 11 ]
@@ -94,4 +94,12 @@ if [ "$JAVA_FEATURE_VERSION" -ge 11 ]; then
   else
     export PATH=/opt/freeware/bin:$JAVA_HOME/bin:/usr/local/bin:/opt/IBM/xlC/13.1.3/bin:/opt/IBM/xlc/13.1.3/bin:$PATH
   fi
+fi
+
+# J9 JDK14 builds seem to be chewing up more RAM than the others, so restrict it
+# Ref: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1151
+if [ "$JAVA_FEATURE_VERSION" -ge 14 ] && [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]; then
+  export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-memory-size=7000"
+else
+  export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-memory-size=10000"
 fi

--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -50,8 +50,8 @@ else
   fi
 fi
 
-# The configure option '--with-macosx-codesign-identity' is supported in Java 11 and higher versions.
-if [ "$JAVA_FEATURE_VERSION" -ge 11 ]
+# The configure option '--with-macosx-codesign-identity' is supported in JDK11 and JDK14+
+if [ "$JAVA_FEATURE_VERSION" -eq 11 ] || [ "$JAVA_FEATURE_VERSION" -ge 14 ]
 then
   export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-sysroot=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/"
   # Login to KeyChain


### PR DESCRIPTION
I want to clean up the ["Failing Builds" tab]() - for this I need to run another successful build for the JDK13 ones that are failing. At the moment this is not possibly because it tries to force the codesigning option in which is not supported on JDK13.

Ref: https://ci.adoptopenjdk.net/job/build-scripts/job/jobs/job/jdk13u/job/jdk13u-mac-x64-openj9/176/console

```
Using autoconf at /usr/local/bin/autoconf [autoconf (GNU Autoconf) 2.69]
configure: error: unrecognized options: --with-macosx-codesign-identity
configure exiting with result code 1
```

