### PR TITLE
Dump stack trace on build failure

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -604,8 +604,7 @@ class Build {
 
                 } catch (Exception e) {
                     currentBuild.result = 'FAILURE'
-                    context.println "Execution error: ${e}"
-                    throw e
+                    context.println "Execution error: " + e.printStackTrace()
                 }
             }
         }


### PR DESCRIPTION
* To debug https://github.com/AdoptOpenJDK/openjdk-build/issues/1834 (and potentially https://github.com/AdoptOpenJDK/openjdk-build/issues/1878). 
* Far from ideal but we're running short of options.