### PR TITLE
Verbose curl to retrieve latest API version

### DIFF
--- a/build-farm/make-adopt-build-farm.sh
+++ b/build-farm/make-adopt-build-farm.sh
@@ -30,7 +30,7 @@ if [ -z "${JAVA_FEATURE_VERSION}" ]
 then
   # Use Adopt API to get the JDK Head number
   echo "This appears to be JDK Head. Querying the Adopt API to get the JDK HEAD Number (https://api.adoptopenjdk.net/v3/info/available_releases)..."
-  JAVA_FEATURE_VERSION=$(curl https://api.adoptopenjdk.net/v3/info/available_releases | awk '/tip_version/{print$2}')
+  JAVA_FEATURE_VERSION=$(curl -v https://api.adoptopenjdk.net/v3/info/available_releases | awk '/tip_version/{print$2}')
     
   # Checks the api request was successfull and the return value is a number
   if [ -z "${JAVA_FEATURE_VERSION}" ] || ! [[ "${JAVA_FEATURE_VERSION}" -gt 0 ]]

--- a/sbin/common/common.sh
+++ b/sbin/common/common.sh
@@ -38,7 +38,7 @@ function setOpenJdkVersion() {
   then
     # Use Adopt API to get the JDK Head number
     echo "This appears to be JDK Head. Querying the Adopt API to get the JDK HEAD Number (https://api.adoptopenjdk.net/v3/info/available_releases)..."
-    local featureNumber=$(curl https://api.adoptopenjdk.net/v3/info/available_releases | awk '/tip_version/{print$2}')
+    local featureNumber=$(curl -v https://api.adoptopenjdk.net/v3/info/available_releases | awk '/tip_version/{print$2}')
     
     # Checks the api request was successfull and the return value is a number
     if [ -z "${featureNumber}" ] || ! [[ "${featureNumber}" -gt 0 ]]


### PR DESCRIPTION
This may only be required temporarily in order to debug the issue described in https://github.com/AdoptOpenJDK/openjdk-build/issues/1873 but we need to see the headers of the operation we're storing the result from and not the retry.

As far as I can tell `-v` does not impact the capturing of the stdout of the operation.

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>