### PR TITLE
fix signtool.exe path on windows

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -187,7 +187,7 @@ class Build {
                     ]
 
                     def signJob = context.build job: "build-scripts/release/sign_build",
-                            propagate: false,
+                            propagate: true,
                             parameters: params
 
                     //Copy signed artifact back and rearchive

--- a/sign.sh
+++ b/sign.sh
@@ -55,7 +55,7 @@ signRelease()
   case "$OPERATING_SYSTEM" in
     "windows")
       echo "Signing Windows release"
-      signToolPath=${signToolPath:-"/cygdrive/c/Program Files/Microsoft SDKs/Windows/v7.1/Bin/signtool.exe"}
+      signToolPath=${signToolPath:-"/cygdrive/c/Program Files (x86)/Windows Kits/10/bin/10.0.17763.0/x64/signtool.exe"}
 
       # Sign .exe files
       FILES=$(find . -type f -name '*.exe')


### PR DESCRIPTION
This broke all windows releases from the last cycle (https://github.com/AdoptOpenJDK/openjdk-build/issues/1694)

None of the exe/dll files were signed because the path was incorrect on the azure machines. Added Propagate: true to prevent this happening again