### PR TITLE
docker: Put in missing backslash to dockerfile-generator.sh

### DIFF
--- a/docker/dockerfile-generator.sh
+++ b/docker/dockerfile-generator.sh
@@ -200,7 +200,7 @@ RUN apt-get update \\
     nasm \\
     pkg-config \\
     xvfb \\
-    zlib1g-dev" >> $DOCKERFILE_PATH
+    zlib1g-dev \\" >> $DOCKERFILE_PATH
   else 
     echo "    ccache \\
     g++ \\


### PR DESCRIPTION
ref: #1912 

https://ci.adoptopenjdk.net/job/DockerfileCheck/153/ - Missed out a couple backslashes
