### PR TITLE
set GRADLE_USER_HOME only when it's unset

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -458,12 +458,12 @@ buildSharedLibs() {
     cd "${LIB_DIR}"
 
     local gradleJavaHome=$(getGradleJavaHome)
-    export GRADLE_USER_HOME=$(getGradleUserHome)
+    local gradleUserHome=$(getGradleUserHome)
 
-    echo "Running gradle with $gradleJavaHome at ${GRADLE_USER_HOME}"
+    echo "Running gradle with $gradleJavaHome at ${gradleUserHome}"
 
     gradlecount=1
-    while ! JAVA_HOME="$gradleJavaHome" GRADLE_USER_HOME="${GRADLE_USER_HOME}" bash ./gradlew --no-daemon clean shadowJar; do
+    while ! JAVA_HOME="$gradleJavaHome" GRADLE_USER_HOME="${gradleUserHome}" bash ./gradlew --no-daemon clean shadowJar; do
       echo "RETRYWARNING: Gradle failed on attempt $gradlecount"
       sleep 120 # Wait before retrying in case of network/server outage ...
       gradlecount=$(( gradlecount + 1 ))

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -445,10 +445,10 @@ getGradleJavaHome() {
 getGradleUserHome() {
   local gradleUserHome=""
 
-  if [ -z "${BUILD_CONFIG[GRADLE_USER_HOME]}" ]; then
-    gradleUserHome="${BUILD_CONFIG[WORKSPACE_DIR]}/.gradle"
+  if [ -n "${BUILD_CONFIG[GRADLE_USER_HOME_DIR]}" ]; then
+    gradleUserHome="${BUILD_CONFIG[GRADLE_USER_HOME_DIR]}"
   else
-    gradleUserHome="${BUILD_CONFIG[GRADLE_USER_HOME]}"
+    gradleUserHome="${BUILD_CONFIG[WORKSPACE_DIR]}/.gradle"
   fi
 
   echo $gradleUserHome

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -446,7 +446,10 @@ buildSharedLibs() {
     cd "${LIB_DIR}"
 
     local gradleJavaHome=$(getGradleHome)
-    export GRADLE_USER_HOME="${BUILD_CONFIG[WORKSPACE_DIR]}/.gradle"
+
+    if [ -z "${GRADLE_USER_HOME}" ]; then
+      export GRADLE_USER_HOME="${BUILD_CONFIG[WORKSPACE_DIR]}/.gradle"
+    fi
 
     echo "Running gradle with $gradleJavaHome at ${GRADLE_USER_HOME}"
 

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -447,8 +447,10 @@ buildSharedLibs() {
 
     local gradleJavaHome=$(getGradleHome)
 
-    if [ -z "${GRADLE_USER_HOME}" ]; then
+    if [ -z "${BUILD_CONFIG[GRADLE_USER_HOME]}" ]; then
       export GRADLE_USER_HOME="${BUILD_CONFIG[WORKSPACE_DIR]}/.gradle"
+    else
+      export GRADLE_USER_HOME="${BUILD_CONFIG[GRADLE_USER_HOME]}"
     fi
 
     echo "Running gradle with $gradleJavaHome at ${GRADLE_USER_HOME}"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -417,7 +417,7 @@ executeTemplatedFile() {
 
 }
 
-getGradleHome() {
+getGradleJavaHome() {
   local gradleJavaHome=""
 
   if [ ${JAVA_HOME+x} ] && [ -d "${JAVA_HOME}" ]; then
@@ -442,16 +442,23 @@ getGradleHome() {
   echo $gradleJavaHome
 }
 
+getGradleUserHome() {
+  local gradleUserHome=""
+
+  if [ -z "${BUILD_CONFIG[GRADLE_USER_HOME]}" ]; then
+    gradleUserHome="${BUILD_CONFIG[WORKSPACE_DIR]}/.gradle"
+  else
+    gradleUserHome="${BUILD_CONFIG[GRADLE_USER_HOME]}"
+  fi
+
+  echo $gradleUserHome
+}
+
 buildSharedLibs() {
     cd "${LIB_DIR}"
 
-    local gradleJavaHome=$(getGradleHome)
-
-    if [ -z "${BUILD_CONFIG[GRADLE_USER_HOME]}" ]; then
-      export GRADLE_USER_HOME="${BUILD_CONFIG[WORKSPACE_DIR]}/.gradle"
-    else
-      export GRADLE_USER_HOME="${BUILD_CONFIG[GRADLE_USER_HOME]}"
-    fi
+    local gradleJavaHome=$(getGradleJavaHome)
+    export GRADLE_USER_HOME=$(getGradleUserHome)
 
     echo "Running gradle with $gradleJavaHome at ${GRADLE_USER_HOME}"
 
@@ -473,7 +480,7 @@ parseJavaVersionString() {
   local javaVersion=$(JAVA_HOME="$PRODUCT_HOME" "$PRODUCT_HOME"/bin/java -version 2>&1)
 
   cd "${LIB_DIR}"
-  local gradleJavaHome=$(getGradleHome)
+  local gradleJavaHome=$(getGradleJavaHome)
   local version=$(echo "$javaVersion" | JAVA_HOME="$gradleJavaHome" "$gradleJavaHome"/bin/java -cp "target/libs/adopt-shared-lib.jar" ParseVersion -s -f openjdk-semver $ADOPT_BUILD_NUMBER | tr -d '\n')
 
   echo $version

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -460,10 +460,10 @@ buildSharedLibs() {
     local gradleJavaHome=$(getGradleJavaHome)
     local gradleUserHome=$(getGradleUserHome)
 
-    echo "Running gradle with $gradleJavaHome at ${gradleUserHome}"
+    echo "Running gradle with $gradleJavaHome at $gradleUserHome"
 
     gradlecount=1
-    while ! JAVA_HOME="$gradleJavaHome" GRADLE_USER_HOME="${gradleUserHome}" bash ./gradlew --no-daemon clean shadowJar; do
+    while ! JAVA_HOME="$gradleJavaHome" GRADLE_USER_HOME="$gradleUserHome" bash ./gradlew --no-daemon clean shadowJar; do
       echo "RETRYWARNING: Gradle failed on attempt $gradlecount"
       sleep 120 # Wait before retrying in case of network/server outage ...
       gradlecount=$(( gradlecount + 1 ))

--- a/sbin/common/config_init.sh
+++ b/sbin/common/config_init.sh
@@ -56,6 +56,7 @@ FREETYPE
 FREETYPE_DIRECTORY
 FREETYPE_FONT_BUILD_TYPE_PARAM
 FREETYPE_FONT_VERSION
+GRADLE_USER_HOME
 KEEP_CONTAINER
 JDK_BOOT_DIR
 JDK_PATH
@@ -233,6 +234,9 @@ function parseConfigurationArguments() {
         "--freetype-version" )
         BUILD_CONFIG[FREETYPE_FONT_VERSION]="$1"; shift;;
 
+        "--gradle-user-home" )
+        BUILD_CONFIG[GRADLE_USER_HOME]="$1"; shift;;
+
         "--skip-freetype" | "-F" )
         BUILD_CONFIG[FREETYPE]=false;;
 
@@ -333,6 +337,9 @@ function configDefaults() {
 
   BUILD_CONFIG[JDK_PATH]=""
   BUILD_CONFIG[JRE_PATH]=""
+
+# The value defined for GRADLE_USER_HOME
+  BUILD_CONFIG[GRADLE_USER_HOME]=""
 
   # The O/S architecture, e.g. x86_64 for a modern intel / Mac OS X
   BUILD_CONFIG[OS_ARCHITECTURE]=${arch}

--- a/sbin/common/config_init.sh
+++ b/sbin/common/config_init.sh
@@ -56,7 +56,7 @@ FREETYPE
 FREETYPE_DIRECTORY
 FREETYPE_FONT_BUILD_TYPE_PARAM
 FREETYPE_FONT_VERSION
-GRADLE_USER_HOME
+GRADLE_USER_HOME_DIR
 KEEP_CONTAINER
 JDK_BOOT_DIR
 JDK_PATH
@@ -234,8 +234,8 @@ function parseConfigurationArguments() {
         "--freetype-version" )
         BUILD_CONFIG[FREETYPE_FONT_VERSION]="$1"; shift;;
 
-        "--gradle-user-home" )
-        BUILD_CONFIG[GRADLE_USER_HOME]="$1"; shift;;
+        "--gradle-user-home-dir" )
+        BUILD_CONFIG[GRADLE_USER_HOME_DIR]="$1"; shift;;
 
         "--skip-freetype" | "-F" )
         BUILD_CONFIG[FREETYPE]=false;;
@@ -339,7 +339,7 @@ function configDefaults() {
   BUILD_CONFIG[JRE_PATH]=""
 
   # The default value defined for GRADLE_USER_HOME
-  BUILD_CONFIG[GRADLE_USER_HOME]=""
+  BUILD_CONFIG[GRADLE_USER_HOME_DIR]=""
 
   # The O/S architecture, e.g. x86_64 for a modern intel / Mac OS X
   BUILD_CONFIG[OS_ARCHITECTURE]=${arch}

--- a/sbin/common/config_init.sh
+++ b/sbin/common/config_init.sh
@@ -338,7 +338,7 @@ function configDefaults() {
   BUILD_CONFIG[JDK_PATH]=""
   BUILD_CONFIG[JRE_PATH]=""
 
-# The value defined for GRADLE_USER_HOME
+  # The default value defined for GRADLE_USER_HOME
   BUILD_CONFIG[GRADLE_USER_HOME]=""
 
   # The O/S architecture, e.g. x86_64 for a modern intel / Mac OS X


### PR DESCRIPTION
Proposing a small improvement to make GRADLE_USER_HOME configurable through `BUILD_CONFIG`.

In Azure Pipelines, we need to specify the location of `GRADLE_USER_HOME` in order to perform gradle caching between builds. This improvement grants us control for that location and prevents future issues when the location of GRADLE_USER_HOME gets modified. 