### PR TITLE
docker: Refactor of buildDocker.sh

### DIFF
--- a/docker/buildDocker.sh
+++ b/docker/buildDocker.sh
@@ -1,13 +1,30 @@
 #!/bin/bash
 set -u
 
-jdkVersion=''
-bootDir=''
-buildVariant="hotspot"
+BOOTDIR=''
+VARIANT="hotspot"
 useEclipseOpenJ9DockerFiles=false
-cleanWorkspace=false
+CLEAN=false
+WORKSPACE=${PWD}
+JDK_VERSION=
+JDK_MAX=
+JDK_GA=
 
-#takes in all arguments to determine script options
+# shellcheck disable=SC2002 # Disable UUOC error
+setJDKVars() {
+	wget -q https://api.adoptopenjdk.net/v3/info/available_releases
+	JDK_MAX=$(cat available_releases \
+		| grep 'tip_version' \
+		| cut -d':' -f 2 \
+		| sed 's/,//g; s/ //g')
+	JDK_GA=$(cat available_releases \
+		| grep 'most_recent_feature_release' \
+		| cut -d':' -f 2 \
+		| sed 's/,//g; s/ //g')
+	rm available_releases
+}
+
+# Takes in all arguments to determine script options
 parseCommandLineArgs()
 {
 	if [ $# -lt 1 ]; then
@@ -19,18 +36,22 @@ parseCommandLineArgs()
 			local opt="$1";
 			shift;
 			case "$opt" in
-				"--all" | "-a" )
-					jdkVersion="all";;
 				"--clean" | "-c" )
-					cleanWorkspace=true;;
+					CLEAN=true;;
 				"--version" | "-v" )
-					jdkVersion="$1"; shift;;
+					if [ $1 == "jdk" ]; then
+	  					JDK_VERSION=$JDK_MAX
+					else
+	  					JDK_VERSION=$(echo $1 | tr -d [:alpha:])
+        				fi
+					checkJDK
+					shift;;
 				"--jdk-boot-dir" | "-J")
-					bootDir="$1"; shift;;
+					BOOTDIR="$1"; shift;;
 				"--openj9" | "-j9")
-					buildVariant="openj9";;
+					VARIANT="openj9";;
 				"--use-eclipse-docker-files" | "-e" )
-					useEclipseOpenJ9DockerFiles=true; buildVariant="eclipse";;
+					useEclipseOpenJ9DockerFiles=true; VARIANT="eclipse";;
 				"--help" | "-h" )
 					usage; exit 0;;
 				*) echo >&2 "Invalid option: ${opt}"; echo "This option was unrecognised."; usage; exit 1;;
@@ -43,135 +64,102 @@ parseCommandLineArgs()
 usage()
 {
 	echo
-	echo "Usage: ./buildDocker.sh	--all|-a 				Build all support JDK versions"
-	echo "			--version|-v 				Build the specified JDK version"
-	echo "			--clean | -c				Clean the old workspace"
+	echo "Usage: ./buildDocker.sh	 --version|-v                            Build the specified JDK version"
+	echo "			--clean | -c				Clean old generated dockerfiles and the old workspace"
 	echo "			--jdk-boot-dir|-J			Specify the boot JDK directory"
 	echo "			--openj9|-j9				Builds using OpenJ9 instead of Hotspot"
 	echo "			--use-eclipse-docker-files|-e		Builds the specified jdk using the Eclipse Openj9 dockerfiles"
 	echo
 }
 
-checkJDKVersion()
-{
-	case "$jdkVersion" in
-		"jdk8u" | "jdk8" | "8" | "8u" )
-			jdkVersion="jdk8u";;
-		"jdk9u" | "jdk9" | "9" | "9u" )
-			jdkVersion="jdk9u";;
-		"jdk10u" | "jdk10" | "10" | "10u" )
-			jdkVersion="jdk10u";;
-		"jdk11u" | "jdk11" | "11" | "11u" )
-			jdkVersion="jdk11u";;
-		"jdk12u" | "jdk12" | "12" | "12u" )
-			jdkVersion="jdk12u";;
-		"jdk13u" | "jdk13" | "13" | "13u" )
-			jdkVersion="jdk13u";;
-                "jdk14u" | "jdk14" | "14" | "14u" )
-                        jdkVersion="jdk14";;
-                "jdk" | "jdknext" )
-                        jdkVersion="jdk";;
-		"all" )
-			jdkVersion="jdk8u jdk9u jdk10u jdk11u jdk12u jdk13u jdk14u jdk";;
-		*)
-			echo "Not a valid JDK Version" ; jdkVersionList; exit 1;;
-	esac
-}
-
-jdkVersionList()
-{
-	echo
-	echo "Valid JDK versions :
-		- jdk8u
-		- jdk9u
-		- jdk10u
-		- jdk11u
-		- jdk12u
-		- jdk13u
-		- jdk14u
-		- jdk"
+checkJDK() {
+  if ! ((JDK_VERSION >= 8 && JDK_VERSION <= JDK_MAX)); then
+    echo "Please input a JDK between 8 & ${JDK_MAX}, or 'jdk'"
+    exit 1
+  fi
 }
 
 checkArgs()
 {
-	# Sets WORKSPACE to home if WORKSPACE is empty or unbounded
-	if [ ! -n "${WORKSPACE:-}" ]; then
-        	echo "WORKSPACE not found, setting it as environment variable 'HOME'"
-        	WORKSPACE=$HOME
+	# ${WORKSPACE##*/} returns the name of the current dir
+	if [ ${WORKSPACE##*/} != "docker" ]; then
+		echo "Unable to run script from : $WORKSPACE"
+		echo "The script must be run from openjdk-build/docker/"
+		exit 1
 	fi
-	if [ "$cleanWorkspace" == true ]; then
-		echo "Cleaning workspace"
-		rm -rf $WORKSPACE/DockerBuildFolder/$jdkVersion-$buildVariant
+	if [ "$CLEAN" == true ]; then
+		echo "Removing all jdkXX folders"
+		rm -rf $WORKSPACE/jdk*
+		echo "Removing old workspace folder"
+		rm -rf $WORKSPACE/workspace
+		echo "Removing old EclipseDockerfiles folder"
+		rm -rf $WORKSPACE/EclipseDockerfiles
 	fi
 }
 
 useEclipseOpenJ9DockerFiles()
 {
-	mkdir -p $WORKSPACE/DockerBuildFolder/$jdkVersion-$buildVariant/EclipseDockerfiles
-	cd $WORKSPACE/DockerBuildFolder/$jdkVersion-$buildVariant/EclipseDockerfiles
+	local dockerfileDir="$WORKSPACE/EclipseDockerfiles"
+	local jdk="jdk"
+
+	mkdir -p $dockerfileDir
+	cd $dockerfileDir
 	wget https://raw.githubusercontent.com/eclipse/openj9/master/buildenv/docker/mkdocker.sh
 	chmod +x mkdocker.sh
 	# Generate an Ubuntu1804 Dockerfile using mkdocker.sh
-	$WORKSPACE/DockerBuildFolder/$jdkVersion-$buildVariant/EclipseDockerfiles/mkdocker.sh --dist=ubuntu --version=18 --print >> $WORKSPACE/DockerBuildFolder/$jdkVersion-$buildVariant/EclipseDockerfiles/Dockerfile
+	$dockerfileDir/mkdocker.sh --dist=ubuntu --version=18 --print >> $dockerfileDir/Dockerfile
 	
 	# This Dockerfile requires an ssh key, authorized_key and known_hosts file to build
-	ssh-keygen -q -f id_rsa -t rsa -N ''
-	cat id_rsa.pub >> authorized_keys
-	ssh-keyscan github.com >> $PWD/known_hosts
+	ssh-keygen -q -f $dockerfileDir/id_rsa -t rsa -N ''
+	cat id_rsa.pub >> $dockerfileDir/authorized_keys
+	ssh-keyscan github.com >> $dockerfileDir/known_hosts
 
-	# ${jdk%?} will remove the 'u' from 'jdkXXu'.
-	for jdk in $jdkVersion
-	do
-		if [ ${jdk} != "jdk" ]; then
-			jdk=${jdk%?}
-		fi
-		eclipseDockerCommands ${jdk}
-	done
+	if [ $JDK_VERSION != $JDK_MAX ]; then
+        	jdk="jdk${JDK_VERSION}"
+	fi
+	eclipseDockerCommands ${jdk}
 }
 
 eclipseDockerCommands()
 {
 	local jdk=$1
-	docker build -t ${jdk}-${buildVariant}-dfc -f Dockerfile .
-	docker run -it -u root -d --name=${jdk}-${buildVariant} ${jdk}-${buildVariant}-dfc
-	docker exec -u root -i ${jdk}-${buildVariant} sh -c "git clone https://github.com/ibmruntimes/openj9-openjdk-${jdk}"
-	docker exec -u root -i ${jdk}-${buildVariant} sh -c "cd openj9-openjdk-${jdk} && bash ./get_source.sh && bash ./configure --with-freemarker-jar=/root/freemarker.jar && make all"
-	docker stop ${jdk}-${buildVariant}
-	docker rm ${jdk}-${buildVariant}
-	docker rmi ${jdk}-${buildVariant}-dfc
+	local dockerImage="${jdk}-${VARIANT}-dfc"
+	local dockerContainer="${jdk}-${VARIANT}"
+
+	docker build -t ${dockerImage} -f Dockerfile .
+	docker run -it -u root -d --name=${dockerContainer} ${dockerImage}
+	docker exec -u root -i ${dockerContainer} sh -c "git clone https://github.com/ibmruntimes/openj9-openjdk-${jdk}"
+	docker exec -u root -i ${dockerContainer} sh -c "cd openj9-openjdk-${jdk} && bash ./get_source.sh && bash ./configure --with-freemarker-jar=/root/freemarker.jar && make all"
+	docker stop ${dockerContainer}
+	docker rm ${dockerContainer}
+	docker rmi ${dockerImage}
 }
 
 buildDocker()
 {
 	local commandString="./makejdk-any-platform.sh --docker --clean-docker-build"
-	if [ -n "$bootDir" ]; then
-		commandString="$commandString -J $bootDir"
+	local jdk="jdk"
+
+	# Pass jdkXXu to makejdk-any-platform.sh where possible
+	if ((JDK_VERSION != JDK_MAX && JDK_VERSION <= JDK_GA )); then
+		jdk="jdk${JDK_VERSION}u"
+	elif ((JDK_VERSION != JDK_MAX && JDK_VERSION > JDK_GA )); then
+		jdk="jdk${JDK_VERSION}"
 	fi
-	if [[ "$buildVariant" == "openj9" ]]; then
+	if [ -n "$BOOTDIR" ]; then
+		commandString="$commandString -J $BOOTDIR"
+	fi
+	if [[ "$VARIANT" == "openj9" ]]; then
 		commandString="$commandString --build-variant openj9"
 	fi
-	for jdk in $jdkVersion
-	do
-		echo "$commandString $jdk being executed"
-		cd $WORKSPACE/DockerBuildFolder/$jdk-$buildVariant && $commandString $jdk
-	done
+	echo "$commandString $jdk being executed"
+	cd "$WORKSPACE/.." && $commandString $jdk
 }
 
-setupGit()
-{
-	if [ ! -d "$WORKSPACE/DockerBuildFolder/$jdkVersion-$buildVariant/docker" ]; then
-		git clone https://github.com/adoptopenjdk/openjdk-build $WORKSPACE/DockerBuildFolder/$jdkVersion-$buildVariant
-	else
-		cd $WORKSPACE/DockerBuildFolder/$jdkVersion-$buildVariant
-		git pull
-	fi
-}
+setJDKVars
 parseCommandLineArgs $@
-checkJDKVersion
-mkdir -p $WORKSPACE/DockerBuildFolder/$jdkVersion-$buildVariant
 if [[ "$useEclipseOpenJ9DockerFiles" == "true" ]]; then
 	useEclipseOpenJ9DockerFiles
 else
-	setupGit
 	buildDocker
 fi

--- a/docker/buildDocker.sh
+++ b/docker/buildDocker.sh
@@ -13,14 +13,8 @@ JDK_GA=
 # shellcheck disable=SC2002 # Disable UUOC error
 setJDKVars() {
 	wget -q https://api.adoptopenjdk.net/v3/info/available_releases
-	JDK_MAX=$(cat available_releases \
-		| grep 'tip_version' \
-		| cut -d':' -f 2 \
-		| sed 's/,//g; s/ //g')
-	JDK_GA=$(cat available_releases \
-		| grep 'most_recent_feature_release' \
-		| cut -d':' -f 2 \
-		| sed 's/,//g; s/ //g')
+	JDK_MAX=$(awk -F: '/tip_version/{gsub("[, ]","",$2); print$2}' < available_releases)
+	JDK_GA=$(awk -F: '/most_recent_feature_release/{gsub("[, ]","",$2); print$2}' < available_releases)
 	rm available_releases
 }
 

--- a/docker/buildDocker.sh
+++ b/docker/buildDocker.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -u
 
-BOOTDIR=''
+BOOTDIR=""
 VARIANT="hotspot"
 useEclipseOpenJ9DockerFiles=false
 CLEAN=false
@@ -51,7 +51,7 @@ parseCommandLineArgs()
 				"--openj9" | "-j9")
 					VARIANT="openj9";;
 				"--use-eclipse-docker-files" | "-e" )
-					useEclipseOpenJ9DockerFiles=true; VARIANT="eclipse";;
+					useEclipseOpenJ9DockerFiles=true; VARIANT="eclipsei_openj9";;
 				"--help" | "-h" )
 					usage; exit 0;;
 				*) echo >&2 "Invalid option: ${opt}"; echo "This option was unrecognised."; usage; exit 1;;
@@ -75,6 +75,7 @@ usage()
 checkJDK() {
   if ! ((JDK_VERSION >= 8 && JDK_VERSION <= JDK_MAX)); then
     echo "Please input a JDK between 8 & ${JDK_MAX}, or 'jdk'"
+    echo "i.e. The following formats will work for jdk8: 'jdk8u', 'jdk8' , '8'"
     exit 1
   fi
 }


### PR DESCRIPTION
Ref: 
https://ci.adoptopenjdk.net/view/Tooling/job/DockerfileCheck/159/
https://ci.adoptopenjdk.net/view/Tooling/job/DockerfileCheck/162/
(The job for both of these runs had the config changed to run from this branch to test it)

A big refactor of `buildDocker.sh` changing the following:
- Rename variables, replace duplicated file paths with variables, add whitespace where it makes the code more readable
- Use the same logic in `dockerfile-generator.sh` ( using the API ) to set `JDK_MAX` and `JDK_GA`, so the script doesn't have to be changed in the future to add in later JDKs.
- The script runs within the openjdk-build directory it's executed, instead of re-cloning the openjdk-build repository again (requested by @sxa )
- Removed the `all` option as it seemed superfluous.