### PR TITLE
Reduce parallelism on AIX JDK14+ hotspot builds

### DIFF
--- a/build-farm/platform-specific-configurations/aix.sh
+++ b/build-farm/platform-specific-configurations/aix.sh
@@ -114,7 +114,7 @@ fi
 
 # J9 JDK14 builds seem to be chewing up more RAM than the others, so restrict it
 # Ref: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1151
-if [ "$JAVA_FEATURE_VERSION" -ge 14 ] && [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]; then
+if [ "$JAVA_FEATURE_VERSION" -ge 14 ]; then
   export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-memory-size=7000"
 else
   export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-memory-size=10000"


### PR DESCRIPTION
We're hitting intermittent (but now quite frequent) resource limit issues consistent with those we first saw on the OpenJ9 builds. This implements the same fix to HotSpot

```
22:15:06  Creating java.net.http.jmod
22:15:06  Creating java.prefs.jmod
22:15:08  gmake[3]: CreateJmods.gmk:57: fork: Resource temporarily unavailable
22:15:08  gmake[3]: CreateJmods.gmk:221: fork: Resource temporarily unavailable
22:15:08  /opt/freeware/bin/bash: fork: retry: No child processes
22:15:08  gmake[3]: CreateJmods.gmk:221: fork: Resource temporarily unavailable
22:15:08  gmake[3]: CreateJmods.gmk:221: fork: Resource temporarily unavailable
22:15:08  Creating java.rmi.jmod
22:15:08  gmake[3]: fork: Resource temporarily unavailable
```

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>