### PR TITLE
prepareWorkspace: Add space after BUILD_CONFIG[REPOSITORY] variable

### DIFF
--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -49,7 +49,7 @@ checkoutAndCloneOpenJDKGitRepo() {
     set +e
     git --git-dir "${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/.git" remote -v
     echo "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}"
-    git --git-dir "${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/.git" remote -v | grep "origin.*fetch" | grep "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" | grep "${BUILD_CONFIG[REPOSITORY]}"
+    git --git-dir "${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/.git" remote -v | grep "origin.*fetch" | grep "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" | grep "${BUILD_CONFIG[REPOSITORY]} "
     local isValidGitRepo=$?
     set -e
 


### PR DESCRIPTION
Should fix: #1680 
ref: https://ci.adoptopenjdk.net/view/Failing%20Builds/job/build-scripts/job/jobs/job/jdk/job/jdk-windows-x64-hotspot/83/console
The addition of a space means that the when checking a src repo's remote to make sure the source is correct, there's no chance of mistaking the source of `openjdk-jdkXXu` for `openjdk-jdk`
i.e.
`grep "${BUILD_CONFIG[REPOSITORY]}" ` returns 0 when the remote is `openjdk-jdk11`, despite `$BUILD_CONFIG[REPOSITORY]` being `openjdk-jdk`
