### PR TITLE
Remove duplicate pigz + debug code from build.sh

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -737,11 +737,6 @@ createOpenJDKTarArchive()
   local testImageTargetPath=$(getTestImageArchivePath)
   local debugImageTargetPath=$(getDebugImageArchivePath)
 
-  COMPRESS=gzip
-
-  if which pigz >/dev/null 2>&1; then COMPRESS=pigz; fi
-  echo "Archiving the build OpenJDK image and compressing with $COMPRESS"
-
   echo "OpenJDK JDK path will be ${jdkTargetPath}. JRE path will be ${jreTargetPath}"
 
   if [ -d "${jreTargetPath}" ]; then


### PR DESCRIPTION
This is resulting in duplicate messages in the log as the pigz setting and information message is duplicated from https://github.com/AdoptOpenJDK/openjdk-build/blob/master/sbin/common/common.sh#L100
```
12:34:48  Archiving the build OpenJDK image and compressing with gzip
12:34:48  OpenJDK JDK path will be jdk-11.0.8+5. JRE path will be jdk-11.0.8+5-jre
12:34:49  Archiving the build OpenJDK image and compressing with gzip
12:35:40  Your final archive was created at /home/jenkins/workspace/build-scripts/jobs/jdk11u/jdk11u-linux-aarch64-hotspot/workspace/build/src/build/linux-aarch64-normal-server-release/images/OpenJDK.tar.gz
```