### PR TITLE
Reschedule pipelines to run JDK8 bit earlier and replacing with JDK15

### DIFF
--- a/pipelines/jobs/configurations/jdk15.groovy
+++ b/pipelines/jobs/configurations/jdk15.groovy
@@ -23,7 +23,7 @@ targetConfigurations = [
         ]
 ]
 
-// 17:05
-triggerSchedule="TZ=UTC\n05 17 * * *"
+// 03:30
+triggerSchedule="TZ=UTC\n30 03 * * *"
 
 return this

--- a/pipelines/jobs/configurations/jdk8u.groovy
+++ b/pipelines/jobs/configurations/jdk8u.groovy
@@ -54,7 +54,7 @@ targetConfigurations = [
         ]
 ]
 
-// 03:30
-triggerSchedule="TZ=UTC\n30 03 * * *"
+// 17:05
+triggerSchedule="TZ=UTC\n05 17 * * *"
 
 return this


### PR DESCRIPTION
This to manage overnight test execution for JDK8 HotSpot vs openj9

Signed-off-by: Archana Nogriya <archana.nogriya@uk.ibm.com>