### PR TITLE
docker: Refer to dockerfile-generator correctly in docker-build

### DIFF
--- a/docker-build.sh
+++ b/docker-build.sh
@@ -83,7 +83,7 @@ buildOpenJDKViaDocker()
     build_variant_flag="--openj9"
   fi
 
-  docker/dockerfile_generator.sh --jdk "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" --path "${BUILD_CONFIG[DOCKER_FILE_PATH]}" "$build_variant_flag"
+  docker/dockerfile-generator.sh --jdk "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" --path "${BUILD_CONFIG[DOCKER_FILE_PATH]}" "$build_variant_flag"
   # shellcheck disable=SC1090
   source "${BUILD_CONFIG[DOCKER_FILE_PATH]}/dockerConfiguration.sh"
 


### PR DESCRIPTION
Fixes: #1909 

I renamed `dockerfile_generator.sh` to `dockerfile-generator.sh` and forgot to update `docker-build.sh` afterwards.

Signed off by: William Parker william.parker1@ibm.com