### PR TITLE
Quotate JDK_BOOT_DIR setup

### DIFF
--- a/sbin/common/common.sh
+++ b/sbin/common/common.sh
@@ -135,10 +135,10 @@ function setBootJdk() {
       set -e
 
       if [[ ${returnCode} -ne 0 ]]; then
-        BUILD_CONFIG[JDK_BOOT_DIR]=$(dirname $(dirname $(greadlink -f $(which javac))))
+        BUILD_CONFIG[JDK_BOOT_DIR]="$(dirname "$(dirname "$(greadlink -f "$(which javac)")")")"
       fi
     else
-      BUILD_CONFIG[JDK_BOOT_DIR]=$(dirname $(dirname $(readlink -f $(which javac))))
+      BUILD_CONFIG[JDK_BOOT_DIR]="$(dirname "$(dirname "$(readlink -f "$(which javac)")")")"
     fi
 
     echo "Guessing JDK_BOOT_DIR: ${BUILD_CONFIG[JDK_BOOT_DIR]}"


### PR DESCRIPTION
* Prevents cygwin from misunderstanding the path and setting JDK_BOOT_DIR to /cygdrive

Closes: #1093 
Signed-off-by: Morgan Davies <morgan.davies@ibm.com>