### PR TITLE
Disable cmd line shell exit for gradle re-try logic

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -438,7 +438,8 @@ buildSharedLibs() {
     local gradleJavaHome=$(getGradleHome)
     echo "Running gradle with $gradleJavaHome"
 
-
+    # Disable cmd line failure shell exit    
+    set +e
     gradlecount=1
     rc=1
     while [[ $rc -ne 0 && $gradlecount -le 3 ]]
@@ -448,6 +449,8 @@ buildSharedLibs() {
         echo "gradle attempt $gradlecount : rc=$rc "
         gradlecount=$(( gradlecount + 1 ))
     done
+    # Re-enable cmd line failure shell exit
+    set -e
 
     # Test that the parser can execute as fail fast rather than waiting till after the build to find out
     "$gradleJavaHome"/bin/java -version 2>&1 | "$gradleJavaHome"/bin/java -cp "target/libs/adopt-shared-lib.jar" ParseVersion -s -f semver 1


### PR DESCRIPTION
Overnight build failure demonstrated set -e shell exit not disabled around gradlew retry logic:
https://ci.adoptopenjdk.net/view/Failing%20Builds/job/build-scripts/job/jobs/job/jdk11u/job/jdk11u-linux-aarch64-openj9/366/console

This PR adds set +e around the gradle retry

Signed-off-by: andrew-m-leonard <andrew_m_leonard@uk.ibm.com>