### PR TITLE
Revert: "Ensure testType isn't false"

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -108,36 +108,33 @@ class Build {
             testList = buildConfig.TEST_LIST
         }
         testList.each { testType ->
-			// Ensure testType isn't malformed (https://github.com/AdoptOpenJDK/openjdk-build/issues/1712)
-			if (testType != "false") {
 			
-				// For each requested test, i.e 'sanity.openjdk', 'sanity.system', 'sanity.perf', 'sanity.external', call test job
-				try {
-					context.println "Running test: ${testType}"
-					testStages["${testType}"] = {
-						context.stage("${testType}") {
+			// For each requested test, i.e 'sanity.openjdk', 'sanity.system', 'sanity.perf', 'sanity.external', call test job
+			try {
+				context.println "Running test: ${testType}"
+				testStages["${testType}"] = {
+					context.stage("${testType}") {
 
-							// example jobName: Test_openjdk11_hs_sanity.system_ppc64_aix
-							def jobName = determineTestJobName(testType)
+						// example jobName: Test_openjdk11_hs_sanity.system_ppc64_aix
+						def jobName = determineTestJobName(testType)
 
-							def JobHelper = context.library(identifier: 'openjdk-jenkins-helper@master').JobHelper
-							if (JobHelper.jobIsRunnable(jobName as String)) {
-								context.catchError {
-									context.build job: jobName,
-											propagate: false,
-											parameters: [
-													context.string(name: 'UPSTREAM_JOB_NUMBER', value: "${env.BUILD_NUMBER}"),
-													context.string(name: 'UPSTREAM_JOB_NAME', value: "${env.JOB_NAME}"),
-													context.string(name: 'RELEASE_TAG', value: "${buildConfig.SCM_REF}")]
-								}
-							} else {
-								context.println "Requested test job that does not exist or is disabled: ${jobName}"
+						def JobHelper = context.library(identifier: 'openjdk-jenkins-helper@master').JobHelper
+						if (JobHelper.jobIsRunnable(jobName as String)) {
+							context.catchError {
+								context.build job: jobName,
+										propagate: false,
+										parameters: [
+												context.string(name: 'UPSTREAM_JOB_NUMBER', value: "${env.BUILD_NUMBER}"),
+												context.string(name: 'UPSTREAM_JOB_NAME', value: "${env.JOB_NAME}"),
+												context.string(name: 'RELEASE_TAG', value: "${buildConfig.SCM_REF}")]
 							}
+						} else {
+							context.println "Requested test job that does not exist or is disabled: ${jobName}"
 						}
 					}
-				} catch (Exception e) {
-					context.println "Failed execute test: ${e.getLocalizedMessage()}"
 				}
+			} catch (Exception e) {
+				context.println "Failed execute test: ${e.getLocalizedMessage()}"
 			}
         }
         return testStages


### PR DESCRIPTION
* https://github.com/AdoptOpenJDK/openjdk-build/pull/1723 is no longer needed. It was not the test job's that were at fault.