### PR TITLE
If an HTTP download fails in downloadFile, abort rather than fail later

### DIFF
--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -264,9 +264,9 @@ downloadFile() {
   
   # Temporary fudge as curl on my windows boxes is exiting with RC=127
   if [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]]; then
-    wget -O "${targetFileName}" "${url}"
+    wget -O "${targetFileName}" "${url}" || exit 2
   else
-    curl -L -o "${targetFileName}" "${url}"
+    curl --fail -L -o "${targetFileName}" "${url}" || exit 2
   fi
 
   if [ $# -ge 3 ]; then

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -261,7 +261,6 @@ downloadFile() {
   local url="$2"
 
   echo downloadFile: Saving "url" to "$targetFileName"
-
   
   # Temporary fudge as curl on my windows boxes is exiting with RC=127
   if [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]]; then


### PR DESCRIPTION
This is to aid debugging. At the moment if `downloadFile` (in `prepareWorkspace.sh`) failures to download, it continues regardless. This can lead to error messages further down the line which are harder to diagnose.

This will ensure that the script aborts if the download operation with `curl` or `wget` fails.

Note that without `--fail`, curl does not abort on an HTTP/404.

Validating with a bad URL at https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/618/ across platforms to ensure that `--fail` is valid, hence WIP