### PR TITLE
Ensure jdk(next) prepareWorkspace validates cache correctly

### DIFF
--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -49,7 +49,11 @@ checkoutAndCloneOpenJDKGitRepo() {
     set +e
     git --git-dir "${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/.git" remote -v
     echo "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}"
-    git --git-dir "${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/.git" remote -v | grep "origin.*fetch" | grep "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" | grep "${BUILD_CONFIG[REPOSITORY]}.git\|${BUILD_CONFIG[REPOSITORY]}"
+    # Ensure cached origin fetch remote repo is correct version and repo (eg.jdk11u, or jdk), remember "jdk" sub-string of jdk11u hence grep with "\s"
+    # eg. origin https://github.com/adoptopenjdk/openjdk-jdk11u (fetch)
+    # eg. origin https://github.com/adoptopenjdk/openjdk-jdk (fetch)
+    # eg. origin git@github.com:adoptopenjdk/openjdk-jdk.git (fetch)
+    git --git-dir "${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/.git" remote -v | grep "origin.*fetch" | grep "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" | grep "${BUILD_CONFIG[REPOSITORY]}.git\|${BUILD_CONFIG[REPOSITORY]}\s"
     local isValidGitRepo=$?
     set -e
 


### PR DESCRIPTION
The prepareWorkspace.sh check for the git remote (fetch) url was not allowing for the fact that "jdk"(next) version repository string is a sub-string of jdk11u...
Added a "\s"(whitespace) match to REPOSITORY grep.
and a comment to explain!!

Verified fix here: https://ci.adoptopenjdk.net/view/work%20in%20progress/job/andrew-jdk14u-linux-x64-openj9/14/console

Signed-off-by: andrew-m-leonard <andrew_m_leonard@uk.ibm.com>