### PR TITLE
Move GPG key to be generated/stored in `WORKSPACE_DIR/WORKING_DIR`

### DIFF
--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -207,13 +207,13 @@ checkFingerprint() {
     return
   fi
 
-  rm /tmp/public_key.gpg || true
+  rm ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/public_key.gpg || true
 
-  gpg --no-options --output /tmp/public_key.gpg --dearmor "${SCRIPT_DIR}/sig_check/${publicKey}.asc"
+  gpg --no-options --output ${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/public_key.gpg --dearmor "${SCRIPT_DIR}/sig_check/${publicKey}.asc"
 
   # If this dir does not exist, gpg 1.4.20 supplied on Ubuntu16.04 aborts
   mkdir -p $HOME/.gnupg
-  local verify=$(gpg --no-options -v --no-default-keyring --keyring "/tmp/public_key.gpg" --verify $sigFile $fileName 2>&1)
+  local verify=$(gpg --no-options -v --no-default-keyring --keyring "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/public_key.gpg" --verify $sigFile $fileName 2>&1)
 
   echo $verify
 


### PR DESCRIPTION
fixes: #1580 

Ensures that the `public_key.gpg` is specific to each build.

Testing at : https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/392/