### PR TITLE
fix mirror script

### DIFF
--- a/git-hg/jdk8u/merge.sh
+++ b/git-hg/jdk8u/merge.sh
@@ -143,7 +143,7 @@ function rebuildLocalRepo() {
     mkdir -p "$REPO"
     cd "$REPO"
     git clone $UPSTREAM_GIT_REPO .
-    git checkout master
+    git checkout master || git checkout -b master
 
     # Step 3 Setup remotes
     addRemotes

--- a/git-hg/jdk8u/merge.sh
+++ b/git-hg/jdk8u/merge.sh
@@ -247,7 +247,7 @@ commitId=$(git rev-list -n 1  $tag)
 cd "$REPO"
 git merge --abort || true
 git rebase --abort || true
-git checkout $workingBranch || git checkout -b $workingBranch
+git checkout $workingBranch
 
 # Get rid of existing tag that we are about to create
 if [ "$doTagging" == "true" ]; then

--- a/git-hg/jdk8u/merge.sh
+++ b/git-hg/jdk8u/merge.sh
@@ -247,7 +247,7 @@ commitId=$(git rev-list -n 1  $tag)
 cd "$REPO"
 git merge --abort || true
 git rebase --abort || true
-git checkout $workingBranch
+git checkout $workingBranch || git checkout -b $workingBranch
 
 # Get rid of existing tag that we are about to create
 if [ "$doTagging" == "true" ]; then

--- a/git-hg/jdk8u/merge.sh
+++ b/git-hg/jdk8u/merge.sh
@@ -10,7 +10,11 @@ doInit="false"
 doReset="false"
 doTagging="false"
 doUpdate="false"
-hgRepo="https://hg.openjdk.java.net/jdk8u/jdk8u"
+if [ -z ${HG_REPO} ]; then
+  hgRepo="https://hg.openjdk.java.net/jdk8u/jdk8u"
+else 
+  hgRepo="$HG_REPO"
+fi
 tag="jdk8u172-b08"
 workingBranch="master"
 

--- a/git-hg/jdk8u/updateRepo.sh
+++ b/git-hg/jdk8u/updateRepo.sh
@@ -10,7 +10,7 @@ source constants.sh
 cd "$REPO"
 if [ -d ".git" ];then
   git reset --hard
-  git checkout master
+  git checkout master || git checkout -b master
   git merge --abort || true
   git am --abort || true
 fi

--- a/git-hg/jdk8u/updateRepo.sh
+++ b/git-hg/jdk8u/updateRepo.sh
@@ -22,7 +22,7 @@ git fetch --all --no-tags
 if git rev-parse -q --verify "dev" ; then
   git checkout dev
 else
-  git checkout -b dev upstream/dev
+  git checkout -b dev upstream/dev || git checkout -b dev
 fi
 
 cd $SCRIPT_DIR


### PR DESCRIPTION
this ensures that the hg repo can be overridden for `aarch64`

switch https://ci.adoptopenjdk.net/view/git-mirrors/job/git-mirrors/job/git-hg-aarch64-jdk8u/ back to using master on merge