### PR TITLE
Fixing Issue: 1417 -s and -d parameters assumed relative

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,12 +299,12 @@ project for setting these pre-requisites.
 
 Example Usage (TODO Add example of openj9):
 
-`./makejdk-any-platform.sh -s /home/openjdk10/src -d /home/openjdk/target -T MyOpenJDK10.tar.gz jdk10`
+`./makejdk-any-platform.sh -s src -d target -T MyOpenJDK10.tar.gz jdk10`
 
-This would clone OpenJDK source from _https://github.com/AdoptOpenJDK/openjdk-jdk10_
-to `/home/openjdk10/src`, configure the build with sensible defaults according
-to your local platform and then build (Adopt) OpenJDK and place the result in
-`/home/openjdk/target/MyOpenJDK10.tar.gz`.
+This would clone OpenJDK source from _https://github.com/AdoptOpenJDK/openjdk-jdk10
+to `src` under your current directory, configure the build with sensible defaults 
+according to your local platform and then build (Adopt) OpenJDK and place the result in
+`target/MyOpenJDK10.tar.gz`.
 
 ### Building OpenJDK from a non Adopt source
 


### PR DESCRIPTION
Modifying the instructions is a appropriate action, so that users will use only relative paths, as there are multiple places where the script needs to be updated.

Signed-off-by: Surya Narkedimilli <narkedi@gmail.com>