### PR TITLE
Use JDK-Head version number instead of 'jdk'

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -417,6 +417,12 @@ class Build {
 
         javaToBuild = javaToBuild.toUpperCase()
 
+	// Use version number for HEAD binaries
+	if (javaToBuild == "JDK") {
+		// This needs to be updated each time JDK-Head updates
+		javaToBuild = "15U"
+	}
+
         def fileName = "Open${javaToBuild}-jdk_${architecture}_${os}_${variant}"
 
         if (additionalFileNameTag) {


### PR DESCRIPTION
* Renames JDK-Next binaries to include the major version number
* I.e.`OpenJDK-jdk_x64_windows_hotspot_2020-03-27-03-31.zip` to `OpenJDK15U-jdk_x64_windows_hotspot_2020-03-27-03-31.zip`
* Includes various documentation and script updates to allow this to function

Ref: #1016 (Doesn't close it)
Signed-off-by: Morgan Davies <morgan.davies@ibm.com>