### PR TITLE
windows: Don't set JAVA_HOME to JDK_BOOT_DIR

### DIFF
--- a/build-farm/platform-specific-configurations/windows.sh
+++ b/build-farm/platform-specific-configurations/windows.sh
@@ -21,7 +21,6 @@ source "$SCRIPT_DIR/../../sbin/common/constants.sh"
 export ANT_HOME=/cygdrive/C/Projects/OpenJDK/apache-ant-1.10.1
 export ALLOW_DOWNLOADS=true
 export LANG=C
-export JAVA_HOME=$JDK_BOOT_DIR
 export OPENJ9_NASM_VERSION=2.13.03
 
 TOOLCHAIN_VERSION=""


### PR DESCRIPTION
Tested and seems to resolve the issue where JAVA_HOME becomes set to a java 7 which prevents gradle from running properly in the siutation where neither JDK8_BOOT_DIR or JDK11_BOOT_DIR are defined which can happen when building java 8. As per https://github.com/AdoptOpenJDK/openjdk-infrastructure/pull/1263#issuecomment-615090885 in 