### PR TITLE
add 'f' tag to riscv specific config

### DIFF
--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -153,7 +153,7 @@ if [ "${ARCHITECTURE}" == "riscv" ]
 then
 	echo RISCV cross-compilation ... Downloading latest nightly OpenJ9/x64 as build JDK
 	export BUILDJDK=$WORKSPACE/buildjdk
-	rm -r "$BUILDJDK"
+	rm -rf "$BUILDJDK"
 	mkdir "$BUILDJDK"
 	wget -O - "https://api.adoptopenjdk.net/v3/binary/latest/${JAVA_FEATURE_VERSION}/ea/linux/x64/jdk/openj9/normal/adoptopenjdk" | tar xpzf - --strip-components=1 -C "$BUILDJDK"
 	"$BUILDJDK/bin/java" -version 2>&1 | sed 's/^/CROSSBUILD JDK > /g'


### PR DESCRIPTION
ref: https://ci.adoptopenjdk.net/job/build-scripts/job/jobs/job/jdk11u/job/jdk11u-linux-riscv-openj9/12/console

Nightly failed as it was unable to find the `buildjdk` folder - addition of the `f` flag to `rm` will stop it failing if it isn't there.

ping @sxa 