### PR TITLE
Set JAVA_HOME to --jdk-boot-dir

### DIFF
--- a/configureBuild.sh
+++ b/configureBuild.sh
@@ -61,6 +61,11 @@ parseCommandLineArgs() {
     setOpenJdkVersion "$1"
     setDockerVolumeSuffix "$1"
   fi
+
+  # This check is to set the JAVA_HOME to the --jdk-boot-dir parameter (if both the param exists and JAVA_HOME doesn't)
+  if [ -d "${BUILD_CONFIG[JDK_BOOT_DIR]}" ] && [ -n "${JAVA_HOME:+x}" ]; then
+    export JAVA_HOME="${BUILD_CONFIG[JDK_BOOT_DIR]}"
+  fi
 }
 
 # Extra config for OpenJDK variants such as OpenJ9, SAP et al


### PR DESCRIPTION
* If both --jdk-boot-dir exists and JAVA_HOME doesn't

Closes: #1308 
Signed-off-by: Morgan Davies <morgan.davies@ibm.com>