### PR TITLE
Fake version.txt on cross compiles on RISC-V

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -482,7 +482,18 @@ printJavaVersionString()
 
        echo "Error 'java' does not exist in '$PRODUCT_HOME'."
        exit -1
-     elif [ "${ARCHITECTURE}" != "riscv" ]; then
+     elif [ "${ARCHITECTURE}" == "riscv" ]; then
+       # riscv is cross compiled, so we cannot run it on the build system
+       # This is a temporary plausible solution in the absence of another fix
+       cat << EOT > "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/version.txt"
+openjdk version "11.0.0-internal" 2020-05-22
+OpenJDK Runtime Environment AdoptOpenJDK (build 11.0.0-internal+0-adhoc.jenkins.openj9-openjdk-jdk11)
+Eclipse OpenJ9 VM AdoptOpenJDK (build master-000000000, JRE 11 Linux riscv-64-Bit Compressed References 20200505_46 (JIT disabled, AOT disabled)
+OpenJ9   - 000000000
+OMR      - 000000000
+JCL      - 000000000 based on jdk-11.0.0+0)
+EOT
+     else
        # riscv is cross compiled, so we cannot run it on the build system
        # print version string around easy to find output
        # do not modify these strings as jenkins looks for them

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -494,7 +494,6 @@ OMR      - 000000000
 JCL      - 000000000 based on jdk-11.0.0+0)
 EOT
      else
-       # riscv is cross compiled, so we cannot run it on the build system
        # print version string around easy to find output
        # do not modify these strings as jenkins looks for them
        echo "=JAVA VERSION OUTPUT="


### PR DESCRIPTION
This isn't the best idea, but if it works to get green pipelines I'll take it for now until someone implementes a better solution. I'm not sure what the implications are of faking the metadata like this, but we're a little short of options. I suspect the best option would be to modify the code that reads it and handle an empty case.

[EDIT: The more i think about this the more I dislike it event as a temporary solution]

[@M-Davies @Willsparker If you can figure out how it's used and implement a better alternative that might be useful]