### PR TITLE
Improve installer filter parsing

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -220,7 +220,7 @@ class Build {
 
 
     private void buildMacInstaller(VersionInfo versionData) {
-        def filter = "**/OpenJDK*_mac_*.tar.gz"
+        def filter = "**/OpenJDK-{jdk,jre}*_mac_*.tar.gz"
         def certificate = "Developer ID Installer: London Jamocha Community CIC"
 
         def nodeFilter = "${buildConfig.TARGET_OS}&&macos10.14&&xcode10"
@@ -253,7 +253,7 @@ class Build {
     }
 
     private void buildLinuxInstaller(VersionInfo versionData) {
-        def filter = "**/OpenJDK*_linux_*.tar.gz"
+        def filter = "**/OpenJDK-{jdk,jre}*_linux_*.tar.gz"
         def nodeFilter = "${buildConfig.TARGET_OS}&&fpm"
 
         def buildNumber = versionData.build
@@ -284,7 +284,7 @@ class Build {
     }
 
     private void buildWindowsInstaller(VersionInfo versionData) {
-        def filter = "**/OpenJDK*_windows_*.zip"
+        def filter = "**/OpenJDK-{jdk,jre}*_windows_*.zip"
         def certificate = "C:\\Users\\jenkins\\windows.p12"
 
         def buildNumber = versionData.build


### PR DESCRIPTION
* Only JDK and JRE files are needed for the installer, ignore all others

Signed-off-by: Morgan Davies <morgan.davies@ibm.com>