### PR TITLE
prepareWorkspace: fix `REPOSITORY` does not end with `.git`

### DIFF
--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -49,7 +49,7 @@ checkoutAndCloneOpenJDKGitRepo() {
     set +e
     git --git-dir "${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/.git" remote -v
     echo "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}"
-    git --git-dir "${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/.git" remote -v | grep "origin.*fetch" | grep "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" | grep "${BUILD_CONFIG[REPOSITORY]}.git"
+    git --git-dir "${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/.git" remote -v | grep "origin.*fetch" | grep "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" | grep "${BUILD_CONFIG[REPOSITORY]}"
     local isValidGitRepo=$?
     set -e
 


### PR DESCRIPTION
This PR is trying to fixed an issue introduced by:

`https://github.com/AdoptOpenJDK/openjdk-build/pull/1813`

Before this change:
`echo "origin  https://ms-juniper@dev.azure.com/ms-juniper/Juniper/_git/shenandoah-jdk11 (fetch)" | grep "https://ms-juniper@dev.azure.com/ms-juniper/Juniper/_git/shenandoah-jdk11.git"` will return nothing

After this change:
`echo "origin  https://ms-juniper@dev.azure.com/ms-juniper/Juniper/_git/shenandoah-jdk11 (fetch)" | grep "https://ms-juniper@dev.azure.com/ms-juniper/Juniper/_git/shenandoah-jdk11"` It will return the correct information.

Validated by running those 3 variants: 

`echo "origin  https://ms-juniper@dev.azure.com/ms-juniper/Juniper/_git/shenandoah-jdk11 (fetch)" | grep "https://ms-juniper@dev.azure.com/ms-juniper/Juniper/_git/shenandoah-jdk11"`

`echo "origin  https://github.com/adoptopenjdk/openjdk-jdk11u.git (fetch)" | grep "https://github.com/adoptopenjdk/openjdk-jdk11u.git"`

`echo "origin  https://github.com/adoptopenjdk/openjdk-jdk11u (fetch)" | grep "https://github.com/adoptopenjdk/openjdk-jdk11u"`