### PR TITLE
Set dtrace only on JDK15+ builds

### DIFF
--- a/pipelines/build/openjdk10_pipeline.groovy
+++ b/pipelines/build/openjdk10_pipeline.groovy
@@ -17,13 +17,15 @@ def buildConfigurations = [
                 os                  : 'mac',
                 arch                : 'x64',
                 additionalNodeLabels: 'build-macstadium-macos1010-1',
-                test                : ['sanity.openjdk', 'sanity.system']
+                test                : ['sanity.openjdk', 'sanity.system'],
+                configureArgs       : '--enable-dtrace=auto'
         ],
         x64Linux  : [
                 os                  : 'linux',
                 arch                : 'x64',
                 additionalNodeLabels: 'centos6',
-                test                : ['sanity.openjdk', 'sanity.system', 'sanity.external']
+                test                : ['sanity.openjdk', 'sanity.system', 'sanity.external'],
+                configureArgs       : '--enable-dtrace=auto'
         ],
 
         // Currently we have to be quite specific about which windows to use as not all of them have freetype installed
@@ -49,32 +51,37 @@ def buildConfigurations = [
                 additionalNodeLabels: [
                         hotspot: 'rhel7'
                 ],
-                test                : ['sanity.openjdk', 'sanity.system']
+                test                : ['sanity.openjdk', 'sanity.system'],
+                configureArgs       : '--enable-dtrace=auto'
         ],
 
         sparcv9Solaris    : [
                 os                  : 'solaris',
                 arch                : 'sparcv9',
-                test                : false
+                test                : false,
+                configureArgs       : '--enable-dtrace=auto'
         ],
 
         ppc64leLinux    : [
                 os                  : 'linux',
                 arch                : 'ppc64le',
-                test                : ['sanity.openjdk', 'sanity.system']
+                test                : ['sanity.openjdk', 'sanity.system'],
+                configureArgs       : '--enable-dtrace=auto'
         ],
 
         arm32Linux    : [
                 os                  : 'linux',
                 arch                : 'arm',
-                test                : ['sanity.openjdk']
+                test                : ['sanity.openjdk'],
+                configureArgs       : '--enable-dtrace=auto'
         ],
 
         aarch64Linux    : [
                 os                  : 'linux',
                 arch                : 'aarch64',
                 additionalNodeLabels: 'centos7',
-                test                : ['sanity.openjdk']
+                test                : ['sanity.openjdk'],
+                configureArgs       : '--enable-dtrace=auto'
         ],
 
         /*
@@ -91,7 +98,7 @@ def buildConfigurations = [
                 arch                 : 'x64',
                 test                 : false,
                 additionalFileNameTag: "linuxXL",
-                configureArgs        : '--with-noncompressedrefs'
+                configureArgs        : '--with-noncompressedrefs --enable-dtrace=auto'
         ],
 ]
 

--- a/pipelines/build/openjdk11_pipeline.groovy
+++ b/pipelines/build/openjdk11_pipeline.groovy
@@ -17,7 +17,8 @@ def buildConfigurations = [
                 os                  : 'mac',
                 arch                : 'x64',
                 additionalNodeLabels : 'macos10.14',
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
+                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                configureArgs       : '--enable-dtrace=auto'
         ],
 
         x64MacXL    : [
@@ -26,7 +27,7 @@ def buildConfigurations = [
                 additionalNodeLabels : 'macos10.14',
                 test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
                 additionalFileNameTag: "macosXL",
-                configureArgs        : '--with-noncompressedrefs'
+                configureArgs        : '--with-noncompressedrefs --enable-dtrace=auto'
         ],
 
         x64Linux  : [
@@ -38,11 +39,11 @@ def buildConfigurations = [
                         release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external', 'special.functional']
                 ],
                 configureArgs       : [
-                        "openj9"      : '--disable-ccache --enable-jitserver',
-                        "hotspot"     : '--disable-ccache',
-                        "hotspot-jfr" : '--disable-ccache',
-                        "corretto"    : '--disable-ccache',
-                        "SapMachine"  : '--disable-ccache'
+                        "openj9"      : '--disable-ccache --enable-jitserver --enable-dtrace=auto',
+                        "hotspot"     : '--disable-ccache --enable-dtrace=auto',
+                        "hotspot-jfr" : '--disable-ccache --enable-dtrace=auto',
+                        "corretto"    : '--disable-ccache --enable-dtrace=auto',
+                        "SapMachine"  : '--disable-ccache --enable-dtrace=auto'
                 ]
         ],
 
@@ -96,20 +97,21 @@ def buildConfigurations = [
                 os                  : 'linux',
                 arch                : 's390x',
                 test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
-                configureArgs        : '--disable-ccache'
+                configureArgs       : '--disable-ccache --enable-dtrace=auto'
         ],
 
         sparcv9Solaris    : [
                 os                  : 'solaris',
                 arch                : 'sparcv9',
-                test                : false
+                test                : false,
+                configureArgs       : '--enable-dtrace=auto'
         ],
 
         ppc64leLinux    : [
                 os                  : 'linux',
                 arch                : 'ppc64le',
                 test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
-                configureArgs       : '--disable-ccache'
+                configureArgs       : '--disable-ccache --enable-dtrace=auto'
 
         ],
 
@@ -118,14 +120,16 @@ def buildConfigurations = [
                 arch                : 'arm',
                 // TODO Temporarily remove the ARM tests because we don't have fast enough hardware
                 //test                : ['sanity.openjdk', 'sanity.perf']
-                test                : false
+                test                : false,
+                configureArgs       : '--enable-dtrace=auto'
         ],
 
         aarch64Linux    : [
                 os                  : 'linux',
                 arch                : 'aarch64',
                 additionalNodeLabels: 'centos7',
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
+                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                configureArgs       : '--enable-dtrace=auto'
         ],
 
         /*
@@ -142,21 +146,21 @@ def buildConfigurations = [
                 arch                 : 'x64',
                 test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
                 additionalFileNameTag: "linuxXL",
-                configureArgs        : '--with-noncompressedrefs --disable-ccache --enable-jitserver'
+                configureArgs        : '--with-noncompressedrefs --disable-ccache --enable-jitserver --enable-dtrace=auto'
         ],
         s390xLinuxXL    : [
                 os                   : 'linux',
                 arch                 : 's390x',
                 test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
                 additionalFileNameTag: "linuxXL",
-                configureArgs        : '--with-noncompressedrefs --disable-ccache'
+                configureArgs        : '--with-noncompressedrefs --disable-ccache --enable-dtrace=auto'
         ],
         ppc64leLinuxXL    : [
                 os                   : 'linux',
                 arch                 : 'ppc64le',
                 test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
                 additionalFileNameTag: "linuxXL",
-                configureArgs        : '--with-noncompressedrefs --disable-ccache'
+                configureArgs        : '--with-noncompressedrefs --disable-ccache --enable-dtrace=auto'
         ],
         aarch64LinuxXL    : [
                 os                   : 'linux',
@@ -164,7 +168,7 @@ def buildConfigurations = [
                 arch                 : 'aarch64',
                 test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
                 additionalFileNameTag: "linuxXL",
-                configureArgs        : '--with-noncompressedrefs --disable-ccache'
+                configureArgs        : '--with-noncompressedrefs --disable-ccache --enable-dtrace=auto'
         ],
 ]
 

--- a/pipelines/build/openjdk12_pipeline.groovy
+++ b/pipelines/build/openjdk12_pipeline.groovy
@@ -17,7 +17,8 @@ def buildConfigurations = [
                 os                  : 'mac',
                 arch                : 'x64',
                 additionalNodeLabels : 'macos10.12',
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
+                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                configureArgs       : '--enable-dtrace=auto'
         ],
 
         x64MacXL    : [
@@ -26,7 +27,7 @@ def buildConfigurations = [
                 additionalNodeLabels : 'macos10.12',
                 test                 : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
                 additionalFileNameTag: "macosXL",
-                configureArgs        : '--with-noncompressedrefs'
+                configureArgs        : '--with-noncompressedrefs --enable-dtrace=auto'
         ],
 
         x64Linux  : [
@@ -37,7 +38,7 @@ def buildConfigurations = [
                         nightly: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external'],
                         release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external', 'special.functional']
                 ],
-                configureArgs        : '--disable-ccache'
+                configureArgs        : '--disable-ccache --enable-dtrace=auto'
         ],
 
         // Currently we have to be quite specific about which windows to use as not all of them have freetype installed
@@ -89,20 +90,21 @@ def buildConfigurations = [
                 os                  : 'linux',
                 arch                : 's390x',
                 test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
-                configureArgs        : '--disable-ccache'
+                configureArgs        : '--disable-ccache --enable-dtrace=auto'
         ],
 
         sparcv9Solaris    : [
                 os                  : 'solaris',
                 arch                : 'sparcv9',
-                test                : false
+                test                : false,
+                configureArgs       : '--enable-dtrace=auto'
         ],
 
         ppc64leLinux    : [
                 os                  : 'linux',
                 arch                : 'ppc64le',
                 test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
-                configureArgs       : '--disable-ccache'
+                configureArgs       : '--disable-ccache --enable-dtrace=auto'
 
         ],
 
@@ -111,14 +113,16 @@ def buildConfigurations = [
                 arch                : 'arm',
                 // TODO Temporarily remove the ARM tests because we don't have fast enough hardware
                 //test                : ['sanity.openjdk', 'sanity.perf']
-                test                : false
+                test                : false,
+                configureArgs       : '--enable-dtrace=auto'
         ],
 
         aarch64Linux    : [
                 os                  : 'linux',
                 arch                : 'aarch64',
                 additionalNodeLabels: 'centos7',
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
+                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                configureArgs       : '--enable-dtrace=auto'
         ],
 
         /*
@@ -135,7 +139,7 @@ def buildConfigurations = [
                 arch                 : 'x64',
                 test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
                 additionalFileNameTag: "linuxXL",
-                configureArgs        : '--with-noncompressedrefs --disable-ccache'
+                configureArgs        : '--with-noncompressedrefs --disable-ccache --enable-dtrace=auto'
         ],
 ]
 

--- a/pipelines/build/openjdk13_pipeline.groovy
+++ b/pipelines/build/openjdk13_pipeline.groovy
@@ -17,7 +17,8 @@ def buildConfigurations = [
                 os                  : 'mac',
                 arch                : 'x64',
                 additionalNodeLabels : 'macos10.12',
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
+                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                configureArgs       : '--enable-dtrace=auto'
         ],
 
         x64MacXL    : [
@@ -26,7 +27,7 @@ def buildConfigurations = [
                 additionalNodeLabels : 'macos10.12',
                 test                 : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
                 additionalFileNameTag: "macosXL",
-                configureArgs        : '--with-noncompressedrefs'
+                configureArgs        : '--with-noncompressedrefs --enable-dtrace=auto'
         ],
 
         x64Linux  : [
@@ -37,7 +38,7 @@ def buildConfigurations = [
                         nightly: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external'],
                         release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external', 'special.functional']
                 ],
-                configureArgs        : '--disable-ccache'
+                configureArgs        : '--disable-ccache --enable-dtrace=auto'
         ],
 
         // Currently we have to be quite specific about which windows to use as not all of them have freetype installed
@@ -90,20 +91,21 @@ def buildConfigurations = [
                 os                  : 'linux',
                 arch                : 's390x',
                 test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
-                configureArgs        : '--disable-ccache'
+                configureArgs        : '--disable-ccache --enable-dtrace=auto'
         ],
 
         sparcv9Solaris    : [
                 os                  : 'solaris',
                 arch                : 'sparcv9',
-                test                : false
+                test                : false,
+                configureArgs       : '--enable-dtrace=auto'
         ],
 
         ppc64leLinux    : [
                 os                  : 'linux',
                 arch                : 'ppc64le',
                 test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
-                configureArgs       : '--disable-ccache'
+                configureArgs       : '--disable-ccache --enable-dtrace=auto'
 
         ],
 
@@ -112,14 +114,16 @@ def buildConfigurations = [
                 arch                : 'arm',
                 // TODO Temporarily remove the ARM tests because we don't have fast enough hardware
                 //test                : ['sanity.openjdk', 'sanity.perf']
-                test                : false
+                test                : false,
+                configureArgs       : '--enable-dtrace=auto'
         ],
 
         aarch64Linux    : [
                 os                  : 'linux',
                 arch                : 'aarch64',
                 additionalNodeLabels: 'centos7',
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
+                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                configureArgs       : '--enable-dtrace=auto'
         ],
 
         /*
@@ -136,21 +140,21 @@ def buildConfigurations = [
                 arch                 : 'x64',
                 test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
                 additionalFileNameTag: "linuxXL",
-                configureArgs        : '--with-noncompressedrefs --disable-ccache'
+                configureArgs        : '--with-noncompressedrefs --disable-ccache --enable-dtrace=auto'
         ],
         s390xLinuxXL    : [
                 os                   : 'linux',
                 arch                 : 's390x',
                 test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
                 additionalFileNameTag: "linuxXL",
-                configureArgs        : '--with-noncompressedrefs --disable-ccache'
+                configureArgs        : '--with-noncompressedrefs --disable-ccache --enable-dtrace=auto'
         ],
         ppc64leLinuxXL    : [
                 os                   : 'linux',
                 arch                 : 'ppc64le',
                 test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
                 additionalFileNameTag: "linuxXL",
-                configureArgs        : '--with-noncompressedrefs --disable-ccache'
+                configureArgs        : '--with-noncompressedrefs --disable-ccache --enable-dtrace=auto'
         ],
 ]
 

--- a/pipelines/build/openjdk14_pipeline.groovy
+++ b/pipelines/build/openjdk14_pipeline.groovy
@@ -17,7 +17,8 @@ def buildConfigurations = [
                 os                  : 'mac',
                 arch                : 'x64',
                 additionalNodeLabels : 'macos10.14',
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
+                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                configureArgs       : '--enable-dtrace=auto'
         ],
 
         x64MacXL: [
@@ -26,7 +27,7 @@ def buildConfigurations = [
                 additionalNodeLabels : 'macos10.14',
                 test                 : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
                 additionalFileNameTag: "macosXL",
-                configureArgs        : '--with-noncompressedrefs'
+                configureArgs        : '--with-noncompressedrefs --enable-dtrace=auto'
         ],
 
         x64Linux  : [
@@ -34,7 +35,7 @@ def buildConfigurations = [
                 arch                : 'x64',
                 additionalNodeLabels: 'centos6',
                 test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external', 'special.functional'],
-                configureArgs        : '--disable-ccache'
+                configureArgs        : '--disable-ccache --enable-dtrace=auto'
         ],
 
         x64LinuxXL    : [
@@ -43,7 +44,7 @@ def buildConfigurations = [
                 arch                 : 'x64',
                 test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
                 additionalFileNameTag: "linuxXL",
-                configureArgs        : '--with-noncompressedrefs --disable-ccache'
+                configureArgs        : '--with-noncompressedrefs --disable-ccache --enable-dtrace=auto'
         ],
 
         // Currently we have to be quite specific about which windows to use as not all of them have freetype installed
@@ -83,7 +84,7 @@ def buildConfigurations = [
                 os                  : 'linux',
                 arch                : 's390x',
                 test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
-                configureArgs        : '--disable-ccache'
+                configureArgs        : '--disable-ccache --enable-dtrace=auto'
         ],
 
         s390xLinuxXL    : [
@@ -91,14 +92,14 @@ def buildConfigurations = [
                 arch                 : 's390x',
                 test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
                 additionalFileNameTag: "linuxXL",
-                configureArgs        : '--with-noncompressedrefs --disable-ccache'
+                configureArgs        : '--with-noncompressedrefs --disable-ccache --enable-dtrace=auto'
         ],
 
         ppc64leLinux    : [
                 os                  : 'linux',
                 arch                : 'ppc64le',
                 test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
-                configureArgs       : '--disable-ccache'
+                configureArgs       : '--disable-ccache --enable-dtrace=auto'
 
         ],
 
@@ -107,14 +108,15 @@ def buildConfigurations = [
                 arch                 : 'ppc64le',
                 test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
                 additionalFileNameTag: "linuxXL",
-                configureArgs        : '--with-noncompressedrefs --disable-ccache'
+                configureArgs        : '--with-noncompressedrefs --disable-ccache --enable-dtrace=auto'
         ],
 
         aarch64Linux    : [
                 os                  : 'linux',
                 arch                : 'aarch64',
                 additionalNodeLabels: 'centos7',
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
+                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                configureArgs       : '--enable-dtrace=auto'
         ],
 
 ]

--- a/pipelines/build/openjdk15_pipeline.groovy
+++ b/pipelines/build/openjdk15_pipeline.groovy
@@ -20,7 +20,8 @@ def buildConfigurations = [
                 test                : [
                         nightly: false,
                         release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
-                ]
+                ],
+                configureArgs       : '--enable-dtrace'
         ],
 
         x64Linux  : [
@@ -31,7 +32,7 @@ def buildConfigurations = [
                         nightly: false,
                         release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external', 'special.functional']
                 ],
-                configureArgs        : '--disable-ccache'
+                configureArgs       : '--disable-ccache --enable-dtrace'
         ],
 
         // Currently we have to be quite specific about which windows to use as not all of them have freetype installed
@@ -68,7 +69,7 @@ def buildConfigurations = [
                         nightly: false,
                         release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
                 ],
-                configureArgs        : '--disable-ccache'
+                configureArgs       : '--disable-ccache --enable-dtrace'
         ],
 
         ppc64leLinux    : [
@@ -78,7 +79,7 @@ def buildConfigurations = [
                         nightly: false,
                         release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
                 ],
-                configureArgs       : '--disable-ccache'
+                configureArgs       : '--disable-ccache --enable-dtrace'
 
         ],
 
@@ -89,7 +90,8 @@ def buildConfigurations = [
                 test                : [
                         nightly: false,
                         release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
-                ]
+                ],
+                configureArgs       : '--enable-dtrace'
         ],
 
 ]

--- a/pipelines/build/openjdk8_pipeline.groovy
+++ b/pipelines/build/openjdk8_pipeline.groovy
@@ -23,7 +23,8 @@ def buildConfigurations = [
                         corretto: 'build-macstadium-macos1010-1',
                         openj9  : 'build-macstadium-macos1010-2'
                 ],
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk']
+                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk'],
+                configureArgs       : '--enable-dtrace=auto'
         ],
 
         x64MacXL      : [
@@ -32,7 +33,7 @@ def buildConfigurations = [
                 additionalNodeLabels : 'build-macstadium-macos1010-2',
                 test                 : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'special.openjdk'],
                 additionalFileNameTag: "macosXL",
-                configureArgs        : '--with-noncompressedrefs'
+                configureArgs        : '--with-noncompressedrefs --enable-dtrace=auto'
         ],
 
         x64Linux      : [
@@ -41,8 +42,8 @@ def buildConfigurations = [
                 additionalNodeLabels: 'centos6',
                 test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external', 'special.functional', 'special.openjdk'],
                 configureArgs       : [
-                        "hotspot-jfr" : '--enable-jfr',
-                        "openj9"      : '--enable-jitserver'
+                        "hotspot-jfr" : '--enable-jfr --enable-dtrace=auto',
+                        "openj9"      : '--enable-jitserver --enable-dtrace=auto'
                 ]
         ],
 
@@ -94,25 +95,29 @@ def buildConfigurations = [
         s390xLinux    : [
                 os  : 'linux',
                 arch: 's390x',
-                test: ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk']
+                test: ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk'],
+                configureArgs : '--enable-dtrace=auto'
         ],
 
         sparcv9Solaris: [
                 os  : 'solaris',
                 arch: 'sparcv9',
-                test: false
+                test: false,
+                configureArgs: '--enable-dtrace=auto'
         ],
 
         x64Solaris    : [
                 os                  : 'solaris',
                 arch                : 'x64',
-                test                : false
+                test                : false,
+                configureArgs       : '--enable-dtrace=auto'
         ],
 
         ppc64leLinux  : [
                 os  : 'linux',
                 arch: 'ppc64le',
-                test: ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk']
+                test: ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk'],
+                configureArgs : '--enable-dtrace=auto'
         ],
 
         arm32Linux    : [
@@ -120,14 +125,16 @@ def buildConfigurations = [
                 arch: 'arm',
                 // TODO Temporarily remove the ARM tests because we don't have fast enough hardware
                 //test                : ['sanity.openjdk']
-                test: false
+                test: false,
+                configureArgs : '--enable-dtrace=auto'
         ],
 
         aarch64Linux  : [
                 os                  : 'linux',
                 arch                : 'aarch64',
                 additionalNodeLabels: 'centos7',
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk']
+                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk'],
+                configureArgs       : '--enable-dtrace=auto'
         ],
 
         x64LinuxXL       : [
@@ -135,7 +142,7 @@ def buildConfigurations = [
                 additionalNodeLabels : 'centos6',
                 arch                 : 'x64',
                 additionalFileNameTag: "linuxXL",
-                configureArgs        : '--with-noncompressedrefs --enable-jitserver',
+                configureArgs        : '--with-noncompressedrefs --enable-jitserver --enable-dtrace=auto',
                 test                 : ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk'],
         ],
         s390xLinuxXL       : [
@@ -143,14 +150,14 @@ def buildConfigurations = [
                 arch                 : 's390x',
                 additionalFileNameTag: "linuxXL",
                 test                 : ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk'],
-                configureArgs        : '--with-noncompressedrefs'
+                configureArgs        : '--with-noncompressedrefs --enable-dtrace=auto'
         ],
         ppc64leLinuxXL       : [
                 os                   : 'linux',
                 arch                 : 'ppc64le',
                 additionalFileNameTag: "linuxXL",
                 test                 : ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk'],
-                configureArgs        : '--with-noncompressedrefs'
+                configureArgs        : '--with-noncompressedrefs --enable-dtrace=auto'
         ],
 ]
 

--- a/pipelines/build/openjdk9_pipeline.groovy
+++ b/pipelines/build/openjdk9_pipeline.groovy
@@ -17,14 +17,16 @@ def buildConfigurations = [
                 os                  : 'mac',
                 arch                : 'x64',
                 additionalNodeLabels: 'build-macstadium-macos1010-1',
-                test                : ['sanity.openjdk', 'sanity.system']
+                test                : ['sanity.openjdk', 'sanity.system'],
+                configureArgs       : '--enable-dtrace=auto'
         ],
 
         x64Linux  : [
                 os                  : 'linux',
                 arch                : 'x64',
                 additionalNodeLabels: 'centos6',
-                test                : ['sanity.openjdk', 'sanity.system', 'sanity.external']
+                test                : ['sanity.openjdk', 'sanity.system', 'sanity.external'],
+                configureArgs       : '--enable-dtrace=auto'
         ],
 
         // Currently we have to be quite specific about which windows to use as not all of them have freetype installed
@@ -48,33 +50,38 @@ def buildConfigurations = [
                 os                  : 'linux',
                 arch                : 's390x',
                 additionalNodeLabels: 'rhel7',
-                test                : ['sanity.openjdk', 'sanity.system']
+                test                : ['sanity.openjdk', 'sanity.system'],
+                configureArgs       : '--enable-dtrace=auto'
         ],
 
         sparcv9Solaris    : [
                 os                  : 'solaris',
                 arch                : 'sparcv9',
-                test                : false
+                test                : false,
+                configureArgs       : '--enable-dtrace=auto'
         ],
 
         ppc64leLinux    : [
                 os                  : 'linux',
                 arch                : 'ppc64le',
                 additionalNodeLabels: 'centos7',
-                test                : ['sanity.openjdk', 'sanity.system']
+                test                : ['sanity.openjdk', 'sanity.system'],
+                configureArgs       : '--enable-dtrace=auto'
         ],
 
         arm32Linux    : [
                 os                  : 'linux',
                 arch                : 'arm',
-                test                : ['sanity.openjdk']
+                test                : ['sanity.openjdk'],
+                configureArgs       : '--enable-dtrace=auto'
         ],
 
         aarch64Linux    : [
                 os                  : 'linux',
                 arch                : 'aarch64',
                 additionalNodeLabels: 'centos7',
-                test                : ['sanity.openjdk']
+                test                : ['sanity.openjdk'],
+                configureArgs       : '--enable-dtrace=auto'
         ],
 
         x64LinuxXL    : [
@@ -83,7 +90,7 @@ def buildConfigurations = [
                 arch                 : 'x64',
                 test                 : false,
                 additionalFileNameTag: "linuxXL",
-                configureArgs        : '--with-noncompressedrefs'
+                configureArgs        : '--with-noncompressedrefs --enable-dtrace=auto'
         ],
 ]
 

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -273,7 +273,6 @@ buildingTheRestOfTheConfigParameters()
   else
     addConfigureArg "--with-debug-level=" "release"
     addConfigureArg "--with-native-debug-symbols=" "none"
-    addConfigureArg "--enable-dtrace" ""
   fi
 }
 


### PR DESCRIPTION
* Dtrace is set to auto on all active pipeline configurations save JDK15+ (which is required)
* Removes --enable-dtrace from the global build script

Closes: #1586

Signed-off-by: Morgan Davies <morgan.davies@ibm.com>