### PR TITLE
Add java version and configure to VersionInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,24 +316,29 @@ from, but you can override this with the `-r` flag.
 Alongside the built assets a metadata file will be created with info about the build. This will be a JSON document of the form:
 
 ```
-    {
-        "WARNING": "THIS METADATA FILE IS STILL IN ALPHA DO NOT USE ME",
-        "os": "linux",
-        "arch": "x64",
-        "variant": "hotspot",
-        "version": "jdk8u",
-        "tag": "jdk8u202-b08",
-        {
-            "adopt_build_number": 2,
-            "major": 8,
-            "minor": 0,
-            "security": 202,
-            "build": 8,
-            "version": "8u202-b08",
-            "semver": "8.0.202+8.2",
-        },
-        "binary_type": "jdk"
-    }
+{
+    "WARNING": "THIS METADATA FILE IS STILL IN ALPHA DO NOT USE ME",
+    "os": "mac",
+    "arch": "x64",
+    "variant": "hotspot",
+    "version": {
+        "minor": 0,
+        "full_version_output": "<output of java --version>",
+        "security": 0,
+        "pre": null,
+        "adopt_build_number": 0,
+        "major": 15,
+        "version": "15+28-202006220910",
+        "semver": "15.0.0+28.0.202006220910",
+        "build": 28,
+        "opt": "202006220910",
+        "configure_arguments": <output of bash configure>
+    },
+    "scmRef": "",
+    "version_data": "jdk15",
+    "binary_type": "jdk",
+    "sha256": "<shasum>"
+}
 ```
 
 It is worth noting the additional tags on the semver is the adopt build number.

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -158,7 +158,7 @@ class Build {
             String versionOutput = matcher.group('version')
             context.println(versionOutput)
 
-            return new VersionInfo().parse(versionOutput, buildConfig.ADOPT_BUILD_NUMBER)
+            return new VersionInfo().parse(consoleOut, versionOutput, buildConfig.ADOPT_BUILD_NUMBER)
         }
         return null
     }
@@ -400,27 +400,31 @@ class Build {
 
     def writeMetadata(VersionInfo version) {
         /*
-    example data:
-    {
-        "WARNING": "THIS METADATA FILE IS STILL IN ALPHA DO NOT USE ME",
-        "os": "linux",
-        "arch": "x64",
-        "variant": "hotspot",
-        "version": "jdk8u",
-        "tag": "jdk8u202-b08",
-        "version_data": {
-            "adopt_build_number": 2,
-            "major": 8,
-            "minor": 0,
-            "security": 202,
-            "build": 8,
-            "version": "8u202-b08",
-            "semver": "8.0.202+8.2"
-        },
-        "binary_type": "jdk",
-        "sha256": "c1b8fb7298d66a5bca9b830e8d612a85bbc52c81b9a88cef4dd71f2f37b289f1"
-    }
-    */
+        example data:
+            {
+                "WARNING": "THIS METADATA FILE IS STILL IN ALPHA DO NOT USE ME",
+                "os": "mac",
+                "arch": "x64",
+                "variant": "hotspot",
+                "version": {
+                    "minor": 0,
+                    "full_version_output": "<output of java --version>",
+                    "security": 0,
+                    "pre": null,
+                    "adopt_build_number": 0,
+                    "major": 15,
+                    "version": "15+28-202006220910",
+                    "semver": "15.0.0+28.0.202006220910",
+                    "build": 28,
+                    "opt": "202006220910",
+                    "configure_arguments": <output of bash configure>
+                },
+                "scmRef": "",
+                "version_data": "jdk15",
+                "binary_type": "jdk",
+                "sha256": "<shasum>"
+            }
+        */
 
         MetaData data = formMetadata(version)
 
@@ -526,6 +530,8 @@ class Build {
                     String versionOut = context.readFile("workspace/target/version.txt")
 
                     versionInfo = parseVersionOutput(versionOut)
+
+                    versionInfo.configure_arguments = context.readFile("workspace/target/configure.txt")
                 }
                 writeMetadata(versionInfo)
                 context.archiveArtifacts artifacts: "workspace/target/*"

--- a/pipelines/library/src/ParseVersion.groovy
+++ b/pipelines/library/src/ParseVersion.groovy
@@ -15,7 +15,7 @@ class ParseVersion {
         } else {
             def versionString = args[args.length - 2]
             def adoptBuildNumber = args[args.length - 1]
-            version = new VersionInfo().parse(versionString, adoptBuildNumber)
+            version = new VersionInfo().parse(null, versionString, adoptBuildNumber)
         }
 
         printVersion(parsedArgs, version)
@@ -42,7 +42,7 @@ class ParseVersion {
         while ((line = reader.readLine()) != null) {
             Matcher matcher = (line =~ /.*\(build (?<version>.*)\).*/)
             if (matcher.matches()) {
-                VersionInfo version = new VersionInfo().parse(matcher.group("version"), args[args.length - 1])
+                VersionInfo version = new VersionInfo().parse(null, matcher.group("version"), args[args.length - 1])
                 return version
             }
         }

--- a/pipelines/library/src/common/VersionInfo.groovy
+++ b/pipelines/library/src/common/VersionInfo.groovy
@@ -7,6 +7,8 @@ class VersionInfo {
     Integer minor // 0
     Integer security // 181
     Integer build // 8
+    String full_version_output
+    String configure_arguments
     String opt
     String version
     String pre
@@ -16,7 +18,13 @@ class VersionInfo {
     VersionInfo() {
     }
 
-    VersionInfo parse(String PUBLISH_NAME, String ADOPT_BUILD_NUMBER) {
+    VersionInfo parse(String FULL_VERSION, String PUBLISH_NAME, String ADOPT_BUILD_NUMBER) {
+
+        if (FULL_VERSION != null && FULL_VERSION != "") {
+            full_version_output = FULL_VERSION
+        } else {
+            full_version_output = null
+        }
 
         if (PUBLISH_NAME != null) {
             if (!matchPre223(PUBLISH_NAME)) {

--- a/pipelines/src/test/groovy/VersionInfoTest.groovy
+++ b/pipelines/src/test/groovy/VersionInfoTest.groovy
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test
 class VersionInfoTest {
     @Test
     void doesNotDefaultAdoptNumber() {
-        VersionInfo parsed = new VersionInfo().parse("11.0.2+10", null)
+        VersionInfo parsed = new VersionInfo().parse(null, "11.0.2+10", null)
         Assertions.assertEquals(11, parsed.major)
         Assertions.assertEquals(0, parsed.minor)
         Assertions.assertEquals(2, parsed.security)
@@ -19,7 +19,7 @@ class VersionInfoTest {
 
     @Test
     void addsZeroAdoptBuildWhenThereIsAnOpt() {
-        VersionInfo parsed = new VersionInfo().parse("11.0.2+10-ea", null)
+        VersionInfo parsed = new VersionInfo().parse(null, "11.0.2+10-ea", null)
         Assertions.assertEquals(11, parsed.major)
         Assertions.assertEquals(0, parsed.minor)
         Assertions.assertEquals(2, parsed.security)
@@ -33,7 +33,7 @@ class VersionInfoTest {
 
     @Test
     void addsAdoptBuildNum() {
-        VersionInfo parsed = new VersionInfo().parse("11.0.2+10", "2")
+        VersionInfo parsed = new VersionInfo().parse(null, "11.0.2+10", "2")
         Assertions.assertEquals(11, parsed.major)
         Assertions.assertEquals(0, parsed.minor)
         Assertions.assertEquals(2, parsed.security)
@@ -43,6 +43,40 @@ class VersionInfoTest {
         Assertions.assertNull(parsed.pre)
         Assertions.assertEquals(2, parsed.adopt_build_number)
         Assertions.assertEquals("11.0.2+10.2", parsed.semver)
+    }
+
+    def versionOut = """openjdk version "11.0.2" 2018-10-16
+OpenJDK Runtime Environment AdoptOpenJDK (build 11.0.2+7)
+OpenJDK 64-Bit Server VM AdoptOpenJDK (build 11.0.2+7, mixed mode)"""
+
+    @Test
+    void addsFullVersionOutput() {
+        VersionInfo parsed = new VersionInfo().parse(versionOut, "11.0.2+7")
+        Assertions.assertEquals(11, parsed.major)
+        Assertions.assertEquals(0, parsed.minor)
+        Assertions.assertEquals(2, parsed.security)
+        Assertions.assertEquals(7, parsed.build)
+        Assertions.assertEquals(versionOut, parsed.full_version_output)
+        Assertions.assertNull(parsed.opt)
+        Assertions.assertEquals("11.0.2+7", parsed.version)
+        Assertions.assertNull(parsed.pre)
+        Assertions.assertNull(parsed.adopt_build_number)
+        Assertions.assertEquals("11.0.2+7", parsed.semver)
+    }
+
+    @Test
+    void addsNullWhenNoFullVersionOutput() {
+        VersionInfo parsed = new VersionInfo().parse(null, "11.0.2+7")
+        Assertions.assertEquals(11, parsed.major)
+        Assertions.assertEquals(0, parsed.minor)
+        Assertions.assertEquals(2, parsed.security)
+        Assertions.assertEquals(7, parsed.build)
+        Assertions.assertNull(parsed.full_version_output)
+        Assertions.assertNull(parsed.opt)
+        Assertions.assertEquals("11.0.2+7", parsed.version)
+        Assertions.assertNull(parsed.pre)
+        Assertions.assertNull(parsed.adopt_build_number)
+        Assertions.assertEquals("11.0.2+7", parsed.semver)
     }
 
 }

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -399,7 +399,9 @@ executeTemplatedFile() {
   stepIntoTheWorkingDirectory
 
   echo "Currently at '${PWD}'"
-  bash "${BUILD_CONFIG[WORKSPACE_DIR]}/config/configure-and-build.sh"
+
+  # Execute the build passing the workspace dir and target dir as params for configure.txt
+  bash "${BUILD_CONFIG[WORKSPACE_DIR]}/config/configure-and-build.sh" ${BUILD_CONFIG[WORKSPACE_DIR]} ${BUILD_CONFIG[TARGET_DIR]}
   exitCode=$?
 
   if [ "${exitCode}" -eq 1 ]; then

--- a/sbin/build.template
+++ b/sbin/build.template
@@ -31,7 +31,7 @@ if [[ ! -z "$alreadyConfigured" ]] ; then
 else
   #Templated var that, gets replaced by build.sh
   # shellcheck disable=SC1073,SC1054,SC1083
-  {configureArg}
+  {configureArg} | tee "$1/$2/configure.txt"
 
   exitCode=$?
   if [ "${exitCode}" -ne 0 ]; then


### PR DESCRIPTION
* Adds the output of java --version and bash configure to VersionInfo
* Adds version tests to account for the changes
* Documentation updates

Closes: #11 
Closes: #367 
Signed-off-by: Morgan Davies <morgan.davies@ibm.com>