### PR TITLE
Enable use of OpenSSL-1.1.1d-64 VS2017 for Windows JDK11+ OpenJ9

### DIFF
--- a/build-farm/platform-specific-configurations/windows.sh
+++ b/build-farm/platform-specific-configurations/windows.sh
@@ -133,7 +133,11 @@ then
     elif [ "$JAVA_FEATURE_VERSION" -ge 11 ]
     then
       TOOLCHAIN_VERSION="2017"
-      export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-freemarker-jar=/cygdrive/c/openjdk/freemarker.jar --with-openssl=/cygdrive/c/openjdk/OpenSSL-1.1.1d-x86_64 --enable-openssl-bundling"
+      if [ -d /cygdrive/c/openjdk/OpenSSL-1.1.1d-x86_64.VS2017 ]; then
+        export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-freemarker-jar=/cygdrive/c/openjdk/freemarker.jar --with-openssl=/cygdrive/c/openjdk/OpenSSL-1.1.1d-x86_64.VS2017 --enable-openssl-bundling"
+      else
+        export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-freemarker-jar=/cygdrive/c/openjdk/freemarker.jar --with-openssl=/cygdrive/c/openjdk/OpenSSL-1.1.1d-x86_64 --enable-openssl-bundling"
+      fi
     fi
 
     CUDA_VERSION=9.0


### PR DESCRIPTION
ref: #https://github.com/AdoptOpenJDK/openjdk-infrastructure/pull/1193 #1556 
fixes: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1159

This change allows machines to use the built-with-VS2017 OpenSSL 64bit, if it's on the machine, with JDK11+ OpenJ9 builds