### PR TITLE
docker: Ensure cleanRep var is bound in dockerfile-generator.sh

### DIFF
--- a/docker/dockerfile-generator.sh
+++ b/docker/dockerfile-generator.sh
@@ -28,7 +28,7 @@ setJDKVars() {
 
 processArgs() {
   local arg
-  local cleanRepo
+  local cleanRepo=false
   while [[ $# -gt 0 ]]
   do	
     arg="$1"


### PR DESCRIPTION
ref: https://ci.adoptopenjdk.net/job/DockerfileCheck/151/label=docker-aws-ubuntu1604-x64-1,variant=j9,version=jdk8u/

Unfortunately this was missed as part of #1912, as the issue doesn't occur on `macOS`, the machine this was tested on.
The variable has to have a value assigned to it before it is compared in an `if` statement on linux, otherwise the following error message occurs:
```
docker/dockerfile-generator.sh: line 91: cleanRepo: unbound variable
```
ping @sxa 