### PR TITLE
build: switch aarch64 builds to be docker based

### DIFF
--- a/pipelines/build/prTester/pr_test_pipeline.groovy
+++ b/pipelines/build/prTester/pr_test_pipeline.groovy
@@ -124,6 +124,9 @@ Map<String, ?> defaultTestConfigurations = [
         "x64Linux": [
                 "hotspot",
                 "openj9"
+        ],
+        "aarch64Linux": [
+                "hotspot"
         ]
 ]
 

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -125,7 +125,7 @@ class Config11 {
         aarch64Linux    : [
                 os                  : 'linux',
                 arch                : 'aarch64',
-                additionalNodeLabels: 'centos7',
+                dockerImage         : 'adoptopenjdk/centos7_build_image',
                 test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
                 configureArgs       : '--enable-dtrace=auto'
         ],
@@ -165,7 +165,7 @@ class Config11 {
         ],
         aarch64LinuxXL    : [
                 os                   : 'linux',
-                additionalNodeLabels : 'centos7',
+                dockerImage          : 'adoptopenjdk/centos7_build_image',
                 arch                 : 'aarch64',
                 test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
                 additionalFileNameTag: "linuxXL",

--- a/pipelines/jobs/configurations/jdk14u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk14u_pipeline_config.groovy
@@ -136,7 +136,7 @@ class Config14 {
         aarch64Linux    : [
                 os                  : 'linux',
                 arch                : 'aarch64',
-                additionalNodeLabels: 'centos7',
+                dockerImage         : 'adoptopenjdk/centos7_build_image',
                 test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
                 configureArgs       : '--enable-dtrace=auto'
         ],

--- a/pipelines/jobs/configurations/jdk15_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk15_pipeline_config.groovy
@@ -94,7 +94,7 @@ class Config15 {
         aarch64Linux    : [
                 os                  : 'linux',
                 arch                : 'aarch64',
-                additionalNodeLabels: 'centos7',
+                dockerImage         : 'adoptopenjdk/centos7_build_image',
                 test                : [
                         nightly: false,
                         release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']

--- a/pipelines/jobs/configurations/jdk16_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk16_pipeline_config.groovy
@@ -85,7 +85,7 @@ class Config16 {
         aarch64Linux    : [
                 os                  : 'linux',
                 arch                : 'aarch64',
-                additionalNodeLabels: 'centos7',
+                dockerImage         : 'adoptopenjdk/centos7_build_image',
                 test                : [
                         nightly: false,
                         release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']

--- a/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
@@ -119,7 +119,7 @@ class Config8 {
         aarch64Linux  : [
                 os                  : 'linux',
                 arch                : 'aarch64',
-                additionalNodeLabels: 'centos7',
+                dockerImage         : 'adoptopenjdk/centos7_build_image',
                 test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk']
         ],
 


### PR DESCRIPTION
## LAND AFTER THE CPU RELEASES

This PR switches the aarch64 builds to use the centos7 dockerimage: https://hub.docker.com/repository/docker/adoptopenjdk/centos7_build_image

The agents are dynamically provisioned using the Amazon EC2 Jenkins plugin

Also added aarch64 to PR testing because we can spin up the agents very quickly