### PR TITLE
Use OpenJ9 x64 nightly as RISC-V build jdk

### DIFF
--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -151,13 +151,19 @@ fi
 
 if [ "${ARCHITECTURE}" == "riscv" ]
 then
+	echo RISCV cross-compilation ... Downloading latest nightly OpenJ9/x64 as build JDK
+	export BUILDJDK=$WORKSPACE/buildjdk
+	rm -r "$BUILDJDK"
+	mkdir "$BUILDJDK"
+	wget -O - "https://api.adoptopenjdk.net/v3/binary/latest/${JAVA_FEATURE_VERSION}/ea/linux/x64/jdk/openj9/normal/adoptopenjdk" | tar xpzf - --strip-components=1 -C "$BUILDJDK"
+	"$BUILDJDK/bin/java" -version 2>&1 | sed 's/^/CROSSBUILD JDK > /g'
 	export RISCV64=/opt/riscv_toolchain_linux
 	export LD_LIBRARY_PATH=$RISCV64/lib64
 	export PATH="$RISCV64/bin:$PATH"
 	# riscv has to use a cross compiler
 	export CC=$RISCV64/bin/riscv64-unknown-linux-gnu-gcc
 	export CXX=$RISCV64/bin/riscv64-unknown-linux-gnu-g++
-	CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-ddr --openjdk-target=riscv64-unknown-linux-gnu --with-sysroot=/opt/fedora28_riscv_root --with-boot-jdk=$JDK_BOOT_DIR --with-build-jdk=$JDK_BOOT_DIR"
+	CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-ddr --openjdk-target=riscv64-unknown-linux-gnu --with-sysroot=/opt/fedora28_riscv_root --with-boot-jdk=$JDK_BOOT_DIR --with-build-jdk=$BUILDJDK"
 	BUILD_ARGS="${BUILD_ARGS} -F"
 fi
 


### PR DESCRIPTION
Use an Openj9 nightly as the "build" (not boot) JDK for the RISC-V cross compilation process.
