### PR TITLE
arm32: Build with gcc 7.5 on JDK8/arm32/HotSpot

### DIFF
--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -128,8 +128,8 @@ if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
     "$JDK_BOOT_DIR/bin/java" -version 2>&1 | sed 's/^/BOOT JDK: /'
 fi
 
-# Any version above 10
-if [ "$JAVA_FEATURE_VERSION" -gt 10 ] || [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]; then
+# Any version above 10, OpenJ9 or arm32 (See support#33 ref arm)
+if [ "$JAVA_FEATURE_VERSION" -gt 10 ] || [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ] || [ "${ARCHITECTURE}" == "arm" ]; then
     # If we have the RedHat devtoolset 7 installed, use gcc 7 from there, else /usr/local/gcc/bin
     if [ -r /usr/local/gcc/bin/gcc-7.5 ]; then
       export PATH=/usr/local/gcc/bin:$PATH


### PR DESCRIPTION
I am proposing pushing this into the July quarterly release this week since we cannot currently make https requests

Ref: https://github.com/AdoptOpenJDK/openjdk-support/issues/33#issuecomment-657340402

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>