### PR TITLE
Reschedule pipelines to run JDK8 earlier and replacing with JDK11.

### DIFF
--- a/pipelines/jobs/configurations/jdk11u.groovy
+++ b/pipelines/jobs/configurations/jdk11u.groovy
@@ -53,7 +53,7 @@ targetConfigurations = [
         ]
 ]
 
-// 23:30
-triggerSchedule="TZ=UTC\n30 23 * * *"
+// 03:30
+triggerSchedule="TZ=UTC\n30 03 * * *"
 
 return this

--- a/pipelines/jobs/configurations/jdk8u.groovy
+++ b/pipelines/jobs/configurations/jdk8u.groovy
@@ -54,7 +54,7 @@ targetConfigurations = [
         ]
 ]
 
-// 03:30
-triggerSchedule="TZ=UTC\n30 03 * * *"
+// 23:30
+triggerSchedule="TZ=UTC\n30 23 * * *"
 
 return this


### PR DESCRIPTION
This to manage overnight test execution for JDK8 HotSpot vs openj9

Signed-off-by: Archana Nogriya <archana.nogriya@uk.ibm.com>