### PR TITLE
Undo gradlebreaks

### DIFF
--- a/pipelines/build.gradle
+++ b/pipelines/build.gradle
@@ -22,9 +22,6 @@ repositories {
     maven {
         url "https://repository.mulesoft.org/nexus/content/repositories/public/"
     }
-    maven {
-        url "https://repo.jenkins-ci.org/releases/"
-    }
 }
 
 task uberjar(type: Jar) {
@@ -36,8 +33,6 @@ task uberjar(type: Jar) {
 
 dependencies {
     compile 'org.codehaus.groovy:groovy-all:3.0.4'
-    // https://mvnrepository.com/artifact/org.jenkins-ci.main/jenkins-core?repo=jenkins-releases
-    compile 'org.jenkins-ci.main:jenkins-core:2.238'
     testCompile('org.junit.jupiter:junit-jupiter-api:5.4.1')
     testRuntime('org.junit.jupiter:junit-jupiter-engine:5.4.1')
 }

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -3,7 +3,6 @@ import common.MetaData
 @Library('local-lib@master')
 import common.VersionInfo
 import groovy.json.*
-import hudson.Functions
 
 import java.util.regex.Matcher
 
@@ -605,8 +604,7 @@ class Build {
 
                 } catch (Exception e) {
                     currentBuild.result = 'FAILURE'
-                    context.println "Execution error: ${e}"
-                    context.println Functions.printThrowable(e)
+                    context.println "Execution error: ${e}\n" + e.printStackTrace()
                 }
             }
         }


### PR DESCRIPTION
This reverts https://github.com/AdoptOpenJDK/openjdk-build/pull/1934 and https://github.com/AdoptOpenJDK/openjdk-build/pull/1936 as they have broken the nighttly builds and I cannot risk things being broken over the weekend.