### PR TITLE
Populate metadata scmRef

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ Alongside the built assets a metadata file will be created with info about the b
         "opt": "202006220910",
         "configure_arguments": <output of bash configure>
     },
-    "scmRef": "",
+    "scmRef": "<output of git describe OR the value of buildConfig.SCM_REF>",
     "version_data": "jdk15",
     "binary_type": "jdk",
     "sha256": "<shasum>"

--- a/pipelines/src/main/groovy/testDoubles/ContextStub.groovy
+++ b/pipelines/src/main/groovy/testDoubles/ContextStub.groovy
@@ -86,4 +86,6 @@ class ContextStub {
     ContextStub timestamps(Closure ignore) {}
 
     ContextStub timeout(Map<String, ?> ignore, Closure<? extends Object> ignore2) {}
+
+    String overrideScmref() {}
 }


### PR DESCRIPTION
Hooks up the scmRef in the metadata to whatever the tag has been specified as OR whatever the output of git describe is. On a failed git describe, the tag is used whether it is an empty string or not

Closes: #474 
Signed-off-by: Morgan Davies <morgan.davies@ibm.com>