### PR TITLE
Re-enable ccache as I don't think original reasons still hold

### DIFF
--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -147,6 +147,10 @@ then
   export BUILD_ARGS="${BUILD_ARGS} -r https://github.com/AdoptOpenJDK/openjdk-aarch64-jdk8u"
 fi
 
+if which ccache 2> /dev/null; then
+  export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --enable-ccache"
+fi
+
 if [ "${ARCHITECTURE}" == "riscv64" ]
 then
 	echo RISCV cross-compilation ... Downloading latest nightly OpenJ9/x64 as build JDK

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -32,10 +32,10 @@ class Config11 {
                         release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external', 'special.functional']
                 ],
                 configureArgs       : [
-                        "openj9"      : '--disable-ccache --enable-jitserver --enable-dtrace=auto',
-                        "hotspot"     : '--disable-ccache --enable-dtrace=auto',
-                        "corretto"    : '--disable-ccache --enable-dtrace=auto',
-                        "SapMachine"  : '--disable-ccache --enable-dtrace=auto'
+                        "openj9"      : '--enable-jitserver --enable-dtrace=auto',
+                        "hotspot"     : '--enable-dtrace=auto',
+                        "corretto"    : '--enable-dtrace=auto',
+                        "SapMachine"  : '--enable-dtrace=auto'
                 ]
         ],
 
@@ -92,7 +92,7 @@ class Config11 {
                 os                  : 'linux',
                 arch                : 's390x',
                 test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
-                configureArgs       : '--disable-ccache --enable-dtrace=auto'
+                configureArgs       : '--enable-dtrace=auto'
         ],
 
         sparcv9Solaris    : [
@@ -107,8 +107,8 @@ class Config11 {
                 arch                : 'ppc64le',
                 test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
                 configureArgs       : [
-                        "hotspot"     : '--disable-ccache --enable-dtrace=auto',
-                        "openj9"      : '--disable-ccache --enable-dtrace=auto --enable-jitserver'
+                        "hotspot"     : '--enable-dtrace=auto',
+                        "openj9"      : '--enable-dtrace=auto --enable-jitserver'
                 ]
 
         ],
@@ -147,21 +147,21 @@ class Config11 {
                 arch                 : 'x64',
                 test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
                 additionalFileNameTag: "linuxXL",
-                configureArgs        : '--with-noncompressedrefs --disable-ccache --enable-jitserver --enable-dtrace=auto'
+                configureArgs        : '--with-noncompressedrefs --enable-jitserver --enable-dtrace=auto'
         ],
         s390xLinuxXL    : [
                 os                   : 'linux',
                 arch                 : 's390x',
                 test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
                 additionalFileNameTag: "linuxXL",
-                configureArgs        : '--with-noncompressedrefs --disable-ccache --enable-dtrace=auto'
+                configureArgs        : '--with-noncompressedrefs --enable-dtrace=auto'
         ],
         ppc64leLinuxXL    : [
                 os                   : 'linux',
                 arch                 : 'ppc64le',
                 test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
                 additionalFileNameTag: "linuxXL",
-                configureArgs        : '--with-noncompressedrefs --disable-ccache --enable-dtrace=auto --enable-jitserver'
+                configureArgs        : '--with-noncompressedrefs --enable-dtrace=auto --enable-jitserver'
         ],
         aarch64LinuxXL    : [
                 os                   : 'linux',
@@ -169,7 +169,7 @@ class Config11 {
                 arch                 : 'aarch64',
                 test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
                 additionalFileNameTag: "linuxXL",
-                configureArgs        : '--with-noncompressedrefs --disable-ccache --enable-dtrace=auto'
+                configureArgs        : '--with-noncompressedrefs --enable-dtrace=auto'
         ],
         riscv64Linux      :  [
                 os                   : 'linux',

--- a/pipelines/jobs/configurations/jdk15_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk15_pipeline_config.groovy
@@ -23,8 +23,8 @@ class Config15 {
                         release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external', 'special.functional']
                 ],
                 configureArgs       : [
-                        "openj9"      : '--disable-ccache --enable-dtrace --enable-jitserver',
-                        "hotspot"     : '--disable-ccache --enable-dtrace'
+                        "openj9"      : '--enable-dtrace --enable-jitserver',
+                        "hotspot"     : '--enable-dtrace'
                 ]
         ],
 
@@ -65,7 +65,7 @@ class Config15 {
                         nightly: false,
                         release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
                 ],
-                configureArgs       : '--disable-ccache --enable-dtrace'
+                configureArgs       : '--enable-dtrace'
         ],
 
         ppc64leLinux    : [
@@ -76,8 +76,8 @@ class Config15 {
                         release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
                 ],
                 configureArgs       : [
-                        "hotspot"     : '--disable-ccache --enable-dtrace',
-                        "openj9"      : '--disable-ccache --enable-dtrace --enable-jitserver'
+                        "hotspot"     : '--enable-dtrace',
+                        "openj9"      : '--enable-dtrace --enable-jitserver'
                 ]
 
         ],

--- a/pipelines/jobs/configurations/jdk16_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk16_pipeline_config.groovy
@@ -23,8 +23,8 @@ class Config16 {
                         release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external', 'special.functional']
                 ],
                 configureArgs       : [
-                        "openj9"      : '--disable-ccache --enable-dtrace --enable-jitserver',
-                        "hotspot"     : '--disable-ccache --enable-dtrace'
+                        "openj9"      : '--enable-dtrace --enable-jitserver',
+                        "hotspot"     : '--enable-dtrace'
                 ]
         ],
 
@@ -65,7 +65,7 @@ class Config16 {
                         nightly: false,
                         release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
                 ],
-                configureArgs       : '--disable-ccache --enable-dtrace'
+                configureArgs       : '--enable-dtrace'
         ],
 
         ppc64leLinux    : [
@@ -76,8 +76,8 @@ class Config16 {
                         release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
                 ],
                 configureArgs       : [
-                        "hotspot"     : '--disable-ccache --enable-dtrace',
-                        "openj9"      : '--disable-ccache --enable-dtrace --enable-jitserver'
+                        "hotspot"     : '--enable-dtrace',
+                        "openj9"      : '--enable-dtrace --enable-jitserver'
                 ]
 
         ],


### PR DESCRIPTION
Ref https://github.com/AdoptOpenJDK/openjdk-build/pull/802 - we are not building openssl on most platforms so I want to try re-enabling ccache on our JDK11+ buillds as (mentioned in the original PR) this was only supposed to be temporary.

Note that this will not be of too much benefit with the docker builds unless some additional creativity is employed (but shouldn't impact negatively other than populating a cache that isn't subsequently used!) but will still provide benefits for others.

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>