### PR TITLE
add config arguments for adopt build repo uri and branch

### DIFF
--- a/sbin/common/config_init.sh
+++ b/sbin/common/config_init.sh
@@ -32,6 +32,8 @@
 # map. This is why we can't have nice things.
 CONFIG_PARAMS=(
 ADOPT_PATCHES
+ADOPTOPENJDK_BUILD_REPO_BRANCH
+ADOPTOPENJDK_BUILD_REPO_URI
 BRANCH
 BUILD_FULL_NAME
 BUILD_VARIANT
@@ -173,6 +175,12 @@ function parseConfigurationArguments() {
 
       case "$opt" in
         "--" ) break 2;;
+
+        "--adoptopenjdk-build-repo-branch" )
+        BUILD_CONFIG[ADOPTOPENJDK_BUILD_REPO_BRANCH]="$1"; shift;;
+
+        "--adoptopenjdk-build-repo-uri" )
+        BUILD_CONFIG[ADOPTOPENJDK_BUILD_REPO_URI]="$1"; shift;;
 
         "--build-variant" )
         BUILD_CONFIG[BUILD_VARIANT]="$1"; shift;;
@@ -337,6 +345,12 @@ function configDefaults() {
 
   # The OpenJDK source code repository to build from, e.g. an AdoptOpenJDK repo
   BUILD_CONFIG[REPOSITORY]=""
+
+  # The default AdoptOpenJDK/openjdk-build repo branch
+  BUILD_CONFIG[ADOPTOPENJDK_BUILD_REPO_BRANCH]="master"
+
+  # The default AdoptOpenJDK/openjdk-build repo uri
+  BUILD_CONFIG[ADOPTOPENJDK_BUILD_REPO_URI]="https://github.com/AdoptOpenJDK/openjdk-build.git"
 
   BUILD_CONFIG[COPY_MACOSX_FREE_FONT_LIB_FOR_JDK_FLAG]="false"
   BUILD_CONFIG[COPY_MACOSX_FREE_FONT_LIB_FOR_JRE_FLAG]="false"

--- a/sbin/common/config_init.sh
+++ b/sbin/common/config_init.sh
@@ -32,8 +32,8 @@
 # map. This is why we can't have nice things.
 CONFIG_PARAMS=(
 ADOPT_PATCHES
-ADOPTOPENJDK_BUILD_REPO_BRANCH
-ADOPTOPENJDK_BUILD_REPO_URI
+OPENJDK_BUILD_REPO_BRANCH
+OPENJDK_BUILD_REPO_URI
 BRANCH
 BUILD_FULL_NAME
 BUILD_VARIANT
@@ -176,11 +176,11 @@ function parseConfigurationArguments() {
       case "$opt" in
         "--" ) break 2;;
 
-        "--adoptopenjdk-build-repo-branch" )
-        BUILD_CONFIG[ADOPTOPENJDK_BUILD_REPO_BRANCH]="$1"; shift;;
+        "--openjdk-build-repo-branch" )
+        BUILD_CONFIG[OPENJDK_BUILD_REPO_BRANCH]="$1"; shift;;
 
-        "--adoptopenjdk-build-repo-uri" )
-        BUILD_CONFIG[ADOPTOPENJDK_BUILD_REPO_URI]="$1"; shift;;
+        "--openjdk-build-repo-uri" )
+        BUILD_CONFIG[OPENJDK_BUILD_REPO_URI]="$1"; shift;;
 
         "--build-variant" )
         BUILD_CONFIG[BUILD_VARIANT]="$1"; shift;;
@@ -347,10 +347,10 @@ function configDefaults() {
   BUILD_CONFIG[REPOSITORY]=""
 
   # The default AdoptOpenJDK/openjdk-build repo branch
-  BUILD_CONFIG[ADOPTOPENJDK_BUILD_REPO_BRANCH]="master"
+  BUILD_CONFIG[OPENJDK_BUILD_REPO_BRANCH]="master"
 
   # The default AdoptOpenJDK/openjdk-build repo uri
-  BUILD_CONFIG[ADOPTOPENJDK_BUILD_REPO_URI]="https://github.com/AdoptOpenJDK/openjdk-build.git"
+  BUILD_CONFIG[OPENJDK_BUILD_REPO_URI]="https://github.com/AdoptOpenJDK/openjdk-build.git"
 
   BUILD_CONFIG[COPY_MACOSX_FREE_FONT_LIB_FOR_JDK_FLAG]="false"
   BUILD_CONFIG[COPY_MACOSX_FREE_FONT_LIB_FOR_JRE_FLAG]="false"

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -472,7 +472,7 @@ checkingAndDownloadCaCerts() {
     git remote add origin -f "${BUILD_CONFIG[ADOPTOPENJDK_BUILD_REPO_URI]}"
     git config core.sparsecheckout true
     echo "security/*" >>.git/info/sparse-checkout
-    git pull origin "${BUILD_CONFIG[ADOPTOPENJDK_BUILD_REPO_BRANCH]}"
+    git pull origin "${BUILD_CONFIG[OPENJDK_BUILD_REPO_BRANCH]}"
   fi
 
   cd "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}" || exit

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -469,7 +469,7 @@ checkingAndDownloadCaCerts() {
     downloadCerts "$caLink"
   elif [ "${BUILD_CONFIG[USE_JEP319_CERTS]}" != "true" ]; then
     git init
-    git remote add origin -f "${BUILD_CONFIG[ADOPTOPENJDK_BUILD_REPO_URI]}"
+    git remote add origin -f "${BUILD_CONFIG[OPENJDK_BUILD_REPO_URI]}"
     git config core.sparsecheckout true
     echo "security/*" >>.git/info/sparse-checkout
     git pull origin "${BUILD_CONFIG[OPENJDK_BUILD_REPO_BRANCH]}"

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -107,7 +107,7 @@ checkoutAndCloneOpenJDKGitRepo() {
 }
 
 # Checkout the required code to build from the given cached git repo
-# Set checkoutRc to result so we can retry 
+# Set checkoutRc to result so we can retry
 checkoutRequiredCodeToBuild() {
   checkoutRc=1
 
@@ -341,7 +341,7 @@ downloadFile() {
   local url="$2"
 
   echo downloadFile: Saving "url" to "$targetFileName"
-  
+
   # Temporary fudge as curl on my windows boxes is exiting with RC=127
   if [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]]; then
     wget -O "${targetFileName}" "${url}" || exit 2
@@ -469,10 +469,10 @@ checkingAndDownloadCaCerts() {
     downloadCerts "$caLink"
   elif [ "${BUILD_CONFIG[USE_JEP319_CERTS]}" != "true" ]; then
     git init
-    git remote add origin -f https://github.com/AdoptOpenJDK/openjdk-build.git
+    git remote add origin -f "${BUILD_CONFIG[ADOPTOPENJDK_BUILD_REPO_URI]}"
     git config core.sparsecheckout true
     echo "security/*" >>.git/info/sparse-checkout
-    git pull origin master
+    git pull origin "${BUILD_CONFIG[ADOPTOPENJDK_BUILD_REPO_BRANCH]}"
   fi
 
   cd "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}" || exit


### PR DESCRIPTION
Introducing 2 additional config arguments to `sbin/prepareWorkspace.sh`, for other vendors to have the option to build openjdk with different openjdk-build source code.
`OPENJDK_BUILD_REPO_BRANCH`
and
`OPENJDK_BUILD_REPO_URI`