### PR TITLE
Update shellcheck script to avoid error

### DIFF
--- a/shellcheck.sh
+++ b/shellcheck.sh
@@ -29,7 +29,7 @@ shellcheckCmd="${shellcheckDir}/shellcheck"
 
 install() 
 {
-  wget "https://storage.googleapis.com/shellcheck/shellcheck-${shellcheckVersion}.linux.x86_64.tar.xz"
+  wget "https://github.com/koalaman/shellcheck/releases/download/${shellcheckVersion}/shellcheck-stable.linux.x86_64.tar.xz"
   tar --xz -xvf "shellcheck-${shellcheckVersion}.linux.x86_64.tar.xz"
   rm "shellcheck-${shellcheckVersion}.linux.x86_64.tar.xz"
   "${shellcheckCmd}" --version


### PR DESCRIPTION
```
You are downloading ShellCheck from an outdated URL!
Please update to the new URL:
https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz
For more information, see:
https://github.com/koalaman/shellcheck/issues/1871
```