### PR TITLE
Adjust faked version string on cross-compiled RISC-V builds

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -517,9 +517,9 @@ printJavaVersionString()
        # This is a temporary plausible solution in the absence of another fix
        local jdkversion=$(getOpenJdkVersion)
        cat << EOT > "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/version.txt"
-openjdk version "${jdkversion%%+*}-internal" 2020-05-22
-OpenJDK Runtime Environment AdoptOpenJDK (build ${jdkversion%%+*}-internal+0-adhoc.jenkins.openj9-openjdk-jdk11)
-Eclipse OpenJ9 VM AdoptOpenJDK (build master-000000000, JRE 11 Linux riscv-64-Bit Compressed References 20200505_46 (JIT disabled, AOT disabled)
+openjdk version "${jdkversion%%+*}" "$(date +%Y-%m-%d)"
+OpenJDK Runtime Environment AdoptOpenJDK (build ${jdkversion%%+*}+0-$(date +%Y%m%d%H%M))
+Eclipse OpenJ9 VM AdoptOpenJDK (build master-000000000, JRE 11 Linux riscv-64-Bit Compressed References $(date +%Y%m%d)_00 (JIT disabled, AOT disabled)
 OpenJ9   - 000000000
 OMR      - 000000000
 JCL      - 000000000 based on ${jdkversion})


### PR DESCRIPTION
This should help the APi order these correctly. At the moment as the result of the `-internal` suffix the `pre` string in [VersionInfo.groovy](https://github.com/AdoptOpenJDK/openjdk-build/blob/master/pipelines/library/src/common/VersionInfo.groovy#L100) is causing them to be sorted in an inconsistent manner.

This also updates the date field in the output to be current, although I don't think that particular information is actively used fo the sort order.