### PR TITLE
Query the adopt api to get the JDK-Head version

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -210,10 +210,10 @@ class Builder implements Serializable {
         } else if ("jdk".equalsIgnoreCase(javaToBuild.trim())) {
             // Query the Adopt api to get the "most_recent_feature_release" (currently 15)
             def JobHelper = context.library(identifier: 'openjdk-jenkins-helper@master').JobHelper
-            context.println "Querying Adopt Api for the JDK-Head number (most_recent_feature_version)..."
+            context.println "Querying Adopt Api for the JDK-Head number (most_recent_feature_release)..."
 
             response = JobHelper.getAvailableReleases()
-            Integer headVersion = Integer.valueOf(response.most_recent_feature_version)
+            Integer headVersion = Integer.valueOf(response.most_recent_feature_release)
             if (headVersion.equalsIgnoreCase(null)) {
                 context.println "Failure on api connection or parsing."
                 throw new Exception()

--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -1,6 +1,6 @@
 @Library('local-lib@master')
 import common.IndividualBuildConfig
-import groovy.json.JsonSlurper
+import groovy.json.*
 
 import java.util.regex.Matcher
 
@@ -208,13 +208,18 @@ class Builder implements Serializable {
         if (matcher.matches()) {
             return Integer.parseInt(matcher.group('version'))
         } else if ("jdk".equalsIgnoreCase(javaToBuild.trim())) {
-            String javaFeatureVersion = System.getenv("JAVA_FEATURE_VERSION")
-            if (javaFeatureVersion) {
-                return Integer.valueOf(javaFeatureVersion)
-            } else {
-                context.error("Environment variable JAVA_FEATURE_VERSION not set")
+            // Query the Adopt api to get the "most_recent_feature_release" (currently 15)
+            def JobHelper = context.library(identifier: 'openjdk-jenkins-helper@master').JobHelper
+            context.println "Querying Adopt Api for the JDK-Head number (most_recent_feature_version)..."
+
+            response = JobHelper.getAvailableReleases()
+            Integer headVersion = Integer.valueOf(response.most_recent_feature_version)
+            if (headVersion.equalsIgnoreCase(null)) {
+                context.println "Failure on api connection or parsing."
                 throw new Exception()
             }
+            context.println "Found Java Version Number: ${headVersion}"
+            return headVersion
         } else {
             context.error("Failed to read java version '${javaToBuild}'")
             throw new Exception()

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -64,10 +64,10 @@ class Build {
         } else if ("jdk".equalsIgnoreCase(javaToBuild.trim())) {
             // Query the Adopt api to get the "most_recent_feature_release" (currently 15)
             def JobHelper = context.library(identifier: 'openjdk-jenkins-helper@master').JobHelper
-            context.println "Querying Adopt Api for the JDK-Head number (most_recent_feature_version)..."
+            context.println "Querying Adopt Api for the JDK-Head number (most_recent_feature_release)..."
 
             response = JobHelper.getAvailableReleases()
-            Integer headVersion = Integer.valueOf(response.most_recent_feature_version)
+            Integer headVersion = Integer.valueOf(response.most_recent_feature_release)
             if (headVersion.equalsIgnoreCase(null)) {
                 context.println "Failure on api connection or parsing."
                 throw new Exception()


### PR DESCRIPTION
Uses the info/available_releases/ endpoint to obtain the JDK-HEAD version number

Closes: #1820 
Signed-off-by: Morgan Davies <morgan.davies@ibm.com>