### PR TITLE
Gradle slow retry

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -441,6 +441,7 @@ buildSharedLibs() {
     gradlecount=1
     while ! JAVA_HOME="$gradleJavaHome" GRADLE_USER_HOME=./gradle-cache bash ./gradlew --no-daemon clean uberjar; do
       echo "RETRYWARNING: Gradle failed on attempt $gradlecount"
+      sleep 120 # Wait before retrying in case of network/server outage ...
       gradlecount=$(( gradlecount + 1 ))
       [ $gradlecount -gt 3 ] && exit 1
     done

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -445,11 +445,6 @@ buildSharedLibs() {
       [ $gradlecount -gt 3 ] && exit 1
     done
 
-    if [ $rc -ne 0 ]; then
-        echo "gradle failed to create uberjar"
-        exit $rc
-    fi 
-
     # Test that the parser can execute as fail fast rather than waiting till after the build to find out
     "$gradleJavaHome"/bin/java -version 2>&1 | "$gradleJavaHome"/bin/java -cp "target/libs/adopt-shared-lib.jar" ParseVersion -s -f semver 1
 }


### PR DESCRIPTION
One of the builds last night failed after three attempts. Putting this delay in will avoid any problems if it really is with the connection to the server and it's very temporary.