### PR TITLE
Remove master node from pipeline files

### DIFF
--- a/pipelines/build/openjdk10_pipeline.groovy
+++ b/pipelines/build/openjdk10_pipeline.groovy
@@ -13,30 +13,38 @@ limitations under the License.
 */
 
 def javaToBuild = "jdk10u"
+def scmVars = null
+Closure configureBuild = null
+def buildConfigurations = null
 
 node ("master") {
-    def scmVars = checkout scm
+    scmVars = checkout scm
     load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
-    Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
-    def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
+    configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
+    buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
 }
 
-configureBuild(
-    javaToBuild,
-    buildConfigurations,
-    targetConfigurations,
-    enableTests,
-    releaseType,
-    scmReference,
-    overridePublishName,
-    additionalConfigureArgs,
-    scmVars,
-    additionalBuildArgs,
-    overrideFileNameVersion,
-    cleanWorkspaceBeforeBuild,
-    adoptBuildNumber,
-    propagateFailures,
-    currentBuild,
-    this,
-    env
-).doBuild()
+if (scmVars != null && configureBuild != null && buildConfigurations != null) {
+    configureBuild(
+        javaToBuild,
+        buildConfigurations,
+        targetConfigurations,
+        enableTests,
+        releaseType,
+        scmReference,
+        overridePublishName,
+        additionalConfigureArgs,
+        scmVars,
+        additionalBuildArgs,
+        overrideFileNameVersion,
+        cleanWorkspaceBeforeBuild,
+        adoptBuildNumber,
+        propagateFailures,
+        currentBuild,
+        this,
+        env
+    ).doBuild()
+} else {
+    println "[ERROR] One or more setup parameters are null.\nscmVars = ${scmVars}\nconfigureBuild = ${configureBuild}\nbuildConfigurations = ${buildConfigurations}"
+    throw new Exception()
+}

--- a/pipelines/build/openjdk10_pipeline.groovy
+++ b/pipelines/build/openjdk10_pipeline.groovy
@@ -14,29 +14,27 @@ limitations under the License.
 
 def javaToBuild = "jdk10u"
 
-node ("master") {
-    def scmVars = checkout scm
-    load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
-    Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
-    def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
+def scmVars = checkout scm
+load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
+Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
+def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
 
-    configureBuild(
-            javaToBuild,
-            buildConfigurations,
-            targetConfigurations,
-            enableTests,
-            releaseType,
-            scmReference,
-            overridePublishName,
-            additionalConfigureArgs,
-            scmVars,
-            additionalBuildArgs,
-            overrideFileNameVersion,
-            cleanWorkspaceBeforeBuild,
-            adoptBuildNumber,
-            propagateFailures,
-            currentBuild,
-            this,
-            env
-    ).doBuild()
-}
+configureBuild(
+    javaToBuild,
+    buildConfigurations,
+    targetConfigurations,
+    enableTests,
+    releaseType,
+    scmReference,
+    overridePublishName,
+    additionalConfigureArgs,
+    scmVars,
+    additionalBuildArgs,
+    overrideFileNameVersion,
+    cleanWorkspaceBeforeBuild,
+    adoptBuildNumber,
+    propagateFailures,
+    currentBuild,
+    this,
+    env
+).doBuild()

--- a/pipelines/build/openjdk10_pipeline.groovy
+++ b/pipelines/build/openjdk10_pipeline.groovy
@@ -14,10 +14,12 @@ limitations under the License.
 
 def javaToBuild = "jdk10u"
 
-def scmVars = checkout scm
-load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
-Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
-def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
+node ("master") {
+    def scmVars = checkout scm
+    load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
+    Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
+    def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
+}
 
 configureBuild(
     javaToBuild,

--- a/pipelines/build/openjdk11_pipeline.groovy
+++ b/pipelines/build/openjdk11_pipeline.groovy
@@ -14,10 +14,12 @@ limitations under the License.
 
 def javaToBuild = "jdk11u"
 
-def scmVars = checkout scm
-load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
-Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
-def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
+node ("master") {
+    def scmVars = checkout scm
+    load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
+    Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
+    def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
+}
 
 configureBuild(
     javaToBuild,

--- a/pipelines/build/openjdk11_pipeline.groovy
+++ b/pipelines/build/openjdk11_pipeline.groovy
@@ -13,30 +13,38 @@ limitations under the License.
 */
 
 def javaToBuild = "jdk11u"
+def scmVars = null
+Closure configureBuild = null
+def buildConfigurations = null
 
 node ("master") {
-    def scmVars = checkout scm
+    scmVars = checkout scm
     load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
-    Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
-    def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
+    configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
+    buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
 }
 
-configureBuild(
-    javaToBuild,
-    buildConfigurations,
-    targetConfigurations,
-    enableTests,
-    releaseType,
-    scmReference,
-    overridePublishName,
-    additionalConfigureArgs,
-    scmVars,
-    additionalBuildArgs,
-    overrideFileNameVersion,
-    cleanWorkspaceBeforeBuild,
-    adoptBuildNumber,
-    propagateFailures,
-    currentBuild,
-    this,
-    env
-).doBuild()
+if (scmVars != null && configureBuild != null && buildConfigurations != null) {
+    configureBuild(
+        javaToBuild,
+        buildConfigurations,
+        targetConfigurations,
+        enableTests,
+        releaseType,
+        scmReference,
+        overridePublishName,
+        additionalConfigureArgs,
+        scmVars,
+        additionalBuildArgs,
+        overrideFileNameVersion,
+        cleanWorkspaceBeforeBuild,
+        adoptBuildNumber,
+        propagateFailures,
+        currentBuild,
+        this,
+        env
+    ).doBuild()
+} else {
+    println "[ERROR] One or more setup parameters are null.\nscmVars = ${scmVars}\nconfigureBuild = ${configureBuild}\nbuildConfigurations = ${buildConfigurations}"
+    throw new Exception()
+}

--- a/pipelines/build/openjdk11_pipeline.groovy
+++ b/pipelines/build/openjdk11_pipeline.groovy
@@ -14,29 +14,27 @@ limitations under the License.
 
 def javaToBuild = "jdk11u"
 
-node ("master") {
-    def scmVars = checkout scm
-    load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
-    Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
-    def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
+def scmVars = checkout scm
+load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
+Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
+def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
 
-    configureBuild(
-            javaToBuild,
-            buildConfigurations,
-            targetConfigurations,
-            enableTests,
-            releaseType,
-            scmReference,
-            overridePublishName,
-            additionalConfigureArgs,
-            scmVars,
-            additionalBuildArgs,
-            overrideFileNameVersion,
-            cleanWorkspaceBeforeBuild,
-            adoptBuildNumber,
-            propagateFailures,
-            currentBuild,
-            this,
-            env
-    ).doBuild()
-}
+configureBuild(
+    javaToBuild,
+    buildConfigurations,
+    targetConfigurations,
+    enableTests,
+    releaseType,
+    scmReference,
+    overridePublishName,
+    additionalConfigureArgs,
+    scmVars,
+    additionalBuildArgs,
+    overrideFileNameVersion,
+    cleanWorkspaceBeforeBuild,
+    adoptBuildNumber,
+    propagateFailures,
+    currentBuild,
+    this,
+    env
+).doBuild()

--- a/pipelines/build/openjdk12_pipeline.groovy
+++ b/pipelines/build/openjdk12_pipeline.groovy
@@ -13,30 +13,38 @@ limitations under the License.
 */
 
 def javaToBuild = "jdk12u"
+def scmVars = null
+Closure configureBuild = null
+def buildConfigurations = null
 
 node ("master") {
-    def scmVars = checkout scm
+    scmVars = checkout scm
     load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
-    Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
-    def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
+    configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
+    buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
 }
 
-configureBuild(
-    javaToBuild,
-    buildConfigurations,
-    targetConfigurations,
-    enableTests,
-    releaseType,
-    scmReference,
-    overridePublishName,
-    additionalConfigureArgs,
-    scmVars,
-    additionalBuildArgs,
-    overrideFileNameVersion,
-    cleanWorkspaceBeforeBuild,
-    adoptBuildNumber,
-    propagateFailures,
-    currentBuild,
-    this,
-    env
-).doBuild()
+if (scmVars != null && configureBuild != null && buildConfigurations != null) {
+    configureBuild(
+        javaToBuild,
+        buildConfigurations,
+        targetConfigurations,
+        enableTests,
+        releaseType,
+        scmReference,
+        overridePublishName,
+        additionalConfigureArgs,
+        scmVars,
+        additionalBuildArgs,
+        overrideFileNameVersion,
+        cleanWorkspaceBeforeBuild,
+        adoptBuildNumber,
+        propagateFailures,
+        currentBuild,
+        this,
+        env
+    ).doBuild()
+} else {
+    println "[ERROR] One or more setup parameters are null.\nscmVars = ${scmVars}\nconfigureBuild = ${configureBuild}\nbuildConfigurations = ${buildConfigurations}"
+    throw new Exception()
+}

--- a/pipelines/build/openjdk12_pipeline.groovy
+++ b/pipelines/build/openjdk12_pipeline.groovy
@@ -14,29 +14,27 @@ limitations under the License.
 
 def javaToBuild = "jdk12u"
 
-node ("master") {
-    def scmVars = checkout scm
-    load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
-    Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
-    def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
+def scmVars = checkout scm
+load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
+Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
+def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
 
-    configureBuild(
-            javaToBuild,
-            buildConfigurations,
-            targetConfigurations,
-            enableTests,
-            releaseType,
-            scmReference,
-            overridePublishName,
-            additionalConfigureArgs,
-            scmVars,
-            additionalBuildArgs,
-            overrideFileNameVersion,
-            cleanWorkspaceBeforeBuild,
-            adoptBuildNumber,
-            propagateFailures,
-            currentBuild,
-            this,
-            env
-    ).doBuild()
-}
+configureBuild(
+    javaToBuild,
+    buildConfigurations,
+    targetConfigurations,
+    enableTests,
+    releaseType,
+    scmReference,
+    overridePublishName,
+    additionalConfigureArgs,
+    scmVars,
+    additionalBuildArgs,
+    overrideFileNameVersion,
+    cleanWorkspaceBeforeBuild,
+    adoptBuildNumber,
+    propagateFailures,
+    currentBuild,
+    this,
+    env
+).doBuild()

--- a/pipelines/build/openjdk12_pipeline.groovy
+++ b/pipelines/build/openjdk12_pipeline.groovy
@@ -14,10 +14,12 @@ limitations under the License.
 
 def javaToBuild = "jdk12u"
 
-def scmVars = checkout scm
-load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
-Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
-def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
+node ("master") {
+    def scmVars = checkout scm
+    load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
+    Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
+    def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
+}
 
 configureBuild(
     javaToBuild,

--- a/pipelines/build/openjdk13_pipeline.groovy
+++ b/pipelines/build/openjdk13_pipeline.groovy
@@ -14,10 +14,12 @@ limitations under the License.
 
 def javaToBuild = "jdk13u"
 
-def scmVars = checkout scm
-load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
-Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
-def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
+node ("master") {
+    def scmVars = checkout scm
+    load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
+    Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
+    def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
+}
 
 configureBuild(
     javaToBuild,

--- a/pipelines/build/openjdk13_pipeline.groovy
+++ b/pipelines/build/openjdk13_pipeline.groovy
@@ -13,30 +13,38 @@ limitations under the License.
 */
 
 def javaToBuild = "jdk13u"
+def scmVars = null
+Closure configureBuild = null
+def buildConfigurations = null
 
 node ("master") {
-    def scmVars = checkout scm
+    scmVars = checkout scm
     load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
-    Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
-    def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
+    configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
+    buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
 }
 
-configureBuild(
-    javaToBuild,
-    buildConfigurations,
-    targetConfigurations,
-    enableTests,
-    releaseType,
-    scmReference,
-    overridePublishName,
-    additionalConfigureArgs,
-    scmVars,
-    additionalBuildArgs,
-    overrideFileNameVersion,
-    cleanWorkspaceBeforeBuild,
-    adoptBuildNumber,
-    propagateFailures,
-    currentBuild,
-    this,
-    env
-).doBuild()
+if (scmVars != null && configureBuild != null && buildConfigurations != null) {
+    configureBuild(
+        javaToBuild,
+        buildConfigurations,
+        targetConfigurations,
+        enableTests,
+        releaseType,
+        scmReference,
+        overridePublishName,
+        additionalConfigureArgs,
+        scmVars,
+        additionalBuildArgs,
+        overrideFileNameVersion,
+        cleanWorkspaceBeforeBuild,
+        adoptBuildNumber,
+        propagateFailures,
+        currentBuild,
+        this,
+        env
+    ).doBuild()
+} else {
+    println "[ERROR] One or more setup parameters are null.\nscmVars = ${scmVars}\nconfigureBuild = ${configureBuild}\nbuildConfigurations = ${buildConfigurations}"
+    throw new Exception()
+}

--- a/pipelines/build/openjdk13_pipeline.groovy
+++ b/pipelines/build/openjdk13_pipeline.groovy
@@ -14,29 +14,27 @@ limitations under the License.
 
 def javaToBuild = "jdk13u"
 
-node ("master") {
-    def scmVars = checkout scm
-    load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
-    Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
-    def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
+def scmVars = checkout scm
+load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
+Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
+def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
 
-    configureBuild(
-            javaToBuild,
-            buildConfigurations,
-            targetConfigurations,
-            enableTests,
-            releaseType,
-            scmReference,
-            overridePublishName,
-            additionalConfigureArgs,
-            scmVars,
-            additionalBuildArgs,
-            overrideFileNameVersion,
-            cleanWorkspaceBeforeBuild,
-            adoptBuildNumber,
-            propagateFailures,
-            currentBuild,
-            this,
-            env
-    ).doBuild()
-}
+configureBuild(
+    javaToBuild,
+    buildConfigurations,
+    targetConfigurations,
+    enableTests,
+    releaseType,
+    scmReference,
+    overridePublishName,
+    additionalConfigureArgs,
+    scmVars,
+    additionalBuildArgs,
+    overrideFileNameVersion,
+    cleanWorkspaceBeforeBuild,
+    adoptBuildNumber,
+    propagateFailures,
+    currentBuild,
+    this,
+    env
+).doBuild()

--- a/pipelines/build/openjdk14_pipeline.groovy
+++ b/pipelines/build/openjdk14_pipeline.groovy
@@ -14,10 +14,12 @@ limitations under the License.
 
 def javaToBuild = "jdk14u"
 
-def scmVars = checkout scm
-load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
-Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
-def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
+node ("master") {
+    def scmVars = checkout scm
+    load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
+    Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
+    def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
+}
 
 configureBuild(
     javaToBuild,

--- a/pipelines/build/openjdk14_pipeline.groovy
+++ b/pipelines/build/openjdk14_pipeline.groovy
@@ -13,30 +13,38 @@ limitations under the License.
 */
 
 def javaToBuild = "jdk14u"
+def scmVars = null
+Closure configureBuild = null
+def buildConfigurations = null
 
 node ("master") {
-    def scmVars = checkout scm
+    scmVars = checkout scm
     load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
-    Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
-    def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
+    configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
+    buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
 }
 
-configureBuild(
-    javaToBuild,
-    buildConfigurations,
-    targetConfigurations,
-    enableTests,
-    releaseType,
-    scmReference,
-    overridePublishName,
-    additionalConfigureArgs,
-    scmVars,
-    additionalBuildArgs,
-    overrideFileNameVersion,
-    cleanWorkspaceBeforeBuild,
-    adoptBuildNumber,
-    propagateFailures,
-    currentBuild,
-    this,
-    env
-).doBuild()
+if (scmVars != null && configureBuild != null && buildConfigurations != null) {
+    configureBuild(
+        javaToBuild,
+        buildConfigurations,
+        targetConfigurations,
+        enableTests,
+        releaseType,
+        scmReference,
+        overridePublishName,
+        additionalConfigureArgs,
+        scmVars,
+        additionalBuildArgs,
+        overrideFileNameVersion,
+        cleanWorkspaceBeforeBuild,
+        adoptBuildNumber,
+        propagateFailures,
+        currentBuild,
+        this,
+        env
+    ).doBuild()
+} else {
+    println "[ERROR] One or more setup parameters are null.\nscmVars = ${scmVars}\nconfigureBuild = ${configureBuild}\nbuildConfigurations = ${buildConfigurations}"
+    throw new Exception()
+}

--- a/pipelines/build/openjdk14_pipeline.groovy
+++ b/pipelines/build/openjdk14_pipeline.groovy
@@ -14,29 +14,27 @@ limitations under the License.
 
 def javaToBuild = "jdk14u"
 
-node ("master") {
-    def scmVars = checkout scm
-    load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
-    Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
-    def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
+def scmVars = checkout scm
+load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
+Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
+def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
 
-    configureBuild(
-            javaToBuild,
-            buildConfigurations,
-            targetConfigurations,
-            enableTests,
-            releaseType,
-            scmReference,
-            overridePublishName,
-            additionalConfigureArgs,
-            scmVars,
-            additionalBuildArgs,
-            overrideFileNameVersion,
-            cleanWorkspaceBeforeBuild,
-            adoptBuildNumber,
-            propagateFailures,
-            currentBuild,
-            this,
-            env
-    ).doBuild()
-}
+configureBuild(
+    javaToBuild,
+    buildConfigurations,
+    targetConfigurations,
+    enableTests,
+    releaseType,
+    scmReference,
+    overridePublishName,
+    additionalConfigureArgs,
+    scmVars,
+    additionalBuildArgs,
+    overrideFileNameVersion,
+    cleanWorkspaceBeforeBuild,
+    adoptBuildNumber,
+    propagateFailures,
+    currentBuild,
+    this,
+    env
+).doBuild()

--- a/pipelines/build/openjdk15_pipeline.groovy
+++ b/pipelines/build/openjdk15_pipeline.groovy
@@ -13,30 +13,38 @@ limitations under the License.
 */
 
 def javaToBuild = "jdk15"
+def scmVars = null
+Closure configureBuild = null
+def buildConfigurations = null
 
 node ("master") {
-    def scmVars = checkout scm
+    scmVars = checkout scm
     load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
-    Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
-    def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
+    configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
+    buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
 }
 
-configureBuild(
-    javaToBuild,
-    buildConfigurations,
-    targetConfigurations,
-    enableTests,
-    releaseType,
-    scmReference,
-    overridePublishName,
-    additionalConfigureArgs,
-    scmVars,
-    additionalBuildArgs,
-    overrideFileNameVersion,
-    cleanWorkspaceBeforeBuild,
-    adoptBuildNumber,
-    propagateFailures,
-    currentBuild,
-    this,
-    env
-).doBuild()
+if (scmVars != null && configureBuild != null && buildConfigurations != null) {
+    configureBuild(
+        javaToBuild,
+        buildConfigurations,
+        targetConfigurations,
+        enableTests,
+        releaseType,
+        scmReference,
+        overridePublishName,
+        additionalConfigureArgs,
+        scmVars,
+        additionalBuildArgs,
+        overrideFileNameVersion,
+        cleanWorkspaceBeforeBuild,
+        adoptBuildNumber,
+        propagateFailures,
+        currentBuild,
+        this,
+        env
+    ).doBuild()
+} else {
+    println "[ERROR] One or more setup parameters are null.\nscmVars = ${scmVars}\nconfigureBuild = ${configureBuild}\nbuildConfigurations = ${buildConfigurations}"
+    throw new Exception()
+}

--- a/pipelines/build/openjdk15_pipeline.groovy
+++ b/pipelines/build/openjdk15_pipeline.groovy
@@ -14,10 +14,12 @@ limitations under the License.
 
 def javaToBuild = "jdk15"
 
-def scmVars = checkout scm
-load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
-Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
-def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
+node ("master") {
+    def scmVars = checkout scm
+    load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
+    Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
+    def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
+}
 
 configureBuild(
     javaToBuild,

--- a/pipelines/build/openjdk15_pipeline.groovy
+++ b/pipelines/build/openjdk15_pipeline.groovy
@@ -14,29 +14,27 @@ limitations under the License.
 
 def javaToBuild = "jdk15"
 
-node ("master") {
-    def scmVars = checkout scm
-    load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
-    Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
-    def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
+def scmVars = checkout scm
+load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
+Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
+def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
 
-    configureBuild(
-            javaToBuild,
-            buildConfigurations,
-            targetConfigurations,
-            enableTests,
-            releaseType,
-            scmReference,
-            overridePublishName,
-            additionalConfigureArgs,
-            scmVars,
-            additionalBuildArgs,
-            overrideFileNameVersion,
-            cleanWorkspaceBeforeBuild,
-            adoptBuildNumber,
-            propagateFailures,
-            currentBuild,
-            this,
-            env
-    ).doBuild()
-}
+configureBuild(
+    javaToBuild,
+    buildConfigurations,
+    targetConfigurations,
+    enableTests,
+    releaseType,
+    scmReference,
+    overridePublishName,
+    additionalConfigureArgs,
+    scmVars,
+    additionalBuildArgs,
+    overrideFileNameVersion,
+    cleanWorkspaceBeforeBuild,
+    adoptBuildNumber,
+    propagateFailures,
+    currentBuild,
+    this,
+    env
+).doBuild()

--- a/pipelines/build/openjdk16_pipeline.groovy
+++ b/pipelines/build/openjdk16_pipeline.groovy
@@ -14,29 +14,27 @@ limitations under the License.
 
 def javaToBuild = "jdk"
 
-node ("master") {
-    def scmVars = checkout scm
-    load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
-    Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
-    def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/jdk16_pipeline_config.groovy"
+def scmVars = checkout scm
+load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
+Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
+def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/jdk16_pipeline_config.groovy"
 
-    configureBuild(
-            javaToBuild,
-            buildConfigurations,
-            targetConfigurations,
-            enableTests,
-            releaseType,
-            scmReference,
-            overridePublishName,
-            additionalConfigureArgs,
-            scmVars,
-            additionalBuildArgs,
-            overrideFileNameVersion,
-            cleanWorkspaceBeforeBuild,
-            adoptBuildNumber,
-            propagateFailures,
-            currentBuild,
-            this,
-            env
-    ).doBuild()
-}
+configureBuild(
+    javaToBuild,
+    buildConfigurations,
+    targetConfigurations,
+    enableTests,
+    releaseType,
+    scmReference,
+    overridePublishName,
+    additionalConfigureArgs,
+    scmVars,
+    additionalBuildArgs,
+    overrideFileNameVersion,
+    cleanWorkspaceBeforeBuild,
+    adoptBuildNumber,
+    propagateFailures,
+    currentBuild,
+    this,
+    env
+).doBuild()

--- a/pipelines/build/openjdk16_pipeline.groovy
+++ b/pipelines/build/openjdk16_pipeline.groovy
@@ -14,10 +14,12 @@ limitations under the License.
 
 def javaToBuild = "jdk"
 
-def scmVars = checkout scm
-load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
-Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
-def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/jdk16_pipeline_config.groovy"
+node ("master") {
+    def scmVars = checkout scm
+    load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
+    Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
+    def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
+}
 
 configureBuild(
     javaToBuild,

--- a/pipelines/build/openjdk16_pipeline.groovy
+++ b/pipelines/build/openjdk16_pipeline.groovy
@@ -21,7 +21,7 @@ node ("master") {
     scmVars = checkout scm
     load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
     configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
-    buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
+    buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/jdk16_pipeline_config.groovy"
 }
 
 if (scmVars != null && configureBuild != null && buildConfigurations != null) {

--- a/pipelines/build/openjdk16_pipeline.groovy
+++ b/pipelines/build/openjdk16_pipeline.groovy
@@ -13,30 +13,38 @@ limitations under the License.
 */
 
 def javaToBuild = "jdk"
+def scmVars = null
+Closure configureBuild = null
+def buildConfigurations = null
 
 node ("master") {
-    def scmVars = checkout scm
+    scmVars = checkout scm
     load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
-    Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
-    def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
+    configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
+    buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
 }
 
-configureBuild(
-    javaToBuild,
-    buildConfigurations,
-    targetConfigurations,
-    enableTests,
-    releaseType,
-    scmReference,
-    overridePublishName,
-    additionalConfigureArgs,
-    scmVars,
-    additionalBuildArgs,
-    overrideFileNameVersion,
-    cleanWorkspaceBeforeBuild,
-    adoptBuildNumber,
-    propagateFailures,
-    currentBuild,
-    this,
-    env
-).doBuild()
+if (scmVars != null && configureBuild != null && buildConfigurations != null) {
+    configureBuild(
+        javaToBuild,
+        buildConfigurations,
+        targetConfigurations,
+        enableTests,
+        releaseType,
+        scmReference,
+        overridePublishName,
+        additionalConfigureArgs,
+        scmVars,
+        additionalBuildArgs,
+        overrideFileNameVersion,
+        cleanWorkspaceBeforeBuild,
+        adoptBuildNumber,
+        propagateFailures,
+        currentBuild,
+        this,
+        env
+    ).doBuild()
+} else {
+    println "[ERROR] One or more setup parameters are null.\nscmVars = ${scmVars}\nconfigureBuild = ${configureBuild}\nbuildConfigurations = ${buildConfigurations}"
+    throw new Exception()
+}

--- a/pipelines/build/openjdk8_pipeline.groovy
+++ b/pipelines/build/openjdk8_pipeline.groovy
@@ -14,10 +14,12 @@ limitations under the License.
 
 def javaToBuild = "jdk8u"
 
-def scmVars = checkout scm
-load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
-Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
-def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
+node ("master") {
+    def scmVars = checkout scm
+    load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
+    Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
+    def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
+}
 
 configureBuild(
     javaToBuild,

--- a/pipelines/build/openjdk8_pipeline.groovy
+++ b/pipelines/build/openjdk8_pipeline.groovy
@@ -14,29 +14,27 @@ limitations under the License.
 
 def javaToBuild = "jdk8u"
 
-node ("master") {
-    def scmVars = checkout scm
-    load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
-    Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
-    def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
-    
-    configureBuild(
-            javaToBuild,
-            buildConfigurations,
-            targetConfigurations,
-            enableTests,
-            releaseType,
-            scmReference,
-            overridePublishName,
-            additionalConfigureArgs,
-            scmVars,
-            additionalBuildArgs,
-            overrideFileNameVersion,
-            cleanWorkspaceBeforeBuild,
-            adoptBuildNumber,
-            propagateFailures,
-            currentBuild,
-            this,
-            env
-    ).doBuild()
-}
+def scmVars = checkout scm
+load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
+Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
+def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
+
+configureBuild(
+    javaToBuild,
+    buildConfigurations,
+    targetConfigurations,
+    enableTests,
+    releaseType,
+    scmReference,
+    overridePublishName,
+    additionalConfigureArgs,
+    scmVars,
+    additionalBuildArgs,
+    overrideFileNameVersion,
+    cleanWorkspaceBeforeBuild,
+    adoptBuildNumber,
+    propagateFailures,
+    currentBuild,
+    this,
+    env
+).doBuild()

--- a/pipelines/build/openjdk8_pipeline.groovy
+++ b/pipelines/build/openjdk8_pipeline.groovy
@@ -13,30 +13,38 @@ limitations under the License.
 */
 
 def javaToBuild = "jdk8u"
+def scmVars = null
+Closure configureBuild = null
+def buildConfigurations = null
 
 node ("master") {
-    def scmVars = checkout scm
+    scmVars = checkout scm
     load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
-    Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
-    def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
+    configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
+    buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
 }
 
-configureBuild(
-    javaToBuild,
-    buildConfigurations,
-    targetConfigurations,
-    enableTests,
-    releaseType,
-    scmReference,
-    overridePublishName,
-    additionalConfigureArgs,
-    scmVars,
-    additionalBuildArgs,
-    overrideFileNameVersion,
-    cleanWorkspaceBeforeBuild,
-    adoptBuildNumber,
-    propagateFailures,
-    currentBuild,
-    this,
-    env
-).doBuild()
+if (scmVars != null && configureBuild != null && buildConfigurations != null) {
+    configureBuild(
+        javaToBuild,
+        buildConfigurations,
+        targetConfigurations,
+        enableTests,
+        releaseType,
+        scmReference,
+        overridePublishName,
+        additionalConfigureArgs,
+        scmVars,
+        additionalBuildArgs,
+        overrideFileNameVersion,
+        cleanWorkspaceBeforeBuild,
+        adoptBuildNumber,
+        propagateFailures,
+        currentBuild,
+        this,
+        env
+    ).doBuild()
+} else {
+    println "[ERROR] One or more setup parameters are null.\nscmVars = ${scmVars}\nconfigureBuild = ${configureBuild}\nbuildConfigurations = ${buildConfigurations}"
+    throw new Exception()
+}

--- a/pipelines/build/openjdk9_pipeline.groovy
+++ b/pipelines/build/openjdk9_pipeline.groovy
@@ -14,29 +14,27 @@ limitations under the License.
 
 def javaToBuild = "jdk9u"
 
-node ("master") {
-    def scmVars = checkout scm
-    load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
-    Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
-    def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
+def scmVars = checkout scm
+load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
+Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
+def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
 
-    configureBuild(
-            javaToBuild,
-            buildConfigurations,
-            targetConfigurations,
-            enableTests,
-            releaseType,
-            scmReference,
-            overridePublishName,
-            additionalConfigureArgs,
-            scmVars,
-            additionalBuildArgs,
-            overrideFileNameVersion,
-            cleanWorkspaceBeforeBuild,
-            adoptBuildNumber,
-            propagateFailures,
-            currentBuild,
-            this,
-            env
-    ).doBuild()
-}
+configureBuild(
+    javaToBuild,
+    buildConfigurations,
+    targetConfigurations,
+    enableTests,
+    releaseType,
+    scmReference,
+    overridePublishName,
+    additionalConfigureArgs,
+    scmVars,
+    additionalBuildArgs,
+    overrideFileNameVersion,
+    cleanWorkspaceBeforeBuild,
+    adoptBuildNumber,
+    propagateFailures,
+    currentBuild,
+    this,
+    env
+).doBuild()

--- a/pipelines/build/openjdk9_pipeline.groovy
+++ b/pipelines/build/openjdk9_pipeline.groovy
@@ -13,30 +13,38 @@ limitations under the License.
 */
 
 def javaToBuild = "jdk9u"
+def scmVars = null
+Closure configureBuild = null
+def buildConfigurations = null
 
 node ("master") {
-    def scmVars = checkout scm
+    scmVars = checkout scm
     load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
-    Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
-    def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
+    configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
+    buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
 }
 
-configureBuild(
-    javaToBuild,
-    buildConfigurations,
-    targetConfigurations,
-    enableTests,
-    releaseType,
-    scmReference,
-    overridePublishName,
-    additionalConfigureArgs,
-    scmVars,
-    additionalBuildArgs,
-    overrideFileNameVersion,
-    cleanWorkspaceBeforeBuild,
-    adoptBuildNumber,
-    propagateFailures,
-    currentBuild,
-    this,
-    env
-).doBuild()
+if (scmVars != null && configureBuild != null && buildConfigurations != null) {
+    configureBuild(
+        javaToBuild,
+        buildConfigurations,
+        targetConfigurations,
+        enableTests,
+        releaseType,
+        scmReference,
+        overridePublishName,
+        additionalConfigureArgs,
+        scmVars,
+        additionalBuildArgs,
+        overrideFileNameVersion,
+        cleanWorkspaceBeforeBuild,
+        adoptBuildNumber,
+        propagateFailures,
+        currentBuild,
+        this,
+        env
+    ).doBuild()
+} else {
+    println "[ERROR] One or more setup parameters are null.\nscmVars = ${scmVars}\nconfigureBuild = ${configureBuild}\nbuildConfigurations = ${buildConfigurations}"
+    throw new Exception()
+}

--- a/pipelines/build/openjdk9_pipeline.groovy
+++ b/pipelines/build/openjdk9_pipeline.groovy
@@ -14,10 +14,12 @@ limitations under the License.
 
 def javaToBuild = "jdk9u"
 
-def scmVars = checkout scm
-load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
-Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
-def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
+node ("master") {
+    def scmVars = checkout scm
+    load "${WORKSPACE}/pipelines/build/common/import_lib.groovy"
+    Closure configureBuild = load "${WORKSPACE}/pipelines/build/common/build_base_file.groovy"
+    def buildConfigurations = load "${WORKSPACE}/pipelines/jobs/configurations/${javaToBuild}_pipeline_config.groovy"
+}
 
 configureBuild(
     javaToBuild,


### PR DESCRIPTION
* Stops the pipelines from holding up a master executor for the whole build

Signed-off-by: Morgan Davies <morgan.davies@ibm.com>