### PR TITLE
Remove java -version from riscv64 instead of riscv

### DIFF
--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -149,7 +149,7 @@ then
   export JDK_BOOT_DIR="$(eval echo "\$$BOOT_JDK_VARIABLE")"
 fi
 
-if [ "${ARCHITECTURE}" == "riscv" ]
+if [ "${ARCHITECTURE}" == "riscv64" ]
 then
 	echo RISCV cross-compilation ... Downloading latest nightly OpenJ9/x64 as build JDK
 	export BUILDJDK=$WORKSPACE/buildjdk

--- a/pipelines/jobs/configurations/jdk11_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11_pipeline_config.groovy
@@ -169,7 +169,7 @@ class Config11 {
         riscv64Linux      :  [
                 os                   : 'linux',
                 additionalNodeLabels : 'riscvcross',
-                arch                 : 'riscv',
+                arch                 : 'riscv64',
                 configureArgs        : '--disable-ddr --openjdk-target=riscv64-unknown-linux-gnu --with-sysroot=/opt/fedora28_riscv_root'
         ],
   ]

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -482,7 +482,7 @@ printJavaVersionString()
 
        echo "Error 'java' does not exist in '$PRODUCT_HOME'."
        exit -1
-     elif [ "${ARCHITECTURE}" == "riscv" ]; then
+     elif [ "${ARCHITECTURE}" == "riscv64" ]; then
        # riscv is cross compiled, so we cannot run it on the build system
        # This is a temporary plausible solution in the absence of another fix
        cat << EOT > "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/version.txt"


### PR DESCRIPTION
Pushing this through as it's a build break. Missed it from the last PR