### PR TITLE
Revert "Update hardcoded JDK next values (#1574)"

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -208,13 +208,8 @@ class Builder implements Serializable {
         if (matcher.matches()) {
             return Integer.parseInt(matcher.group('version'))
         } else if ("jdk".equalsIgnoreCase(javaToBuild.trim())) {
-            String javaFeatureVersion = System.getenv("JAVA_FEATURE_VERSION")
-            if (javaFeatureVersion) {
-                return Integer.valueOf(javaFeatureVersion)
-            } else {
-                context.error("Environment variable JAVA_FEATURE_VERSION not set")
-                throw new Exception()
-            }
+            // This needs to get updated when JDK HEAD version updates
+            return Integer.valueOf("15")
         } else {
             context.error("Failed to read java version '${javaToBuild}'")
             throw new Exception()

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -62,13 +62,8 @@ class Build {
         if (matcher.matches()) {
             return Integer.parseInt(matcher.group('version'))
         } else if ("jdk".equalsIgnoreCase(javaToBuild.trim())) {
-            String javaFeatureVersion = System.getenv("JAVA_FEATURE_VERSION")
-            if (javaFeatureVersion) {
-                return Integer.valueOf(javaFeatureVersion)
-            } else {
-                context.error("Environment variable JAVA_FEATURE_VERSION not set")
-                throw new Exception()
-            }
+            // This needs to get updated when JDK HEAD version updates
+            return Integer.valueOf("15")
         } else {
             context.error("Failed to read java version '${javaToBuild}'")
             throw new Exception()


### PR DESCRIPTION
This reverts https://github.com/AdoptOpenJDK/openjdk-build/pull/1574 as it causes a build break on jdk-next (see https://github.com/AdoptOpenJDK/openjdk-build/issues/1820)