### PR TITLE
Docker: Update Dockerfiles to use APIv3

### DIFF
--- a/docker/jdk/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk/x86_64/ubuntu/Dockerfile
@@ -59,12 +59,10 @@ RUN apt-get update \
 RUN mkdir -p /openjdk/target
 
 # Extract AdoptOpenJDK8 to run Gradle.
-RUN wget 'https://api.adoptopenjdk.net/v3/binary/latest/8/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O jdk8.tar.gz
-RUN mkdir -p /usr/lib/jvm/jdk8 && tar -xvf /jdk8.tar.gz -C /usr/lib/jvm/jdk8 --strip-components=1
+RUN sh -c "mkdir -p /usr/lib/jvm/jdk8 && wget 'https://api.adoptopenjdk.net/v3/binary/latest/8/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O - | tar xzf - -C /usr/lib/jvm/jdk8 --strip-components=1"
 
 # Extract AdoptOpenJDK14 for JDK_BOOT_DIR.
-RUN wget 'https://api.adoptopenjdk.net/v3/binary/latest/14/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O jdk14.tar.gz
-RUN mkdir -p /usr/lib/jvm/jdk14 && tar -xvf /jdk14.tar.gz -C /usr/lib/jvm/jdk14 --strip-components=1
+RUN sh -c "mkdir -p /usr/lib/jvm/jdk14 && wget 'https://api.adoptopenjdk.net/v3/binary/latest/14/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O - | tar xzf - -C /usr/lib/jvm/jdk14 --strip-components=1"
 RUN ln -sf /usr/lib/jvm/jdk14/bin/java /usr/bin/java
 RUN ln -sf /usr/lib/jvm/jdk14/bin/javac /usr/bin/javac
 

--- a/docker/jdk/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk/x86_64/ubuntu/Dockerfile
@@ -59,11 +59,11 @@ RUN apt-get update \
 RUN mkdir -p /openjdk/target
 
 # Extract AdoptOpenJDK8 to run Gradle.
-RUN wget 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk8?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk' -O jdk8.tar.gz
+RUN wget 'https://api.adoptopenjdk.net/v3/binary/latest/8/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O jdk8.tar.gz
 RUN mkdir -p /usr/lib/jvm/jdk8 && tar -xvf /jdk8.tar.gz -C /usr/lib/jvm/jdk8 --strip-components=1
 
 # Extract AdoptOpenJDK14 for JDK_BOOT_DIR.
-RUN wget 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk14?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk' -O jdk14.tar.gz
+RUN wget 'https://api.adoptopenjdk.net/v3/binary/latest/14/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O jdk14.tar.gz
 RUN mkdir -p /usr/lib/jvm/jdk14 && tar -xvf /jdk14.tar.gz -C /usr/lib/jvm/jdk14 --strip-components=1
 RUN ln -sf /usr/lib/jvm/jdk14/bin/java /usr/bin/java
 RUN ln -sf /usr/lib/jvm/jdk14/bin/javac /usr/bin/javac

--- a/docker/jdk/x86_64/ubuntu/Dockerfile-openj9
+++ b/docker/jdk/x86_64/ubuntu/Dockerfile-openj9
@@ -65,7 +65,7 @@ RUN ln -s /usr/lib/x86_64-linux-gnu /usr/lib64 \
 RUN mkdir -p /openjdk/target
 
 # Extract AdoptOpenJDK14 for JDK_BOOT_DIR.
-RUN wget 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk14?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk' -O jdk14.tar.gz
+RUN wget 'https://api.adoptopenjdk.net/v3/binary/latest/14/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O jdk14.tar.gz
 RUN mkdir -p /usr/lib/jvm/jdk14 && tar -xvf /jdk14.tar.gz -C /usr/lib/jvm/jdk14 --strip-components=1
 RUN ln -sf /usr/lib/jvm/jdk14/bin/java /usr/bin/java
 RUN ln -sf /usr/lib/jvm/jdk14/bin/javac /usr/bin/javac

--- a/docker/jdk/x86_64/ubuntu/Dockerfile-openj9
+++ b/docker/jdk/x86_64/ubuntu/Dockerfile-openj9
@@ -65,8 +65,7 @@ RUN ln -s /usr/lib/x86_64-linux-gnu /usr/lib64 \
 RUN mkdir -p /openjdk/target
 
 # Extract AdoptOpenJDK14 for JDK_BOOT_DIR.
-RUN wget 'https://api.adoptopenjdk.net/v3/binary/latest/14/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O jdk14.tar.gz
-RUN mkdir -p /usr/lib/jvm/jdk14 && tar -xvf /jdk14.tar.gz -C /usr/lib/jvm/jdk14 --strip-components=1
+RUN sh -c "mkdir -p /usr/lib/jvm/jdk14 && wget 'https://api.adoptopenjdk.net/v3/binary/latest/14/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O - | tar xzf - -C /usr/lib/jvm/jdk14 --strip-components=1"
 RUN ln -sf /usr/lib/jvm/jdk14/bin/java /usr/bin/java
 RUN ln -sf /usr/lib/jvm/jdk14/bin/javac /usr/bin/javac
 

--- a/docker/jdk10/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk10/x86_64/ubuntu/Dockerfile
@@ -55,12 +55,10 @@ RUN apt-get update \
 RUN mkdir -p /openjdk/target
 
 # Extract AdoptOpenJDK8 to run Gradle.
-RUN wget 'https://api.adoptopenjdk.net/v3/binary/latest/8/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O jdk8.tar.gz
-RUN mkdir -p /usr/lib/jvm/jdk8 && tar -xvf /jdk8.tar.gz -C /usr/lib/jvm/jdk8 --strip-components=1
+RUN sh -c "mkdir -p /usr/lib/jvm/jdk8 && wget 'https://api.adoptopenjdk.net/v3/binary/latest/8/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O - | tar xzf - -C /usr/lib/jvm/jdk8 --strip-components=1"
 
 # Extract AdoptOpenJDK9 to set as JDK_BOOT_DIR.
-RUN wget 'https://api.adoptopenjdk.net/v3/binary/latest/9/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O jdk9.tar.gz
-RUN mkdir -p /usr/lib/jvm/jdk9 && tar -xvf /jdk9.tar.gz -C /usr/lib/jvm/jdk9 --strip-components=1
+RUN sh -c "mkdir -p /usr/lib/jvm/jdk9 && wget 'https://api.adoptopenjdk.net/v3/binary/latest/9/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O - | tar xzf - -C /usr/lib/jvm/jdk9 --strip-components=1"
 RUN ln -sf /usr/lib/jvm/jdk9/bin/java /usr/bin/java
 RUN ln -sf /usr/lib/jvm/jdk9/bin/javac /usr/bin/javac
 

--- a/docker/jdk10/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk10/x86_64/ubuntu/Dockerfile
@@ -55,11 +55,11 @@ RUN apt-get update \
 RUN mkdir -p /openjdk/target
 
 # Extract AdoptOpenJDK8 to run Gradle.
-RUN wget 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk8?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk' -O jdk8.tar.gz
+RUN wget 'https://api.adoptopenjdk.net/v3/binary/latest/8/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O jdk8.tar.gz
 RUN mkdir -p /usr/lib/jvm/jdk8 && tar -xvf /jdk8.tar.gz -C /usr/lib/jvm/jdk8 --strip-components=1
 
 # Extract AdoptOpenJDK9 to set as JDK_BOOT_DIR.
-RUN wget 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk9?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk' -O jdk9.tar.gz
+RUN wget 'https://api.adoptopenjdk.net/v3/binary/latest/9/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O jdk9.tar.gz
 RUN mkdir -p /usr/lib/jvm/jdk9 && tar -xvf /jdk9.tar.gz -C /usr/lib/jvm/jdk9 --strip-components=1
 RUN ln -sf /usr/lib/jvm/jdk9/bin/java /usr/bin/java
 RUN ln -sf /usr/lib/jvm/jdk9/bin/javac /usr/bin/javac

--- a/docker/jdk11/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk11/x86_64/ubuntu/Dockerfile
@@ -59,12 +59,10 @@ RUN apt-get update \
 RUN mkdir -p /openjdk/target
 
 # Extract AdoptOpenJDK8 to run Gradle.
-RUN wget 'https://api.adoptopenjdk.net/v3/binary/latest/8/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O jdk8.tar.gz
-RUN mkdir -p /usr/lib/jvm/jdk8 && tar -xvf /jdk8.tar.gz -C /usr/lib/jvm/jdk8 --strip-components=1
+RUN sh -c "mkdir -p /usr/lib/jvm/jdk8 && wget 'https://api.adoptopenjdk.net/v3/binary/latest/8/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O - | tar xzf - -C /usr/lib/jvm/jdk8 --strip-components=1"
 
 # Extract AdoptOpenJDK10 to set as JDK_BOOT_DIR.
-RUN wget 'https://api.adoptopenjdk.net/v3/binary/latest/10/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O jdk10.tar.gz
-RUN mkdir -p /usr/lib/jvm/jdk10 && tar -xvf /jdk10.tar.gz -C /usr/lib/jvm/jdk10 --strip-components=1
+RUN sh -c "mkdir -p /usr/lib/jvm/jdk10 && wget 'https://api.adoptopenjdk.net/v3/binary/latest/10/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O - | tar xzf - -C /usr/lib/jvm/jdk10 --strip-components=1"
 RUN ln -sf /usr/lib/jvm/jdk10/bin/java /usr/bin/java
 RUN ln -sf /usr/lib/jvm/jdk10/bin/javac /usr/bin/javac
 

--- a/docker/jdk11/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk11/x86_64/ubuntu/Dockerfile
@@ -59,11 +59,11 @@ RUN apt-get update \
 RUN mkdir -p /openjdk/target
 
 # Extract AdoptOpenJDK8 to run Gradle.
-RUN wget 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk8?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk' -O jdk8.tar.gz
+RUN wget 'https://api.adoptopenjdk.net/v3/binary/latest/8/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O jdk8.tar.gz
 RUN mkdir -p /usr/lib/jvm/jdk8 && tar -xvf /jdk8.tar.gz -C /usr/lib/jvm/jdk8 --strip-components=1
 
 # Extract AdoptOpenJDK10 to set as JDK_BOOT_DIR.
-RUN wget 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk10?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk' -O jdk10.tar.gz
+RUN wget 'https://api.adoptopenjdk.net/v3/binary/latest/10/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O jdk10.tar.gz
 RUN mkdir -p /usr/lib/jvm/jdk10 && tar -xvf /jdk10.tar.gz -C /usr/lib/jvm/jdk10 --strip-components=1
 RUN ln -sf /usr/lib/jvm/jdk10/bin/java /usr/bin/java
 RUN ln -sf /usr/lib/jvm/jdk10/bin/javac /usr/bin/javac

--- a/docker/jdk11/x86_64/ubuntu/Dockerfile-openj9
+++ b/docker/jdk11/x86_64/ubuntu/Dockerfile-openj9
@@ -65,7 +65,7 @@ RUN ln -s /usr/lib/x86_64-linux-gnu /usr/lib64 \
 RUN mkdir -p /openjdk/target
 
 # Extract AdoptOpenJDK10 to set as JDK_BOOT_DIR.
-RUN wget 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk10?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk' -O jdk10.tar.gz
+RUN wget 'https://api.adoptopenjdk.net/v3/binary/latest/10/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O jdk10.tar.gz
 RUN mkdir -p /usr/lib/jvm/jdk10 && tar -xvf /jdk10.tar.gz -C /usr/lib/jvm/jdk10 --strip-components=1
 RUN ln -sf /usr/lib/jvm/jdk10/bin/java /usr/bin/java
 RUN ln -sf /usr/lib/jvm/jdk10/bin/javac /usr/bin/javac

--- a/docker/jdk11/x86_64/ubuntu/Dockerfile-openj9
+++ b/docker/jdk11/x86_64/ubuntu/Dockerfile-openj9
@@ -65,8 +65,7 @@ RUN ln -s /usr/lib/x86_64-linux-gnu /usr/lib64 \
 RUN mkdir -p /openjdk/target
 
 # Extract AdoptOpenJDK10 to set as JDK_BOOT_DIR.
-RUN wget 'https://api.adoptopenjdk.net/v3/binary/latest/10/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O jdk10.tar.gz
-RUN mkdir -p /usr/lib/jvm/jdk10 && tar -xvf /jdk10.tar.gz -C /usr/lib/jvm/jdk10 --strip-components=1
+RUN sh -c "mkdir -p /usr/lib/jvm/jdk10 && wget 'https://api.adoptopenjdk.net/v3/binary/latest/10/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O - | tar xzf - -C /usr/lib/jvm/jdk10 --strip-components=1"
 RUN ln -sf /usr/lib/jvm/jdk10/bin/java /usr/bin/java
 RUN ln -sf /usr/lib/jvm/jdk10/bin/javac /usr/bin/javac
 

--- a/docker/jdk12/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk12/x86_64/ubuntu/Dockerfile
@@ -59,12 +59,10 @@ RUN apt-get update \
 RUN mkdir -p /openjdk/target
 
 # Extract AdoptOpenJDK8 to run Gradle.
-RUN wget 'https://api.adoptopenjdk.net/v3/binary/latest/8/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O jdk8.tar.gz
-RUN mkdir -p /usr/lib/jvm/jdk8 && tar -xvf /jdk8.tar.gz -C /usr/lib/jvm/jdk8 --strip-components=1
+RUN sh -c "mkdir -p /usr/lib/jvm/jdk8 && wget 'https://api.adoptopenjdk.net/v3/binary/latest/8/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O - | tar xzf - -C /usr/lib/jvm/jdk8 --strip-components=1"
 
 # Extract AdoptOpenJDK11 to set as JDK_BOOT_DIR.
-RUN wget 'https://api.adoptopenjdk.net/v3/binary/latest/11/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O jdk11.tar.gz
-RUN mkdir -p /usr/lib/jvm/jdk11 && tar -xvf /jdk11.tar.gz -C /usr/lib/jvm/jdk11 --strip-components=1
+RUN sh -c "mkdir -p /usr/lib/jvm/jdk11 && wget 'https://api.adoptopenjdk.net/v3/binary/latest/11/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O - | tar xzf - -C /usr/lib/jvm/jdk11 --strip-components=1"
 RUN ln -sf /usr/lib/jvm/jdk11/bin/javac /usr/bin/javac
 RUN ln -sf /usr/lib/jvm/jdk11/bin/javac /usr/bin/javac
 

--- a/docker/jdk12/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk12/x86_64/ubuntu/Dockerfile
@@ -59,11 +59,11 @@ RUN apt-get update \
 RUN mkdir -p /openjdk/target
 
 # Extract AdoptOpenJDK8 to run Gradle.
-RUN wget 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk8?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk' -O jdk8.tar.gz
+RUN wget 'https://api.adoptopenjdk.net/v3/binary/latest/8/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O jdk8.tar.gz
 RUN mkdir -p /usr/lib/jvm/jdk8 && tar -xvf /jdk8.tar.gz -C /usr/lib/jvm/jdk8 --strip-components=1
 
 # Extract AdoptOpenJDK11 to set as JDK_BOOT_DIR.
-RUN wget 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk11?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk' -O jdk11.tar.gz
+RUN wget 'https://api.adoptopenjdk.net/v3/binary/latest/11/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O jdk11.tar.gz
 RUN mkdir -p /usr/lib/jvm/jdk11 && tar -xvf /jdk11.tar.gz -C /usr/lib/jvm/jdk11 --strip-components=1
 RUN ln -sf /usr/lib/jvm/jdk11/bin/javac /usr/bin/javac
 RUN ln -sf /usr/lib/jvm/jdk11/bin/javac /usr/bin/javac

--- a/docker/jdk12/x86_64/ubuntu/Dockerfile-openj9
+++ b/docker/jdk12/x86_64/ubuntu/Dockerfile-openj9
@@ -59,7 +59,7 @@ RUN ln -sf /usr/bin/gcc-4.8 /usr/bin/gcc \
 RUN mkdir -p /openjdk/target
 
 # Extract AdoptOpenJDK11 to set as JDK_BOOT_DIR.
-RUN wget 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk11?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk' -O jdk11.tar.gz
+RUN wget 'https://api.adoptopenjdk.net/v3/binary/latest/11/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O jdk11.tar.gz
 RUN mkdir -p /usr/lib/jvm/jdk11 && tar -xvf /jdk11.tar.gz -C /usr/lib/jvm/jdk11 --strip-components=1
 RUN ln -sf /usr/lib/jvm/jdk11/bin/javac /usr/bin/javac
 RUN ln -sf /usr/lib/jvm/jdk11/bin/javac /usr/bin/javac

--- a/docker/jdk12/x86_64/ubuntu/Dockerfile-openj9
+++ b/docker/jdk12/x86_64/ubuntu/Dockerfile-openj9
@@ -59,8 +59,7 @@ RUN ln -sf /usr/bin/gcc-4.8 /usr/bin/gcc \
 RUN mkdir -p /openjdk/target
 
 # Extract AdoptOpenJDK11 to set as JDK_BOOT_DIR.
-RUN wget 'https://api.adoptopenjdk.net/v3/binary/latest/11/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O jdk11.tar.gz
-RUN mkdir -p /usr/lib/jvm/jdk11 && tar -xvf /jdk11.tar.gz -C /usr/lib/jvm/jdk11 --strip-components=1
+RUN sh -c "mkdir -p /usr/lib/jvm/jdk11 && wget 'https://api.adoptopenjdk.net/v3/binary/latest/11/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O - | tar xzf - -C /usr/lib/jvm/jdk11 --strip-components=1"
 RUN ln -sf /usr/lib/jvm/jdk11/bin/javac /usr/bin/javac
 RUN ln -sf /usr/lib/jvm/jdk11/bin/javac /usr/bin/javac
 

--- a/docker/jdk13/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk13/x86_64/ubuntu/Dockerfile
@@ -59,11 +59,11 @@ RUN apt-get update \
 RUN mkdir -p /openjdk/target
 
 # Extract AdoptOpenJDK8 to run Gradle.
-RUN wget 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk8?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk' -O jdk8.tar.gz
+RUN wget 'https://api.adoptopenjdk.net/v3/binary/latest/8/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O jdk8.tar.gz
 RUN mkdir -p /usr/lib/jvm/jdk8 && tar -xvf /jdk8.tar.gz -C /usr/lib/jvm/jdk8 --strip-components=1
 
 # Extract AdoptOpenJDK12 for JDK_BOOT_DIR.
-RUN wget 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk12?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk' -O jdk12.tar.gz
+RUN wget 'https://api.adoptopenjdk.net/v3/binary/latest/12/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O jdk12.tar.gz
 RUN mkdir -p /usr/lib/jvm/jdk12 && tar -xvf /jdk12.tar.gz -C /usr/lib/jvm/jdk12 --strip-components=1
 RUN ln -sf /usr/lib/jvm/jdk12/bin/java /usr/bin/java
 RUN ln -sf /usr/lib/jvm/jdk12/bin/javac /usr/bin/javac

--- a/docker/jdk13/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk13/x86_64/ubuntu/Dockerfile
@@ -59,12 +59,10 @@ RUN apt-get update \
 RUN mkdir -p /openjdk/target
 
 # Extract AdoptOpenJDK8 to run Gradle.
-RUN wget 'https://api.adoptopenjdk.net/v3/binary/latest/8/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O jdk8.tar.gz
-RUN mkdir -p /usr/lib/jvm/jdk8 && tar -xvf /jdk8.tar.gz -C /usr/lib/jvm/jdk8 --strip-components=1
+RUN sh -c "mkdir -p /usr/lib/jvm/jdk8 && wget 'https://api.adoptopenjdk.net/v3/binary/latest/8/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O - | tar xzf - -C /usr/lib/jvm/jdk8 --strip-components=1"
 
 # Extract AdoptOpenJDK12 for JDK_BOOT_DIR.
-RUN wget 'https://api.adoptopenjdk.net/v3/binary/latest/12/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O jdk12.tar.gz
-RUN mkdir -p /usr/lib/jvm/jdk12 && tar -xvf /jdk12.tar.gz -C /usr/lib/jvm/jdk12 --strip-components=1
+RUN sh -c "mkdir -p /usr/lib/jvm/jdk12 && wget 'https://api.adoptopenjdk.net/v3/binary/latest/12/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O - | tar xzf - -C /usr/lib/jvm/jdk12 --strip-components=1"
 RUN ln -sf /usr/lib/jvm/jdk12/bin/java /usr/bin/java
 RUN ln -sf /usr/lib/jvm/jdk12/bin/javac /usr/bin/javac
 

--- a/docker/jdk13/x86_64/ubuntu/Dockerfile-openj9
+++ b/docker/jdk13/x86_64/ubuntu/Dockerfile-openj9
@@ -65,8 +65,7 @@ RUN ln -s /usr/lib/x86_64-linux-gnu /usr/lib64 \
 RUN mkdir -p /openjdk/target
 
 # Extract AdoptOpenJDK12 for JDK_BOOT_DIR.
-RUN wget 'https://api.adoptopenjdk.net/v3/binary/latest/12/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O jdk12.tar.gz
-RUN mkdir -p /usr/lib/jvm/jdk12 && tar -xvf /jdk12.tar.gz -C /usr/lib/jvm/jdk12 --strip-components=1
+RUN sh -c "mkdir -p /usr/lib/jvm/jdk12 && wget 'https://api.adoptopenjdk.net/v3/binary/latest/12/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O - | tar xzf - -C /usr/lib/jvm/jdk12 --strip-components=1"
 RUN ln -sf /usr/lib/jvm/jdk12/bin/java /usr/bin/java
 RUN ln -sf /usr/lib/jvm/jdk12/bin/javac /usr/bin/javac
 

--- a/docker/jdk13/x86_64/ubuntu/Dockerfile-openj9
+++ b/docker/jdk13/x86_64/ubuntu/Dockerfile-openj9
@@ -65,7 +65,7 @@ RUN ln -s /usr/lib/x86_64-linux-gnu /usr/lib64 \
 RUN mkdir -p /openjdk/target
 
 # Extract AdoptOpenJDK12 for JDK_BOOT_DIR.
-RUN wget 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk12?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk' -O jdk12.tar.gz
+RUN wget 'https://api.adoptopenjdk.net/v3/binary/latest/12/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O jdk12.tar.gz
 RUN mkdir -p /usr/lib/jvm/jdk12 && tar -xvf /jdk12.tar.gz -C /usr/lib/jvm/jdk12 --strip-components=1
 RUN ln -sf /usr/lib/jvm/jdk12/bin/java /usr/bin/java
 RUN ln -sf /usr/lib/jvm/jdk12/bin/javac /usr/bin/javac

--- a/docker/jdk14/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk14/x86_64/ubuntu/Dockerfile
@@ -59,12 +59,10 @@ RUN apt-get update \
 RUN mkdir -p /openjdk/target
 
 # Extract AdoptOpenJDK8 to run Gradle.
-RUN wget 'https://api.adoptopenjdk.net/v3/binary/latest/8/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O jdk8.tar.gz
-RUN mkdir -p /usr/lib/jvm/jdk8 && tar -xvf /jdk8.tar.gz -C /usr/lib/jvm/jdk8 --strip-components=1
+RUN sh -c "mkdir -p /usr/lib/jvm/jdk8 && wget 'https://api.adoptopenjdk.net/v3/binary/latest/8/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O - | tar xzf - -C /usr/lib/jvm/jdk8 --strip-components=1"
 
 # Extract AdoptOpenJDK13 for JDK_BOOT_DIR.
-RUN wget 'https://api.adoptopenjdk.net/v3/binary/latest/13/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O jdk13.tar.gz
-RUN mkdir -p /usr/lib/jvm/jdk13 && tar -xvf /jdk13.tar.gz -C /usr/lib/jvm/jdk13 --strip-components=1
+RUN sh -c "mkdir -p /usr/lib/jvm/jdk13 && wget 'https://api.adoptopenjdk.net/v3/binary/latest/13/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O - | tar xzf - -C /usr/lib/jvm/jdk13 --strip-components=1"
 RUN ln -sf /usr/lib/jvm/jdk13/bin/java /usr/bin/java
 RUN ln -sf /usr/lib/jvm/jdk13/bin/javac /usr/bin/javac
 

--- a/docker/jdk14/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk14/x86_64/ubuntu/Dockerfile
@@ -59,11 +59,11 @@ RUN apt-get update \
 RUN mkdir -p /openjdk/target
 
 # Extract AdoptOpenJDK8 to run Gradle.
-RUN wget 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk8?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk' -O jdk8.tar.gz
+RUN wget 'https://api.adoptopenjdk.net/v3/binary/latest/8/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O jdk8.tar.gz
 RUN mkdir -p /usr/lib/jvm/jdk8 && tar -xvf /jdk8.tar.gz -C /usr/lib/jvm/jdk8 --strip-components=1
 
 # Extract AdoptOpenJDK13 for JDK_BOOT_DIR.
-RUN wget 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk13?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk' -O jdk13.tar.gz
+RUN wget 'https://api.adoptopenjdk.net/v3/binary/latest/13/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O jdk13.tar.gz
 RUN mkdir -p /usr/lib/jvm/jdk13 && tar -xvf /jdk13.tar.gz -C /usr/lib/jvm/jdk13 --strip-components=1
 RUN ln -sf /usr/lib/jvm/jdk13/bin/java /usr/bin/java
 RUN ln -sf /usr/lib/jvm/jdk13/bin/javac /usr/bin/javac

--- a/docker/jdk14/x86_64/ubuntu/Dockerfile-openj9
+++ b/docker/jdk14/x86_64/ubuntu/Dockerfile-openj9
@@ -66,8 +66,7 @@ RUN ln -s /usr/lib/x86_64-linux-gnu /usr/lib64 \
 RUN mkdir -p /openjdk/target
 
 # Extract AdoptOpenJDK13 for JDK_BOOT_DIR.
-RUN wget 'https://api.adoptopenjdk.net/v3/binary/latest/13/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O jdk13.tar.gz
-RUN mkdir -p /usr/lib/jvm/jdk13 && tar -xvf /jdk13.tar.gz -C /usr/lib/jvm/jdk13 --strip-components=1
+RUN sh -c "mkdir -p /usr/lib/jvm/jdk13 && wget 'https://api.adoptopenjdk.net/v3/binary/latest/13/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O - | tar xzf - -C /usr/lib/jvm/jdk13 --strip-components=1"
 RUN ln -sf /usr/lib/jvm/jdk13/bin/java /usr/bin/java
 RUN ln -sf /usr/lib/jvm/jdk13/bin/javac /usr/bin/javac
 

--- a/docker/jdk14/x86_64/ubuntu/Dockerfile-openj9
+++ b/docker/jdk14/x86_64/ubuntu/Dockerfile-openj9
@@ -66,7 +66,7 @@ RUN ln -s /usr/lib/x86_64-linux-gnu /usr/lib64 \
 RUN mkdir -p /openjdk/target
 
 # Extract AdoptOpenJDK13 for JDK_BOOT_DIR.
-RUN wget 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk13?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk' -O jdk13.tar.gz
+RUN wget 'https://api.adoptopenjdk.net/v3/binary/latest/13/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O jdk13.tar.gz
 RUN mkdir -p /usr/lib/jvm/jdk13 && tar -xvf /jdk13.tar.gz -C /usr/lib/jvm/jdk13 --strip-components=1
 RUN ln -sf /usr/lib/jvm/jdk13/bin/java /usr/bin/java
 RUN ln -sf /usr/lib/jvm/jdk13/bin/javac /usr/bin/javac

--- a/docker/jdk8/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk8/x86_64/ubuntu/Dockerfile
@@ -56,7 +56,7 @@ RUN apt-get update \
 RUN mkdir -p /openjdk/target
 
 # Extract AdoptOpenJDK8 to run Gradle with, and set to default Java/Javac.
-RUN wget 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk8?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk' -O jdk8.tar.gz
+RUN wget 'https://api.adoptopenjdk.net/v3/binary/latest/8/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O jdk8.tar.gz
 RUN mkdir -p /usr/lib/jvm/jdk8 && tar -xvf /jdk8.tar.gz -C /usr/lib/jvm/jdk8 --strip-components=1
 RUN ln -sf /usr/lib/jvm/jdk8/bin/java /usr/bin/java
 RUN ln -sf /usr/lib/jvm/jdk8/bin/javac /usr/bin/javac

--- a/docker/jdk8/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk8/x86_64/ubuntu/Dockerfile
@@ -56,8 +56,7 @@ RUN apt-get update \
 RUN mkdir -p /openjdk/target
 
 # Extract AdoptOpenJDK8 to run Gradle with, and set to default Java/Javac.
-RUN wget 'https://api.adoptopenjdk.net/v3/binary/latest/8/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O jdk8.tar.gz
-RUN mkdir -p /usr/lib/jvm/jdk8 && tar -xvf /jdk8.tar.gz -C /usr/lib/jvm/jdk8 --strip-components=1
+RUN sh -c "mkdir -p /usr/lib/jvm/jdk8 && wget 'https://api.adoptopenjdk.net/v3/binary/latest/8/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O - | tar xzf - -C /usr/lib/jvm/jdk8 --strip-components=1"
 RUN ln -sf /usr/lib/jvm/jdk8/bin/java /usr/bin/java
 RUN ln -sf /usr/lib/jvm/jdk8/bin/javac /usr/bin/javac
 

--- a/docker/jdk9/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk9/x86_64/ubuntu/Dockerfile
@@ -54,7 +54,7 @@ RUN apt-get update \
 RUN mkdir -p /openjdk/target
 
 # Extract AdoptOpenJDK8 and set as default Java/Javac
-RUN wget 'https://api.adoptopenjdk.net/v2/binary/releases/openjdk8?openjdk_impl=hotspot&os=linux&arch=x64&release=latest&type=jdk' -O jdk8.tar.gz
+RUN wget 'https://api.adoptopenjdk.net/v3/binary/latest/8/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O jdk8.tar.gz
 RUN mkdir -p /usr/lib/jvm/jdk8 && tar -xvf /jdk8.tar.gz -C /usr/lib/jvm/jdk8 --strip-components=1
 RUN ln -sf /usr/lib/jvm/jdk8/bin/java /usr/bin/java
 RUN ln -sf /usr/lib/jvm/jdk8/bin/javac /usr/bin/javac

--- a/docker/jdk9/x86_64/ubuntu/Dockerfile
+++ b/docker/jdk9/x86_64/ubuntu/Dockerfile
@@ -1,4 +1,4 @@
-#
+RUN sh -c "mkdir -p /usr/lib/jvm/jdk8 && wget 'https://api.adoptopenjdk.net/v3/binary/latest/8/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O - | tar xzf - -C /usr/lib/jvm/jdk8 --strip-components=1"#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -54,8 +54,7 @@ RUN apt-get update \
 RUN mkdir -p /openjdk/target
 
 # Extract AdoptOpenJDK8 and set as default Java/Javac
-RUN wget 'https://api.adoptopenjdk.net/v3/binary/latest/8/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O jdk8.tar.gz
-RUN mkdir -p /usr/lib/jvm/jdk8 && tar -xvf /jdk8.tar.gz -C /usr/lib/jvm/jdk8 --strip-components=1
+RUN sh -c "mkdir -p /usr/lib/jvm/jdk8 && wget 'https://api.adoptopenjdk.net/v3/binary/latest/8/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk' -O - | tar xzf - -C /usr/lib/jvm/jdk8 --strip-components=1"
 RUN ln -sf /usr/lib/jvm/jdk8/bin/java /usr/bin/java
 RUN ln -sf /usr/lib/jvm/jdk8/bin/javac /usr/bin/javac
 


### PR DESCRIPTION
ping @sxa 

Update to the more stable APIv3 as to stop 404 errors.
(ref: https://ci.adoptopenjdk.net/job/DockerfileCheck/label=docker-aws-ubuntu1604-x64-1,variant=hotspot,version=jdk14u/116/ )