### PR TITLE
switch linux x64 builds to use docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .idea/
 shellcheck-stable
 workspace
+pipelines/.gradle
+pipelines/gradle-cache
+pipelines/target

--- a/configureBuild.sh
+++ b/configureBuild.sh
@@ -61,11 +61,6 @@ parseCommandLineArgs() {
     setOpenJdkVersion "$1"
     setDockerVolumeSuffix "$1"
   fi
-
-  # This check is to set the JAVA_HOME to the --jdk-boot-dir parameter (if both the param exists and JAVA_HOME doesn't)
-  if [ -d "${BUILD_CONFIG[JDK_BOOT_DIR]}" ] && [ -n "${JAVA_HOME:+x}" ]; then
-    export JAVA_HOME="${BUILD_CONFIG[JDK_BOOT_DIR]}"
-  fi
 }
 
 # Extra config for OpenJDK variants such as OpenJ9, SAP et al

--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -75,6 +75,7 @@ class Builder implements Serializable {
                 SCM_REF: scmReference,
                 BUILD_ARGS: buildArgs,
                 NODE_LABEL: "${additionalNodeLabels}&&${platformConfig.os}&&${platformConfig.arch}",
+                DOCKER_IMAGE: platformConfig.dockerImage as String,
                 CONFIGURE_ARGS: getConfigureArgs(platformConfig, additionalConfigureArgs, variant),
                 OVERRIDE_FILE_NAME_VERSION: overrideFileNameVersion,
                 ADDITIONAL_FILE_NAME_TAG: platformConfig.additionalFileNameTag as String,

--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -58,6 +58,8 @@ class Builder implements Serializable {
 
         def additionalNodeLabels = formAdditionalBuildNodeLabels(platformConfig, variant)
 
+        def dockerImage = getDockerImage(platformConfig, variant)
+
         def buildArgs = getBuildArgs(platformConfig, variant)
 
         if (additionalBuildArgs) {
@@ -75,7 +77,8 @@ class Builder implements Serializable {
                 SCM_REF: scmReference,
                 BUILD_ARGS: buildArgs,
                 NODE_LABEL: "${additionalNodeLabels}&&${platformConfig.os}&&${platformConfig.arch}",
-                DOCKER_IMAGE: platformConfig.dockerImage as String,
+                CODEBUILD: platformConfig.codebuild as Boolean,
+                DOCKER_IMAGE: dockerImage,
                 CONFIGURE_ARGS: getConfigureArgs(platformConfig, additionalConfigureArgs, variant),
                 OVERRIDE_FILE_NAME_VERSION: overrideFileNameVersion,
                 ADDITIONAL_FILE_NAME_TAG: platformConfig.additionalFileNameTag as String,
@@ -118,6 +121,18 @@ class Builder implements Serializable {
             }
         }
         return []
+    }
+
+    def getDockerImage(Map<String, ?> configuration, String variant) {
+        def dockerImageValue = ""
+        if (configuration.containsKey("dockerImage")) {
+            if (isMap(configuration.dockerImage)) {
+                dockerImageValue = (configuration.dockerImage as Map<String, ?>).get(variant)
+            } else {
+                dockerImageValue = configuration.dockerImage
+            }
+        }
+        return dockerImageValue
     }
 
     /**

--- a/pipelines/build/common/create_job_from_template.groovy
+++ b/pipelines/build/common/create_job_from_template.groovy
@@ -71,6 +71,7 @@ pipelineJob("$buildFolder/$JOB_NAME") {
                 <dt><strong>SCM_REF</strong></dt><dd>Source code ref to build, i.e branch, tag, commit id</dd>
                 <dt><strong>BUILD_ARGS</strong></dt><dd>args to pass to makejdk-any-platform.sh</dd>
                 <dt><strong>NODE_LABEL</strong></dt><dd>Labels of node to build on</dd>
+                <dt><strong>CODEBUILD</strong></dt><dd>Use a dynamic codebuild machine if no other machine is available</dd>
                 <dt><strong>DOCKER_IMAGE</strong></dt><dd>Use a docker build environment</dd>
                 <dt><strong>CONFIGURE_ARGS</strong></dt><dd>Arguments for ./configure</dd>
                 <dt><strong>OVERRIDE_FILE_NAME_VERSION</strong></dt><dd>Set the version string on the file name</dd>

--- a/pipelines/build/common/create_job_from_template.groovy
+++ b/pipelines/build/common/create_job_from_template.groovy
@@ -71,6 +71,7 @@ pipelineJob("$buildFolder/$JOB_NAME") {
                 <dt><strong>SCM_REF</strong></dt><dd>Source code ref to build, i.e branch, tag, commit id</dd>
                 <dt><strong>BUILD_ARGS</strong></dt><dd>args to pass to makejdk-any-platform.sh</dd>
                 <dt><strong>NODE_LABEL</strong></dt><dd>Labels of node to build on</dd>
+                <dt><strong>DOCKER_IMAGE</strong></dt><dd>Use a docker build environment</dd>
                 <dt><strong>CONFIGURE_ARGS</strong></dt><dd>Arguments for ./configure</dd>
                 <dt><strong>OVERRIDE_FILE_NAME_VERSION</strong></dt><dd>Set the version string on the file name</dd>
                 <dt><strong>RELEASE</strong></dt><dd>Is this build a release</dd>

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -563,27 +563,36 @@ class Build {
                     context.stage("queue") {
                         def NodeHelper = context.library(identifier: 'openjdk-jenkins-helper@master').NodeHelper
 
-                        if (NodeHelper.nodeIsOnline(buildConfig.NODE_LABEL)) {
-                            context.node(buildConfig.NODE_LABEL) {
-                                // This is to avoid windows path length issues.
-                                context.echo("checking ${buildConfig.TARGET_OS}")
-                                if (buildConfig.TARGET_OS == "windows") {
-                                    // See https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1284#issuecomment-621909378 for justification of the below path
-                                    def workspace = "C:/workspace/openjdk-build/"
-                                    if (env.CYGWIN_WORKSPACE) {
-                                        workspace = env.CYGWIN_WORKSPACE
-                                    }
-                                    context.echo("changing ${workspace}")
-                                    context.ws(workspace) {
-                                        buildScripts(cleanWorkspace, filename)
-                                    }
-                                } else {
-                                    buildScripts(cleanWorkspace, filename)
+                        if (buildConfig.DOCKER_IMAGE) {
+                            // Docker build environment
+                            context.node("dockerBuild") {
+                                context.docker.image(buildConfig.DOCKER_IMAGE).inside {
+                                    buildScripts(false, filename)
                                 }
                             }
                         } else {
-                            context.error("No node of this type exists: ${buildConfig.NODE_LABEL}")
-                            return
+                            if (NodeHelper.nodeIsOnline(buildConfig.NODE_LABEL)) {
+                                context.node(buildConfig.NODE_LABEL) {
+                                    // This is to avoid windows path length issues.
+                                    context.echo("checking ${buildConfig.TARGET_OS}")
+                                    if (buildConfig.TARGET_OS == "windows") {
+                                        // See https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1284#issuecomment-621909378 for justification of the below path
+                                        def workspace = "C:/workspace/openjdk-build/"
+                                        if (env.CYGWIN_WORKSPACE) {
+                                            workspace = env.CYGWIN_WORKSPACE
+                                        }
+                                        context.echo("changing ${workspace}")
+                                        context.ws(workspace) {
+                                            buildScripts(cleanWorkspace, filename)
+                                        }
+                                    } else {
+                                        buildScripts(cleanWorkspace, filename)
+                                    }
+                                }   
+                            } else {
+                                context.error("No node of this type exists: ${buildConfig.NODE_LABEL}")
+                                return
+                            }
                         }
                     }
 

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -565,11 +565,12 @@ class Build {
 
                         if (buildConfig.DOCKER_IMAGE) {
                             // Docker build environment
-                            if (NodeHelper.nodeIsOnline(buildConfig.NODE_LABEL) || (buildConfig.CODEBUILD)) {
-                                if (buildConfig.CODEBUILD) {
-                                    buildConfig.NODE_LABEL="codebuild"
-                                }
-                                context.node(buildConfig.NODE_LABEL + "&&dockerBuild") {
+                            def label = buildConfig.NODE_LABEL + "&&dockerBuild"
+                            if (buildConfig.CODEBUILD) {
+                                label = "codebuild"
+                            }
+                            if (NodeHelper.nodeIsOnline(label) || (buildConfig.CODEBUILD)) {
+                                context.node(label) {
                                     context.docker.image(buildConfig.DOCKER_IMAGE).pull()
                                     context.docker.image(buildConfig.DOCKER_IMAGE).inside {
                                         // Cannot clean workspace from inside docker container

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -568,7 +568,9 @@ class Build {
                             context.node(buildConfig.NODE_LABEL + "&&dockerBuild") {
                                 context.docker.image(buildConfig.DOCKER_IMAGE).pull()
                                 context.docker.image(buildConfig.DOCKER_IMAGE).inside {
-                                    buildScripts(false, filename)
+                                    // No need to clean the workspace
+                                    cleanWorkspace = false
+                                    buildScripts(cleanWorkspace, filename)
                                 }
                             }
                         } else {

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -566,6 +566,7 @@ class Build {
                         if (buildConfig.DOCKER_IMAGE) {
                             // Docker build environment
                             context.node(buildConfig.NODE_LABEL + "&&dockerBuild") {
+                                context.docker.image(buildConfig.DOCKER_IMAGE).pull()
                                 context.docker.image(buildConfig.DOCKER_IMAGE).inside {
                                     buildScripts(false, filename)
                                 }

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -568,8 +568,15 @@ class Build {
                             context.node(buildConfig.NODE_LABEL + "&&dockerBuild") {
                                 context.docker.image(buildConfig.DOCKER_IMAGE).pull()
                                 context.docker.image(buildConfig.DOCKER_IMAGE).inside {
-                                    // No need to clean the workspace
-                                    cleanWorkspace = false
+                                    // Cannot clean workspace from inside docker container
+                                    if (cleanWorkspace) {
+                                        try {
+                                            context.cleanWs notFailBuild: true
+                                        } catch (e) {
+                                            context.println "Failed to clean ${e}"
+                                        }
+                                        cleanWorkspace = false
+                                    }
                                     buildScripts(cleanWorkspace, filename)
                                 }
                             }

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -565,7 +565,7 @@ class Build {
 
                         if (buildConfig.DOCKER_IMAGE) {
                             // Docker build environment
-                            context.node("dockerBuild") {
+                            context.node(buildConfig.NODE_LABEL + "&&dockerBuild") {
                                 context.docker.image(buildConfig.DOCKER_IMAGE).inside {
                                     buildScripts(false, filename)
                                 }

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -23,7 +23,7 @@ class Config11 {
         x64Linux  : [
                 os                  : 'linux',
                 arch                : 'x64',
-                additionalNodeLabels: 'centos6',
+                dockerImage         : 'adoptopenjdk/centos6_build_image',
                 test                : [
                         nightly: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external'],
                         release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external', 'special.functional']

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -23,7 +23,12 @@ class Config11 {
         x64Linux  : [
                 os                  : 'linux',
                 arch                : 'x64',
-                dockerImage         : 'adoptopenjdk/centos6_build_image',
+                additionalNodeLabels: [
+                        openj9  : 'centos6'
+                ],
+                dockerImage         : [
+                        hostpot : 'adoptopenjdk/centos6_build_image'
+                ],
                 test                : [
                         nightly: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external'],
                         release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external', 'special.functional']
@@ -33,7 +38,8 @@ class Config11 {
                         "hotspot"     : '--disable-ccache --enable-dtrace=auto',
                         "corretto"    : '--disable-ccache --enable-dtrace=auto',
                         "SapMachine"  : '--disable-ccache --enable-dtrace=auto'
-                ]
+                ],
+                codebuild           : true
         ],
 
         // Currently we have to be quite specific about which windows to use as not all of them have freetype installed

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -27,7 +27,7 @@ class Config11 {
                         openj9  : 'centos6'
                 ],
                 dockerImage         : [
-                        hostpot : 'adoptopenjdk/centos6_build_image'
+                        hotspot : 'adoptopenjdk/centos6_build_image'
                 ],
                 test                : [
                         nightly: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external'],

--- a/pipelines/jobs/configurations/jdk14u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk14u_pipeline_config.groovy
@@ -20,7 +20,7 @@ class Config14 {
         x64Linux  : [
                 os                  : 'linux',
                 arch                : 'x64',
-                additionalNodeLabels: 'centos6',
+                dockerImage         : 'adoptopenjdk/centos6_build_image',
                 test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external', 'special.functional'],
                 configureArgs       : [
                         "openj9"      : '--disable-ccache --enable-dtrace=auto --enable-jitserver',

--- a/pipelines/jobs/configurations/jdk14u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk14u_pipeline_config.groovy
@@ -20,13 +20,19 @@ class Config14 {
         x64Linux  : [
                 os                  : 'linux',
                 arch                : 'x64',
-                dockerImage         : 'adoptopenjdk/centos6_build_image',
+                additionalNodeLabels: [
+                        openj9  : 'centos6'
+                ],
+                dockerImage         : [
+                        hotspot : 'adoptopenjdk/centos6_build_image'
+                ],
                 test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external', 'special.functional'],
                 configureArgs       : [
                         "openj9"      : '--disable-ccache --enable-dtrace=auto --enable-jitserver',
                         "hotspot"     : '--disable-ccache --enable-dtrace=auto',
                         "SapMachine"  : '--disable-ccache --enable-dtrace=auto'
-                ]
+                ],
+                codebuild           : true
         ],
 
         x64LinuxXL    : [

--- a/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
@@ -27,7 +27,7 @@ class Config8 {
                         openj9  : 'centos6'
                 ],
                 dockerImage         : [
-                        hostpot : 'adoptopenjdk/centos6_build_image'
+                        hotspot : 'adoptopenjdk/centos6_build_image'
                 ],
                 test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external', 'special.functional', 'special.openjdk'],
                 configureArgs       : [

--- a/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
@@ -23,7 +23,7 @@ class Config8 {
         x64Linux      : [
                 os                  : 'linux',
                 arch                : 'x64',
-                additionalNodeLabels: 'centos6',
+                dockerImage         : 'adoptopenjdk/centos6_build_image',
                 test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external', 'special.functional', 'special.openjdk'],
                 configureArgs       : [
                         "openj9"      : '--enable-jitserver'

--- a/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
@@ -23,11 +23,17 @@ class Config8 {
         x64Linux      : [
                 os                  : 'linux',
                 arch                : 'x64',
-                dockerImage         : 'adoptopenjdk/centos6_build_image',
+                additionalNodeLabels: [
+                        openj9  : 'centos6'
+                ],
+                dockerImage         : [
+                        hostpot : 'adoptopenjdk/centos6_build_image'
+                ],
                 test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external', 'special.functional', 'special.openjdk'],
                 configureArgs       : [
                         "openj9"      : '--enable-jitserver'
-                ]
+                ],
+                codebuild           : true
         ],
 
         // Currently we have to be quite specific about which windows to use as not all of them have freetype installed

--- a/pipelines/library/src/common/IndividualBuildConfig.groovy
+++ b/pipelines/library/src/common/IndividualBuildConfig.groovy
@@ -12,6 +12,7 @@ class IndividualBuildConfig implements Serializable {
     final String SCM_REF
     final String BUILD_ARGS
     final String NODE_LABEL
+    final boolean CODEBUILD
     final String DOCKER_IMAGE
     final String CONFIGURE_ARGS
     final String OVERRIDE_FILE_NAME_VERSION
@@ -44,6 +45,7 @@ class IndividualBuildConfig implements Serializable {
         SCM_REF = map.get("SCM_REF")
         BUILD_ARGS = map.get("BUILD_ARGS")
         NODE_LABEL = map.get("NODE_LABEL")
+        CODEBUILD = map.get("CODEBUILD")
         DOCKER_IMAGE = map.get("DOCKER_IMAGE")
         CONFIGURE_ARGS = map.get("CONFIGURE_ARGS")
         OVERRIDE_FILE_NAME_VERSION = map.get("OVERRIDE_FILE_NAME_VERSION")
@@ -81,6 +83,7 @@ class IndividualBuildConfig implements Serializable {
                 SCM_REF                   : SCM_REF,
                 BUILD_ARGS                : BUILD_ARGS,
                 NODE_LABEL                : NODE_LABEL,
+                CODEBUILD                 : CODEBUILD,
                 DOCKER_IMAGE              : DOCKER_IMAGE,
                 CONFIGURE_ARGS            : CONFIGURE_ARGS,
                 OVERRIDE_FILE_NAME_VERSION: OVERRIDE_FILE_NAME_VERSION,

--- a/pipelines/library/src/common/IndividualBuildConfig.groovy
+++ b/pipelines/library/src/common/IndividualBuildConfig.groovy
@@ -12,6 +12,7 @@ class IndividualBuildConfig implements Serializable {
     final String SCM_REF
     final String BUILD_ARGS
     final String NODE_LABEL
+    final String DOCKER_IMAGE
     final String CONFIGURE_ARGS
     final String OVERRIDE_FILE_NAME_VERSION
     final String ADDITIONAL_FILE_NAME_TAG
@@ -43,6 +44,7 @@ class IndividualBuildConfig implements Serializable {
         SCM_REF = map.get("SCM_REF")
         BUILD_ARGS = map.get("BUILD_ARGS")
         NODE_LABEL = map.get("NODE_LABEL")
+        DOCKER_IMAGE = map.get("DOCKER_IMAGE")
         CONFIGURE_ARGS = map.get("CONFIGURE_ARGS")
         OVERRIDE_FILE_NAME_VERSION = map.get("OVERRIDE_FILE_NAME_VERSION")
         ADDITIONAL_FILE_NAME_TAG = map.get("ADDITIONAL_FILE_NAME_TAG")
@@ -79,6 +81,7 @@ class IndividualBuildConfig implements Serializable {
                 SCM_REF                   : SCM_REF,
                 BUILD_ARGS                : BUILD_ARGS,
                 NODE_LABEL                : NODE_LABEL,
+                DOCKER_IMAGE              : DOCKER_IMAGE,
                 CONFIGURE_ARGS            : CONFIGURE_ARGS,
                 OVERRIDE_FILE_NAME_VERSION: OVERRIDE_FILE_NAME_VERSION,
                 ADDITIONAL_FILE_NAME_TAG  : ADDITIONAL_FILE_NAME_TAG,

--- a/pipelines/src/main/groovy/testDoubles/ContextStub.groovy
+++ b/pipelines/src/main/groovy/testDoubles/ContextStub.groovy
@@ -47,6 +47,14 @@ class ContextStub {
 
     ContextStub library(Map) {}
 
+    ContextStub docker
+
+    ContextStub inside(Closure c) {}
+
+    ContextStub image(String) {}
+
+    ContextStub pull() {}
+
     String getResult() {}
 
     Integer getNumber() {}

--- a/pipelines/src/test/groovy/IndividualBuildConfigTest.groovy
+++ b/pipelines/src/test/groovy/IndividualBuildConfigTest.groovy
@@ -16,6 +16,8 @@ class IndividualBuildConfigTest {
                  SCM_REF                   : "f",
                  BUILD_ARGS                : "g",
                  NODE_LABEL                : "h",
+                 CODEBUILD                 : false,
+                 DOCKER_IMAGE              : "o",
                  CONFIGURE_ARGS            : "i",
                  OVERRIDE_FILE_NAME_VERSION: "j",
                  ADDITIONAL_FILE_NAME_TAG  : "k",


### PR DESCRIPTION
Swaps all <15 hotspot builds to use the centos6 build image (https://hub.docker.com/r/adoptopenjdk/centos6_build_image)

Also adds codebuild machines to handle the docker images (saves us maintaining any docker only machines.

This PR technically allows us to use a docker build environment for any architecture that supports docker.

I'm currently not doing this on OpenJ9 because it requires CUDA which bloats the docker image substantially, I'm working on a solution for that.