### PR TITLE
openj9: Enable building with cmake on macos/JDK11/J9

### DIFF
--- a/pipelines/jobs/configurations/jdk11_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11_pipeline_config.groovy
@@ -5,7 +5,10 @@ class Config11 {
                 arch                : 'x64',
                 additionalNodeLabels : 'macos10.14',
                 test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
-                configureArgs       : '--enable-dtrace=auto'
+                configureArgs       : [
+                        "openj9"      : '--enable-dtrace=auto --with-cmake',
+                        "hotspot"     : '--enable-dtrace=auto'
+                ]
         ],
 
         x64MacXL    : [
@@ -14,7 +17,7 @@ class Config11 {
                 additionalNodeLabels : 'macos10.14',
                 test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
                 additionalFileNameTag: "macosXL",
-                configureArgs        : '--with-noncompressedrefs --enable-dtrace=auto'
+                configureArgs        : '--with-noncompressedrefs --enable-dtrace=auto --with-cmake'
         ],
 
         x64Linux  : [


### PR DESCRIPTION
OpenJ9 are looking to migrate to using cmake for their builds. We've had cmake in the playbooks for a while, and the initial platform they want to switch over us JDK11 on macos. this PR makes that change and should verify that our build machines are capable of doing this.

Their official cutover will be on the 19th but I want to put this through now to get a good amount of confidence that it will work on the adoptopenjdk systems.

Cc @dnakamura

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>