### PR TITLE
docker: Change jdkVersion to jdk14, not jdk14u

### DIFF
--- a/docker/buildDocker.sh
+++ b/docker/buildDocker.sh
@@ -70,7 +70,7 @@ checkJDKVersion()
                 "jdk14u" | "jdk14" | "14" | "14u" )
                         jdkVersion="jdk14";;
                 "jdk15u" | "jdk15" | "15" | "15u" )
-                        jdkVersion="jdk15";;
+                        jdkVersion="jdk";;
 		"all" )
 			jdkVersion="jdk8u jdk9u jdk10u jdk11u jdk12u jdk13u jdk14u jdk15u";;
 		*)

--- a/docker/buildDocker.sh
+++ b/docker/buildDocker.sh
@@ -68,9 +68,9 @@ checkJDKVersion()
 		"jdk13u" | "jdk13" | "13" | "13u" )
 			jdkVersion="jdk13u";;
                 "jdk14u" | "jdk14" | "14" | "14u" )
-                        jdkVersion="jdk14u";;
+                        jdkVersion="jdk14";;
                 "jdk15u" | "jdk15" | "15" | "15u" )
-                        jdkVersion="jdk15u";;
+                        jdkVersion="jdk15";;
 		"all" )
 			jdkVersion="jdk8u jdk9u jdk10u jdk11u jdk12u jdk13u jdk14u jdk15u";;
 		*)


### PR DESCRIPTION
Was causing the `DockerfileCheck` jenkins job to fail on JDK14, as it was attempting to find the jdk14u repository which isn't there (yet). Also thought I'd remove this for JDK15 so it doesn't trip up the job when it comes to running it.