### PR TITLE
Switch JDK15 Linux/x64 builds to CentOS7/RHEL7

### DIFF
--- a/pipelines/jobs/configurations/jdk15_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk15_pipeline_config.groovy
@@ -14,7 +14,7 @@ class Config15 {
         x64Linux  : [
                 os                  : 'linux',
                 arch                : 'x64',
-                additionalNodeLabels: 'centos6',
+                additionalNodeLabels: 'rhel7',
                 test                : [
                         nightly: false,
                         release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external', 'special.functional']


### PR DESCRIPTION
Part of https://github.com/AdoptOpenJDK/openjdk-build/issues/1819 - seems reasonable to switch the latest version over first... This will obviously affect minimum OS levels (although it will bring them in line with Linux on other architectures).

I have a GoDaddy RHEL7 box earmarked for build that's been used for some other jobs that can be used for this.

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>