### PR TITLE
Replace string includes with count

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -143,7 +143,7 @@ class Build {
         }
         
         jdkRepo = "https://github.com/${suffix}"
-        if (buildConfig.BUILD_ARGS.include("--ssh")) {
+        if (buildConfig.BUILD_ARGS.count("--ssh") > 0) {
             jdkRepo = "git@github.com:${suffix}"
         }
         


### PR DESCRIPTION
String.includes(String) does not appear to exist, which I'm sure was
a typo, so I'm replacing it with count(String).

String.contains(String) is another option, but I didn't use that
because the API says it isn't mandatory for JDK 1.5+. There's also
String.indexOf, according to the error message, but I'm not seeing
that in the API doc, so let's play it safe.

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>