### PR TITLE
If API retries exceeeded, show RC of curl command

### DIFF
--- a/build-farm/make-adopt-build-farm.sh
+++ b/build-farm/make-adopt-build-farm.sh
@@ -34,7 +34,7 @@ then
     do
         # Use Adopt API to get the JDK Head number
         echo "This appears to be JDK Head. Querying the Adopt API to get the JDK HEAD Number (https://api.adoptopenjdk.net/v3/info/available_releases)..."
-        JAVA_FEATURE_VERSION=$(curl -v https://api.adoptopenjdk.net/v3/info/available_releases | awk '/tip_version/{print$2}')
+        JAVA_FEATURE_VERSION=$(curl -q https://api.adoptopenjdk.net/v3/info/available_releases | awk '/tip_version/{print$2}')
         
         # Checks the api request was successful and the return value is a number
         if [ -z "${JAVA_FEATURE_VERSION}" ] || ! [[ "${JAVA_FEATURE_VERSION}" -gt 0 ]]
@@ -52,6 +52,7 @@ then
     then
         echo "Failed ${retryCount} times to query or parse the adopt api. Dumping headers via curl -v https://api.adoptopenjdk.net/v3/info/available_releases and exiting..."
         curl -v https://api.adoptopenjdk.net/v3/info/available_releases
+        echo curl returned RC $? in make_adopt_build_farm.sh
         exit 1
     fi
 fi

--- a/sbin/common/common.sh
+++ b/sbin/common/common.sh
@@ -42,7 +42,7 @@ function setOpenJdkVersion() {
     do
         # Use Adopt API to get the JDK Head number
         echo "This appears to be JDK Head. Querying the Adopt API to get the JDK HEAD Number (https://api.adoptopenjdk.net/v3/info/available_releases)..."
-        local featureNumber=$(curl -v https://api.adoptopenjdk.net/v3/info/available_releases | awk '/tip_version/{print$2}')
+        local featureNumber=$(curl -q https://api.adoptopenjdk.net/v3/info/available_releases | awk '/tip_version/{print$2}')
         
         # Checks the api request was successful and the return value is a number
         if [ -z "${featureNumber}" ] || ! [[ "${featureNumber}" -gt 0 ]]
@@ -60,6 +60,7 @@ function setOpenJdkVersion() {
     then
         echo "Failed ${retryCount} times to query or parse the adopt api. Dumping headers via curl -v https://api.adoptopenjdk.net/v3/info/available_releases and exiting..."
         curl -v https://api.adoptopenjdk.net/v3/info/available_releases
+        echo curl returned RC $? in common.sh
         exit 1
     fi
   fi


### PR DESCRIPTION
Display return code from the final debug `curl -v` since it doesn't appear to be showing any output when it fails (Ref: https://adoptopenjdk.slack.com/archives/C09NW3L2J/p1593680142251300)

Also modifies the main curl commands to use `-q` to curl instead of `-v` as the `-v` can only cause confusion to the subsequent grep operation which will always remove all the verbose stuff anyway.