### PR TITLE
Use OpenJ9 boot jdk for JDK15+ J9 builds

### DIFF
--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -98,6 +98,10 @@ if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
         echo "Downloading GA release of boot JDK version ${BOOT_JDK_VERSION}..."
         releaseType="ga"
         apiUrlTemplate="https://api.adoptopenjdk.net/v3/binary/latest/\${BOOT_JDK_VERSION}/\${releaseType}/linux/\${ARCHITECTURE}/jdk/hotspot/normal/adoptopenjdk"
+        # Add in a specific case for JDK15+ OpenJ9 builds due to openjdk-build#1890
+        if [ "$JAVA_FEATURE_VERSION" -ge 15 ] && [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]; then
+            apiUrlTemplate="https://api.adoptopenjdk.net/v3/binary/latest/\${BOOT_JDK_VERSION}/\${releaseType}/linux/\${ARCHITECTURE}/jdk/openj9/normal/adoptopenjdk"
+        fi
         apiURL=$(eval echo ${apiUrlTemplate})
         # make-adopt-build-farm.sh has 'set -e'. We need to disable that
         # for the fallback mechanism, as downloading of the GA binary might

--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -78,6 +78,10 @@ if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
         echo "Downloading GA release of boot JDK version ${BOOT_JDK_VERSION}..."
         releaseType="ga"
         apiUrlTemplate="https://api.adoptopenjdk.net/v3/binary/latest/\${BOOT_JDK_VERSION}/\${releaseType}/mac/\${ARCHITECTURE}/jdk/hotspot/normal/adoptopenjdk"
+        # Add in a specific case for JDK15+ OpenJ9 builds due to openjdk-build#1890
+        if [ "$JAVA_FEATURE_VERSION" -ge 15 ] && [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]; then
+            apiUrlTemplate="https://api.adoptopenjdk.net/v3/binary/latest/\${BOOT_JDK_VERSION}/\${releaseType}/mac/\${ARCHITECTURE}/jdk/openj9/normal/adoptopenjdk"
+        fi
         apiURL=$(eval echo ${apiUrlTemplate})
         # make-adopt-build-farm.sh has 'set -e'. We need to disable that
         # for the fallback mechanism, as downloading of the GA binary might

--- a/build-farm/platform-specific-configurations/windows.sh
+++ b/build-farm/platform-specific-configurations/windows.sh
@@ -43,6 +43,10 @@ if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
           *) downloadArch="$ARCHITECTURE";;
         esac
         apiUrlTemplate="https://api.adoptopenjdk.net/v3/binary/latest/\${BOOT_JDK_VERSION}/\${releaseType}/windows/\${downloadArch}/jdk/hotspot/normal/adoptopenjdk"
+        # Add in a specific case for JDK15+ OpenJ9 builds due to openjdk-build#1890
+        if [ "$JAVA_FEATURE_VERSION" -ge 15 ] && [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]; then
+            apiUrlTemplate="https://api.adoptopenjdk.net/v3/binary/latest/\${BOOT_JDK_VERSION}/\${releaseType}/windows/\${downloadArch}/jdk/openj9/normal/adoptopenjdk"
+        fi
         apiURL=$(eval echo ${apiUrlTemplate})
         # make-adopt-build-farm.sh has 'set -e'. We need to disable that
         # for the fallback mechanism, as downloading of the GA binary might


### PR DESCRIPTION
* Aix already uses OpenJ9 boot jdk's

Closes: #1890 
Signed-off-by: Morgan Davies <morgan.davies@ibm.com>