### PR TITLE
Boot jdk display fix

### DIFF
--- a/build-farm/make-adopt-build-farm.sh
+++ b/build-farm/make-adopt-build-farm.sh
@@ -73,7 +73,8 @@ then
 fi
 
 echo "Boot jdk directory: ${JDK_BOOT_DIR}:"
-java -version 2>&1 | sed 's/^/BOOT JDK: /'
+${JDK_BOOT_DIR}/bin/java -version 2>&1 | sed 's/^/BOOT JDK: /'
+java -version 2>&1 | sed 's/^/JDK IN PATH: /g'
 
 if [ "${RELEASE}" == "true" ]; then
   OPTIONS="${OPTIONS} --release --clean-libs"


### PR DESCRIPTION
The display of the boot JDK version output in the log is incorrect - it's currnetly displaying whichever is first in the path. This will fix that, and also display the `java -version` output of whatever is in the path to assist any other debug operations.