### PR TITLE
revert to last good copyArtifact filter

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -311,7 +311,7 @@ class Build {
         context.copyArtifacts(
                 projectName: "build-scripts/release/create_installer_windows",
                 selector: context.specific("${installerJob.getNumber()}"),
-                filter: 'wix/ReleaseDir/OpenJDK*jdk_*_windows*.msi',
+                filter: 'wix/ReleaseDir/*',
                 fingerprintArtifacts: true,
                 target: "workspace/target/",
                 flatten: true)
@@ -342,7 +342,7 @@ class Build {
                 context.copyArtifacts(
                     projectName: "build-scripts/release/create_installer_windows",
                     selector: context.specific("${jreinstallerJob.getNumber()}"),
-                    filter: 'wix/ReleaseDir/OpenJDK*jre_*_windows*.msi',
+                    filter: 'wix/ReleaseDir/*',
                     fingerprintArtifacts: true,
                     target: "workspace/target/",
                     flatten: true


### PR DESCRIPTION
related to multiple failure #1834

This is the last filter which work without issue before splitting jre/jdk into two installer job.
This filter is less selective.
If error continue we can know for sure this is not related to this filter.
If this filter is not enough precise we can copy more artefact than needed .. but I don't think so