### PR TITLE
pipeline: Manually delete problematic file for Azure Windows

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -506,9 +506,11 @@ class Build {
             if (cleanWorkspace) {
                 try {
                     if (buildConfig.TARGET_OS == "windows") {
-                        // Softlayer machines struggle to clean themselves
+                        // Windows machines struggle to clean themselves, see:
                         // https://github.com/AdoptOpenJDK/openjdk-build/issues/1855
                         context.sh(script: "rm -rf C:/workspace/openjdk-build/workspace/build/src/build/*/jdk/gensrc")
+                        // https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1419
+                        context.sh(script: "rm -rf J:/jenkins/tmp/workspace/build/src/build/*/jdk/gensrc")
                         context.cleanWs notFailBuild: true, disableDeferredWipeout: true, deleteDirs: true
                     } else {
                         context.cleanWs notFailBuild: true


### PR DESCRIPTION
ref: https://github.com/AdoptOpenJDK/openjdk-build/pull/1892/ , https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1419 , https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1396

Changes to allow the problematic `..the_` file to be deleted for both Softlayer and Azure windows machines before `cleanWS` is used. I was unsure if there was a specific variable that could've been used to make this more general ( i.e. ` context.sh(script: "rm -rf {buildconfig.WORKSPACE}/build/src/build/*/jdk/gensrc` , if anyone could enlighten me?

ping @M-Davies @sxa @karianna 

Signed-off-by: William Parker <william.parker1@ibm.com>