### PR TITLE
Add retry logic to script based api queries

### DIFF
--- a/build-farm/make-adopt-build-farm.sh
+++ b/build-farm/make-adopt-build-farm.sh
@@ -28,18 +28,32 @@ JAVA_FEATURE_VERSION=$(echo "${JAVA_TO_BUILD}" | tr -d "[:alpha:]")
 
 if [ -z "${JAVA_FEATURE_VERSION}" ]
 then
-  # Use Adopt API to get the JDK Head number
-  echo "This appears to be JDK Head. Querying the Adopt API to get the JDK HEAD Number (https://api.adoptopenjdk.net/v3/info/available_releases)..."
-  JAVA_FEATURE_VERSION=$(curl https://api.adoptopenjdk.net/v3/info/available_releases | awk '/tip_version/{print$2}')
-    
-  # Checks the api request was successfull and the return value is a number
-  if [ -z "${JAVA_FEATURE_VERSION}" ] || ! [[ "${JAVA_FEATURE_VERSION}" -gt 0 ]]
-  then
-    echo "Failed to query or parse the adopt api. Dumping headers via curl -v https://api.adoptopenjdk.net/v3/info/available_releases..."
-    curl -v https://api.adoptopenjdk.net/v3/info/available_releases
-    exit 1
-  fi
-  echo "JAVA_FEATURE_VERSION is ${JAVA_FEATURE_VERSION}"
+    retryCount=1
+    retryMax=5
+    until [ "$retryCount" -ge "$retryMax" ]
+    do
+        # Use Adopt API to get the JDK Head number
+        echo "This appears to be JDK Head. Querying the Adopt API to get the JDK HEAD Number (https://api.adoptopenjdk.net/v3/info/available_releases)..."
+        JAVA_FEATURE_VERSION=$(curl https://api.adoptopenjdk.net/v3/info/available_releases | awk '/tip_version/{print$2}')
+        
+        # Checks the api request was successful and the return value is a number
+        if [ -z "${JAVA_FEATURE_VERSION}" ] || ! [[ "${JAVA_FEATURE_VERSION}" -gt 0 ]]
+        then
+            echo "RETRYWARNING: Query ${retryCount} failed. Retrying in 30 seconds (max retries = ${retryMax})..."
+            retryCount=$((retryCount+1)) 
+            sleep 30000
+        else
+            echo "JAVA_FEATURE_VERSION FOUND: ${JAVA_FEATURE_VERSION}" && break
+        fi
+    done
+
+    # Fail build if we still can't find the head number
+    if [ -z "${JAVA_FEATURE_VERSION}" ] || ! [[ "${JAVA_FEATURE_VERSION}" -gt 0 ]]
+    then
+        echo "Failed ${retryCount} times to query or parse the adopt api. Dumping headers via curl -v https://api.adoptopenjdk.net/v3/info/available_releases and exiting..."
+        curl -v https://api.adoptopenjdk.net/v3/info/available_releases
+        exit 1
+    fi
 fi
 
 echo "BUILD TYPE: "

--- a/sbin/common/common.sh
+++ b/sbin/common/common.sh
@@ -36,18 +36,32 @@ function setOpenJdkVersion() {
 
   if [ -z "${featureNumber}" ]
   then
-    # Use Adopt API to get the JDK Head number
-    echo "This appears to be JDK Head. Querying the Adopt API to get the JDK HEAD Number (https://api.adoptopenjdk.net/v3/info/available_releases)..."
-    local featureNumber=$(curl https://api.adoptopenjdk.net/v3/info/available_releases | awk '/tip_version/{print$2}')
-    
-    # Checks the api request was successfull and the return value is a number
+    retryCount=1
+    retryMax=5
+    until [ "$retryCount" -ge "$retryMax" ]
+    do
+        # Use Adopt API to get the JDK Head number
+        echo "This appears to be JDK Head. Querying the Adopt API to get the JDK HEAD Number (https://api.adoptopenjdk.net/v3/info/available_releases)..."
+        local featureNumber=$(curl https://api.adoptopenjdk.net/v3/info/available_releases | awk '/tip_version/{print$2}')
+        
+        # Checks the api request was successful and the return value is a number
+        if [ -z "${featureNumber}" ] || ! [[ "${featureNumber}" -gt 0 ]]
+        then
+            echo "RETRYWARNING: Query ${retryCount} failed. Retrying in 30 seconds (max retries = ${retryMax})..."
+            retryCount=$((retryCount+1)) 
+            sleep 30000
+        else
+            echo "featureNumber FOUND: ${featureNumber}" && break
+        fi
+    done
+
+    # Fail build if we still can't find the head number
     if [ -z "${featureNumber}" ] || ! [[ "${featureNumber}" -gt 0 ]]
     then
-        echo "Failed to query or parse the adopt api. Dumping headers via curl -v https://api.adoptopenjdk.net/v3/info/available_releases..."
+        echo "Failed ${retryCount} times to query or parse the adopt api. Dumping headers via curl -v https://api.adoptopenjdk.net/v3/info/available_releases and exiting..."
         curl -v https://api.adoptopenjdk.net/v3/info/available_releases
         exit 1
     fi
-    echo "featureNumber is $featureNumber"
   fi
 
   # feature number e.g. 11


### PR DESCRIPTION
* Adds retry logic to the script based api calls (groovy ones will be updated in the jenkins helper) to try and pull info from the api 5 times before breaking and failing the build

Inspired by recent instability seen in #1873 
Signed-off-by: Morgan Davies <morgan.davies@ibm.com>