### PR TITLE
Rename riscv in pipelines to riscv64

### DIFF
--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -149,7 +149,7 @@ then
   export JDK_BOOT_DIR="$(eval echo "\$$BOOT_JDK_VARIABLE")"
 fi
 
-if [ "${ARCHITECTURE}" == "riscv" ]
+if [ "${ARCHITECTURE}" == "riscv64" ]
 then
 	echo RISCV cross-compilation ... Downloading latest nightly OpenJ9/x64 as build JDK
 	export BUILDJDK=$WORKSPACE/buildjdk

--- a/pipelines/jobs/configurations/jdk11_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11_pipeline_config.groovy
@@ -169,7 +169,7 @@ class Config11 {
         riscv64Linux      :  [
                 os                   : 'linux',
                 additionalNodeLabels : 'riscvcross',
-                arch                 : 'riscv',
+                arch                 : 'riscv64',
                 configureArgs        : '--disable-ddr --openjdk-target=riscv64-unknown-linux-gnu --with-sysroot=/opt/fedora28_riscv_root'
         ],
   ]


### PR DESCRIPTION
This should really have been riscv64 from the start as that's what `uname -m` is on the boxes, and it's a 64-bit build. Hopefully these are the only places it needs to be changed :-)

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>