### PR TITLE
Windows: Correct OpenSSL path

### DIFF
--- a/build-farm/platform-specific-configurations/windows.sh
+++ b/build-farm/platform-specific-configurations/windows.sh
@@ -78,8 +78,8 @@ then
   if [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]
   then
     # If statements to ensure build machines don't break if they're yet to have openssl-1.1.1e put on them
-    if [ -d /cygdrive/c/openjdk/OpenSSL-1.1.1e-x86_32 ]; then
-      export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-openssl=/cygdrive/c/openjdk/OpenSSL-1.1.1e-x86_32 --enable-openssl-bundling"
+    if [ -d /cygdrive/c/openjdk/OpenSSL-1.1.1e-x86_32-VS2013 ]; then
+      export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-openssl=/cygdrive/c/openjdk/OpenSSL-1.1.1e-x86_32-VS2013 --enable-openssl-bundling"
     else
       export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-openssl=/cygdrive/c/openjdk/OpenSSL-1.1.1d-x86_32 --enable-openssl-bundling"
     fi
@@ -132,8 +132,8 @@ then
       export PATH="$PATH:/c/cygwin64/bin"
       export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-freemarker-jar=/cygdrive/c/openjdk/freemarker.jar --disable-ccache"
       # If statements to ensure build machines don't break if they're yet to have openssl-1.1.1e put on them
-      if [ -d /cygdrive/c/openjdk/OpenSSL-1.1.1e-x86_64 ]; then
-        export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-openssl=/cygdrive/c/openjdk/OpenSSL-1.1.1e-x86_64 --enable-openssl-bundling"
+      if [ -d /cygdrive/c/openjdk/OpenSSL-1.1.1e-x86_64-VS2013 ]; then
+        export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-openssl=/cygdrive/c/openjdk/OpenSSL-1.1.1e-x86_64-VS2013 --enable-openssl-bundling"
       else
         export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-openssl=/cygdrive/c/openjdk/OpenSSL-1.1.1d-x86_64 --enable-openssl-bundling"
       fi
@@ -152,8 +152,8 @@ then
       # If statements to ensure build machines don't break if they're yet to have openssl-1.1.1e put on them
       if [ -d /cygdrive/c/openjdk/OpenSSL-1.1.1e-x86_64-VS2017 ]; then
         export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-freemarker-jar=/cygdrive/c/openjdk/freemarker.jar --with-openssl=/cygdrive/c/openjdk/OpenSSL-1.1.1e-x86_64-VS2017 --enable-openssl-bundling"
-      elif [ -d /cygdrive/c/openjdk/OpenSSL-1.1.1d-x86_64.VS2017 ]; then
-        export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-freemarker-jar=/cygdrive/c/openjdk/freemarker.jar --with-openssl=/cygdrive/c/openjdk/OpenSSL-1.1.1d-x86_64.VS2017 --enable-openssl-bundling"	
+      elif [ -d /cygdrive/c/openjdk/OpenSSL-1.1.1d-x86_64-VS2017 ]; then
+        export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-freemarker-jar=/cygdrive/c/openjdk/freemarker.jar --with-openssl=/cygdrive/c/openjdk/OpenSSL-1.1.1d-x86_64-VS2017 --enable-openssl-bundling"	
       else	
         export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-freemarker-jar=/cygdrive/c/openjdk/freemarker.jar --with-openssl=/cygdrive/c/openjdk/OpenSSL-1.1.1d-x86_64 --enable-openssl-bundling"
       fi


### PR DESCRIPTION
Correct the path it's detecting from, as it currently doesn't line up with what the playbook says ( https://github.com/AdoptOpenJDK/openjdk-infrastructure/pull/1209/ ) or what I've put on the machines as part of https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1205