### PR TITLE
build-farm: Set Boot/build JDK to JDK11 for riscv

### DIFF
--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -157,7 +157,8 @@ then
 	# riscv has to use a cross compiler
 	export CC=$RISCV64/bin/riscv64-unknown-linux-gnu-gcc
 	export CXX=$RISCV64/bin/riscv64-unknown-linux-gnu-g++
-	CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-ddr --openjdk-target=riscv64-unknown-linux-gnu --with-sysroot=/opt/fedora28_riscv_root --with-boot-jdk=$JDK_BOOT_DIR --with-build-jdk=$JDK_BOOT_DIR"
+	# riscv can currently only be built on JDK11, and requires JDK11 as it's build/boot JDK
+	CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-ddr --openjdk-target=riscv64-unknown-linux-gnu --with-sysroot=/opt/fedora28_riscv_root --with-boot-jdk=$JDK11_BOOT_DIR --with-build-jdk=$JDK11_BOOT_DIR"
 	BUILD_ARGS="${BUILD_ARGS} -F"
 fi
 


### PR DESCRIPTION
ref: #1577 , https://ci.adoptopenjdk.net/job/build-scripts/job/jobs/job/jdk11u/job/jdk11u-linux-riscv-openj9/1/console

Unfortunately, the riscv JDK11 job didn't work last night as it appears that the boot and build jdk need to be set to the same JDK that you're trying to build. This can also be seen on the standalone riscv-jdk11 job before this was put into the nightlies: https://ci.adoptopenjdk.net/job/jdk11-linux-riscv-openj9-build/51/

This PR just ensures the the boot and build JDK is set to JDK11. As we currently only build JDK11 on risc-v, hardcoding it to JDK11 isn't an issue currently, however may be an issue down the line, if we can start building other JDKs.

ping @sxa @gdams 