### PR TITLE
Do not attempt to run java -version on riscv cross-compile

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -473,17 +473,18 @@ printJavaVersionString()
   esac
   if [[ -d "$PRODUCT_HOME" ]]; then
      echo "'$PRODUCT_HOME' found"
-     if ! "$PRODUCT_HOME"/bin/java -version; then
+     if [ ! -r "$PRODUCT_HOME/bin/java" ]; then
        echo "===$PRODUCT_HOME===="
        ls -alh "$PRODUCT_HOME"
 
        echo "===$PRODUCT_HOME/bin/===="
        ls -alh "$PRODUCT_HOME/bin/"
 
-       echo " Error executing 'java' does not exist in '$PRODUCT_HOME'."
+       echo "Error 'java' does not exist in '$PRODUCT_HOME'."
        exit -1
-     else
-       # repeat version string around easy to find output
+     elif [ "${ARCHITECTURE}" != "riscv" ]; then
+       # riscv is cross compiled, so we cannot run it on the build system
+       # print version string around easy to find output
        # do not modify these strings as jenkins looks for them
        echo "=JAVA VERSION OUTPUT="
        "$PRODUCT_HOME"/bin/java -version 2>&1


### PR DESCRIPTION
Error from [latest bulid](https://ci.adoptopenjdk.net/job/build-scripts/job/jobs/job/jdk11u/job/jdk11u-linux-riscv-openj9/2/console)
`
 Error executing 'java' does not exist in '/home/jenkins/workspace/build-scripts/jobs/jdk11u/jdk11u-linux-riscv-openj9/workspace/build/src/build/linux-riscv64-normal-server-release/images/jdk'.
`
I'd prefer a bit more generic support for cross-compiled builds but this is the only one we have at present so I'm happy with this "quick fix" on one platform for now.

@johnoliver Can you comment on the line in here please:
```
       # do not modify these strings as jenkins looks for them
```
When does jenkins look for these, and what are the implications if that portion is skipped on these builds?



Signed-off-by: Stewart Addison <sxa@uk.ibm.com>