### PR TITLE
Clean up properly on windows

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -455,7 +455,11 @@ class Build {
         return context.stage("build") {
             if (cleanWorkspace) {
                 try {
-                    context.cleanWs notFailBuild: true
+                    if (buildConfig.TARGET_OS == "windows" && buildConfig.VARIANT == "openj9") {
+                        context.cleanWs notFailBuild: true, disableDeferredWipeout: true, deleteDirs: true
+                    } else {
+                        context.cleanWs notFailBuild: true
+                    }
                 } catch (e) {
                     context.println "Failed to clean ${e}"
                 }


### PR DESCRIPTION
* Asynchronous cleanup does not remove workspace directories
* This is a workaround until [1] is resolved
* [1] https://issues.jenkins-ci.org/browse/JENKINS-53579

Closes: #453 
Signed-off-by: Morgan Davies <morgan.davies@ibm.com>