### PR TITLE
Inhibit nightly testing during April 2020 release cycle

### DIFF
--- a/pipelines/jobs/configurations/jdk11_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11_pipeline_config.groovy
@@ -4,7 +4,7 @@ class Config11 {
                 os                  : 'mac',
                 arch                : 'x64',
                 additionalNodeLabels : 'macos10.14',
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                test                : false,
                 configureArgs       : '--enable-dtrace=auto'
         ],
 
@@ -12,7 +12,7 @@ class Config11 {
                 os                   : 'mac',
                 arch                 : 'x64',
                 additionalNodeLabels : 'macos10.14',
-                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                test                 : false,
                 additionalFileNameTag: "macosXL",
                 configureArgs        : '--with-noncompressedrefs --enable-dtrace=auto'
         ],
@@ -21,10 +21,7 @@ class Config11 {
                 os                  : 'linux',
                 arch                : 'x64',
                 additionalNodeLabels: 'centos6',
-                test                : [
-                        nightly: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external'],
-                        release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external', 'special.functional']
-                ],
+                test                : false,
                 configureArgs       : [
                         "openj9"      : '--disable-ccache --enable-jitserver --enable-dtrace=auto',
                         "hotspot"     : '--disable-ccache --enable-dtrace=auto',
@@ -45,14 +42,14 @@ class Config11 {
                 buildArgs : [
                         hotspot : '--jvm-variant client,server'
                 ],
-                test                : ['sanity.openjdk', 'sanity.perf', 'sanity.system', 'extended.system']
+                test                : false
         ],
 
         x64WindowsXL    : [
                 os                   : 'windows',
                 arch                 : 'x64',
                 additionalNodeLabels : 'win2012&&vs2017',
-                test                 : ['sanity.openjdk', 'sanity.system'],
+                test                 : false,
                 additionalFileNameTag: "windowsXL",
                 configureArgs        : '--with-noncompressedrefs'
         ],
@@ -67,23 +64,20 @@ class Config11 {
                 buildArgs : [
                         hotspot : '--jvm-variant client,server'
                 ],
-                test                : ['sanity.openjdk']
+                test                : false
         ],
 
         ppc64Aix    : [
                 os                  : 'aix',
                 arch                : 'ppc64',
                 additionalNodeLabels: 'xlc13',
-                test                : [
-                        nightly: ['sanity.openjdk'],
-                        release: ['sanity.openjdk', 'sanity.system', 'extended.system']
-                ]
+                test                : false
         ],
 
         s390xLinux    : [
                 os                  : 'linux',
                 arch                : 's390x',
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                test                : false,
                 configureArgs       : '--disable-ccache --enable-dtrace=auto'
         ],
 
@@ -97,7 +91,7 @@ class Config11 {
         ppc64leLinux    : [
                 os                  : 'linux',
                 arch                : 'ppc64le',
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                test                : false,
                 configureArgs       : [
                         "hotspot"     : '--disable-ccache --enable-dtrace=auto',
                         "openj9"      : '--disable-ccache --enable-dtrace=auto --enable-jitserver'
@@ -118,7 +112,7 @@ class Config11 {
                 os                  : 'linux',
                 arch                : 'aarch64',
                 additionalNodeLabels: 'centos7',
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                test                : false,
                 configureArgs       : '--enable-dtrace=auto'
         ],
 
@@ -134,21 +128,21 @@ class Config11 {
                 os                   : 'linux',
                 additionalNodeLabels : 'centos6',
                 arch                 : 'x64',
-                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                test                 : false,
                 additionalFileNameTag: "linuxXL",
                 configureArgs        : '--with-noncompressedrefs --disable-ccache --enable-jitserver --enable-dtrace=auto'
         ],
         s390xLinuxXL    : [
                 os                   : 'linux',
                 arch                 : 's390x',
-                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                test                 : false,
                 additionalFileNameTag: "linuxXL",
                 configureArgs        : '--with-noncompressedrefs --disable-ccache --enable-dtrace=auto'
         ],
         ppc64leLinuxXL    : [
                 os                   : 'linux',
                 arch                 : 'ppc64le',
-                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                test                 : false,
                 additionalFileNameTag: "linuxXL",
                 configureArgs        : '--with-noncompressedrefs --disable-ccache --enable-dtrace=auto --enable-jitserver'
         ],
@@ -156,7 +150,7 @@ class Config11 {
                 os                   : 'linux',
                 additionalNodeLabels : 'centos7',
                 arch                 : 'aarch64',
-                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                test                 : false,
                 additionalFileNameTag: "linuxXL",
                 configureArgs        : '--with-noncompressedrefs --disable-ccache --enable-dtrace=auto'
         ],

--- a/pipelines/jobs/configurations/jdk14_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk14_pipeline_config.groovy
@@ -4,7 +4,7 @@ class Config14 {
                 os                  : 'mac',
                 arch                : 'x64',
                 additionalNodeLabels : 'macos10.14',
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                test                : false,
                 configureArgs       : '--enable-dtrace=auto'
         ],
 
@@ -12,7 +12,7 @@ class Config14 {
                 os                   : 'mac',
                 arch                 : 'x64',
                 additionalNodeLabels : 'macos10.14',
-                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                test                 : false,
                 additionalFileNameTag: "macosXL",
                 configureArgs        : '--with-noncompressedrefs --enable-dtrace=auto'
         ],
@@ -21,7 +21,7 @@ class Config14 {
                 os                  : 'linux',
                 arch                : 'x64',
                 additionalNodeLabels: 'centos6',
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external', 'special.functional'],
+                test                : false,
                 configureArgs        : '--disable-ccache --enable-dtrace=auto'
         ],
 
@@ -29,7 +29,7 @@ class Config14 {
                 os                   : 'linux',
                 additionalNodeLabels : 'centos6',
                 arch                 : 'x64',
-                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                test                 : false,
                 additionalFileNameTag: "linuxXL",
                 configureArgs        : '--with-noncompressedrefs --disable-ccache --enable-dtrace=auto'
         ],
@@ -44,14 +44,14 @@ class Config14 {
                 buildArgs : [
                         hotspot : '--jvm-variant client,server'
                 ],
-                test                : ['sanity.openjdk', 'sanity.perf', 'sanity.system', 'extended.system']
+                test                : false
         ],
 
         x64WindowsXL    : [
                 os                   : 'windows',
                 arch                 : 'x64',
                 additionalNodeLabels : 'win2012&&vs2017',
-                test                 : ['sanity.openjdk', 'sanity.perf', 'sanity.system', 'extended.system'],
+                test                 : false,
                 additionalFileNameTag: "windowsXL",
                 configureArgs        : '--with-noncompressedrefs'
         ],
@@ -65,30 +65,27 @@ class Config14 {
                 buildArgs : [
                         hotspot : '--jvm-variant client,server'
                 ],
-                test                : ['sanity.openjdk']
+                test                : false
         ],
 
         ppc64Aix    : [
                 os                  : 'aix',
                 arch                : 'ppc64',
                 additionalNodeLabels: 'xlc16',
-                test                : [
-                        nightly: ['sanity.openjdk'],
-                        release: ['sanity.openjdk', 'sanity.system', 'extended.system']
-                ]
+                test                : false
         ],
 
         s390xLinux    : [
                 os                  : 'linux',
                 arch                : 's390x',
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                test                : false,
                 configureArgs        : '--disable-ccache --enable-dtrace=auto'
         ],
 
         s390xLinuxXL    : [
                 os                   : 'linux',
                 arch                 : 's390x',
-                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                test                 : false,
                 additionalFileNameTag: "linuxXL",
                 configureArgs        : '--with-noncompressedrefs --disable-ccache --enable-dtrace=auto'
         ],
@@ -96,7 +93,7 @@ class Config14 {
         ppc64leLinux    : [
                 os                  : 'linux',
                 arch                : 'ppc64le',
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                test                : false,
                 configureArgs       : '--disable-ccache --enable-dtrace=auto'
         ],
 
@@ -121,7 +118,7 @@ class Config14 {
         ppc64leLinuxXL    : [
                 os                   : 'linux',
                 arch                 : 'ppc64le',
-                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                test                 : false,
                 additionalFileNameTag: "linuxXL",
                 configureArgs        : '--with-noncompressedrefs --disable-ccache --enable-dtrace=auto'
         ],
@@ -130,7 +127,7 @@ class Config14 {
                 os                  : 'linux',
                 arch                : 'aarch64',
                 additionalNodeLabels: 'centos7',
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                test                : false,
                 configureArgs       : '--enable-dtrace=auto'
         ],
   ]

--- a/pipelines/jobs/configurations/jdk15_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk15_pipeline_config.groovy
@@ -6,7 +6,7 @@ class Config15 {
                 additionalNodeLabels: 'macos10.14',
                 test                : [
                         nightly: false,
-                        release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
+                        release: false
                 ],
                 configureArgs       : '--enable-dtrace'
         ],
@@ -17,7 +17,7 @@ class Config15 {
                 additionalNodeLabels: 'centos6',
                 test                : [
                         nightly: false,
-                        release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external', 'special.functional']
+                        release: false
                 ],
                 configureArgs       : '--disable-ccache --enable-dtrace'
         ],
@@ -34,7 +34,7 @@ class Config15 {
                 ],
                 test                : [
                         nightly: false,
-                        release: ['sanity.openjdk', 'sanity.perf', 'sanity.system', 'extended.system']
+                        release: false
                 ]
         ],
 
@@ -44,7 +44,7 @@ class Config15 {
                 additionalNodeLabels: 'xlc16',
                 test                : [
                         nightly: false,
-                        release: ['sanity.openjdk', 'sanity.system', 'extended.system']
+                        release: false
                 ]
         ],
 
@@ -54,7 +54,7 @@ class Config15 {
                 arch                : 's390x',
                 test                : [
                         nightly: false,
-                        release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
+                        release: false
                 ],
                 configureArgs       : '--disable-ccache --enable-dtrace'
         ],
@@ -64,7 +64,7 @@ class Config15 {
                 arch                : 'ppc64le',
                 test                : [
                         nightly: false,
-                        release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
+                        release: false
                 ],
                 configureArgs       : '--disable-ccache --enable-dtrace'
 
@@ -76,7 +76,7 @@ class Config15 {
                 additionalNodeLabels: 'centos7',
                 test                : [
                         nightly: false,
-                        release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
+                        release: false
                 ],
                 configureArgs       : '--enable-dtrace'
         ],

--- a/pipelines/jobs/configurations/jdk8_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk8_pipeline_config.groovy
@@ -8,14 +8,14 @@ class Config8 {
                         corretto: 'build-macstadium-macos1010-1',
                         openj9  : 'build-macstadium-macos1010-2'
                 ],
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk']
+                test                : false
         ],
 
         x64MacXL      : [
                 os                   : 'mac',
                 arch                 : 'x64',
                 additionalNodeLabels : 'build-macstadium-macos1010-2',
-                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'special.openjdk'],
+                test                 : false,
                 additionalFileNameTag: "macosXL",
                 configureArgs        : '--with-noncompressedrefs'
         ],
@@ -24,7 +24,7 @@ class Config8 {
                 os                  : 'linux',
                 arch                : 'x64',
                 additionalNodeLabels: 'centos6',
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external', 'special.functional', 'special.openjdk'],
+                test                : false,
                 configureArgs       : [
                         "hotspot-jfr" : '--enable-jfr',
                         "openj9"      : '--enable-jitserver'
@@ -40,14 +40,14 @@ class Config8 {
                         corretto: 'win2012',
                         openj9  : 'win2012&&mingw-cygwin'
                 ],
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk']
+                test                : false
         ],
 
         x64WindowsXL    : [
                 os                   : 'windows',
                 arch                 : 'x64',
                 additionalNodeLabels : 'win2012&&mingw-cygwin',
-                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk'],
+                test                 : false,
                 additionalFileNameTag: "windowsXL",
                 configureArgs        : '--with-noncompressedrefs'
         ],
@@ -63,23 +63,20 @@ class Config8 {
                 buildArgs : [
                         hotspot : '--jvm-variant client,server'
                 ],
-                test                : ['sanity.openjdk', 'special.openjdk']
+                test                : false
         ],
 
         ppc64Aix      : [
                 os  : 'aix',
                 arch: 'ppc64',
                 additionalNodeLabels: 'xlc13',
-                test: [
-                        nightly: ['sanity.openjdk'],
-                        release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk']
-                ]
+                test: false
         ],
 
         s390xLinux    : [
                 os  : 'linux',
                 arch: 's390x',
-                test: ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk']
+                test: false
         ],
 
         sparcv9Solaris: [
@@ -97,7 +94,7 @@ class Config8 {
         ppc64leLinux  : [
                 os  : 'linux',
                 arch: 'ppc64le',
-                test: ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk'],
+                test: false,
                 configureArgs       : [
                         "openj9"      : '--enable-jitserver'
                 ]
@@ -115,7 +112,7 @@ class Config8 {
                 os                  : 'linux',
                 arch                : 'aarch64',
                 additionalNodeLabels: 'centos7',
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk']
+                test                : false
         ],
 
         x64LinuxXL       : [
@@ -124,20 +121,20 @@ class Config8 {
                 arch                 : 'x64',
                 additionalFileNameTag: "linuxXL",
                 configureArgs        : '--with-noncompressedrefs --enable-jitserver',
-                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk'],
+                test                 : false
         ],
         s390xLinuxXL       : [
                 os                   : 'linux',
                 arch                 : 's390x',
                 additionalFileNameTag: "linuxXL",
-                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk'],
+                test                 : false,
                 configureArgs        : '--with-noncompressedrefs'
         ],
         ppc64leLinuxXL       : [
                 os                   : 'linux',
                 arch                 : 'ppc64le',
                 additionalFileNameTag: "linuxXL",
-                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk'],
+                test                 : false,
                 configureArgs        : '--with-noncompressedrefs --enable-jitserver'
         ],
   ]


### PR DESCRIPTION
Note to reviewers: DO NOT MERGE THIS YET (I'll do so over the weekend)

As per standard process, this will keep the nightlies running but will not run testing against them, thus preventing executor tie-up for release builds.

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>