### PR TITLE
pipelines: Correct workspace path for Windows build

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -519,6 +519,7 @@ class Build {
                         // This is to avoid windows path length issues.
                         context.echo("checking ${buildConfig.TARGET_OS}")
                         if (buildConfig.TARGET_OS == "windows") {
+                            // See https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1284#issuecomment-621909378 for justification of the below path
                             def workspace = "C:/workspace/openjdk-build/"
                             if (env.CYGWIN_WORKSPACE) {
                                 workspace = env.CYGWIN_WORKSPACE

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -519,7 +519,7 @@ class Build {
                         // This is to avoid windows path length issues.
                         context.echo("checking ${buildConfig.TARGET_OS}")
                         if (buildConfig.TARGET_OS == "windows") {
-                            def workspace = "C:/cygwin64/tmp/openjdk-build/"
+                            def workspace = "C:/workspace/openjdk-build/"
                             if (env.CYGWIN_WORKSPACE) {
                                 workspace = env.CYGWIN_WORKSPACE
                             }


### PR DESCRIPTION
fixes: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1284
ref: https://ci.adoptopenjdk.net/job/build-scripts/job/jobs/job/jdk11u/job/jdk11u-windows-x64-hotspot/554/console

A build issue introduced with #1647 and #1639 . The softlayer Windows build machines (unlike the azure ones), don't have a `CYGWIN_WORKSPACE` variable setup for them. This causes them to default to `C:/cygwin64/tmp/openjdk-build/` currently, however that causes an issue when the build is trying to find the path: 
```
c1xx: fatal error C1083: Cannot open source file: '../../../../..c:/cygwin64/tmp/openjdk-build/workspace/build/src/build/windows-x86_64-normal-clientANDserver-release/hotspot/variant-server/libjvm/gtest/objs/BUILD_GTEST_LIBJVM_pch.cpp': No such file or directory
```
FYI @karianna @gdams @sxa 