### PR TITLE
Gradle: Update Gradle to the latest version (6.5)

### DIFF
--- a/pipelines/gradle/wrapper/gradle-wrapper.properties
+++ b/pipelines/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Discussion from : https://adoptopenjdk.slack.com/archives/C09NW3L2J/p1591349831452800?thread_ts=1590055621.250700&cid=C09NW3L2J

This is due to the issue with the latest JDK11 not being able to run the current version of Gradle (`5.2.1`), on Windows. It was determined that the previous version of Gradle wasn't necessarily pinned for any particular reason, it was just the latest version at the time it was added to the build-scripts. 
I've tested on a local Windows VM with `jdk8u252-b09` and `jdk-11.0.7+10` and they both worked.

ping @karianna @sxa 