### PR TITLE
Disable jdk14 build+test, and enable jdk15 build+test

### DIFF
--- a/pipelines/jobs/configurations/jdk14u.groovy
+++ b/pipelines/jobs/configurations/jdk14u.groovy
@@ -53,7 +53,6 @@ targetConfigurations = [
         ]
 ]
 
-// 20:26
-triggerSchedule="TZ=UTC\n26 20 * * *"
+disableJob = true
 
 return this

--- a/pipelines/jobs/configurations/jdk15.groovy
+++ b/pipelines/jobs/configurations/jdk15.groovy
@@ -3,12 +3,24 @@ targetConfigurations = [
                 "hotspot",
                 "openj9"
         ],
+        "x64MacXL"    : [
+                "openj9"
+        ],
         "x64Linux"    : [
                 "hotspot",
                 "openj9"
         ],
+        "x64LinuxXL"  : [
+                "openj9"
+        ],
+        "x32Windows"  : [
+                "hotspot"
+        ],
         "x64Windows"  : [
                 "hotspot",
+                "openj9"
+        ],
+        "x64WindowsXL": [
                 "openj9"
         ],
         "ppc64Aix"    : [
@@ -19,12 +31,21 @@ targetConfigurations = [
                 "hotspot",
                 "openj9"
         ],
+        "ppc64leLinuxXL": [
+                "openj9"
+        ],
         "s390xLinux"  : [
                 "hotspot",
                 "openj9"
         ],
+        "s390xLinuxXL": [
+                "openj9"
+        ],
         "aarch64Linux": [
                 "hotspot",
+                "openj9"
+        ],
+        "aarch64LinuxXL": [
                 "openj9"
         ],
         "arm32Linux"  : [
@@ -32,7 +53,7 @@ targetConfigurations = [
         ]
 ]
 
-// 03:30
-triggerSchedule="TZ=UTC\n30 03 * * *"
+// 20:26
+triggerSchedule="TZ=UTC\n26 20 * * *"
 
 return this

--- a/pipelines/jobs/configurations/jdk15_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk15_pipeline_config.groovy
@@ -4,11 +4,17 @@ class Config15 {
                 os                  : 'mac',
                 arch                : 'x64',
                 additionalNodeLabels: 'macos10.14',
-                test                : [
-                        nightly: false,
-                        release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
-                ],
+                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
                 configureArgs       : '--enable-dtrace'
+        ],
+
+        x64MacXL    : [
+                os                   : 'mac',
+                arch                 : 'x64',
+                additionalNodeLabels : 'macos10.14',
+                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                additionalFileNameTag: "macosXL",
+                configureArgs        : '--with-noncompressedrefs --enable-dtrace'
         ],
 
         x64Linux  : [
@@ -18,14 +24,23 @@ class Config15 {
                 dockerFile: [
                         openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],
-                test                : [
-                        nightly: false,
-                        release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external', 'special.functional']
-                ],
+                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external', 'special.functional'],
                 configureArgs       : [
                         "openj9"      : '--disable-ccache --enable-dtrace --enable-jitserver',
                         "hotspot"     : '--disable-ccache --enable-dtrace'
                 ]
+        ],
+
+        x64LinuxXL  : [
+                os                  : 'linux',
+                arch                : 'x64',
+                dockerImage         : 'adoptopenjdk/centos7_build_image',
+                dockerFile: [
+                        openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
+                ],
+                test                : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                additionalFileNameTag: "linuxXL",
+                configureArgs       : '--with-noncompressedrefs --disable-ccache --enable-dtrace --enable-jitserver'
         ],
 
         // Currently we have to be quite specific about which windows to use as not all of them have freetype installed
@@ -38,10 +53,28 @@ class Config15 {
                 buildArgs : [
                         hotspot : '--jvm-variant client,server'
                 ],
-                test                : [
-                        nightly: false,
-                        release: ['sanity.openjdk', 'sanity.perf', 'sanity.system', 'extended.system']
-                ]
+                test                : ['sanity.openjdk', 'sanity.perf', 'sanity.system', 'extended.system']
+        ],
+
+        x64WindowsXL: [
+                os                  : 'windows',
+                arch                : 'x64',
+                additionalNodeLabels: 'win2012&&vs2017',
+                test                : ['sanity.openjdk', 'sanity.perf', 'sanity.system', 'extended.system'],
+                additionalFileNameTag: "windowsXL",
+                configureArgs        : '--with-noncompressedrefs'
+        ],
+
+        x32Windows: [
+                os                  : 'windows',
+                arch                : 'x86-32',
+                additionalNodeLabels: [
+                        hotspot: 'win2012&&vs2017'
+                ],
+                buildArgs : [
+                        hotspot : '--jvm-variant client,server'
+                ],
+                test                : ['sanity.openjdk']
         ],
 
         ppc64Aix    : [
@@ -52,54 +85,68 @@ class Config15 {
                         openj9:  'xlc16&&aix715'
                 ],
                 test                : [
-                        nightly: false,
+                        nightly: ['sanity.openjdk'],
                         release: ['sanity.openjdk', 'sanity.system', 'extended.system']
                 ]
         ],
 
-
         s390xLinux    : [
                 os                  : 'linux',
                 arch                : 's390x',
-                test                : [
-                        nightly: false,
-                        release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
-                ],
+                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
                 configureArgs       : '--disable-ccache --enable-dtrace'
+        ],
+
+        s390xLinuxXL  : [
+                os                   : 'linux',
+                arch                 : 's390x',
+                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                additionalFileNameTag: "linuxXL",
+                configureArgs        : '--with-noncompressedrefs --disable-ccache --enable-dtrace'
         ],
 
         ppc64leLinux    : [
                 os                  : 'linux',
                 arch                : 'ppc64le',
-                test                : [
-                        nightly: false,
-                        release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
-                ],
+                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
                 configureArgs       : [
                         "hotspot"     : '--disable-ccache --enable-dtrace',
                         "openj9"      : '--disable-ccache --enable-dtrace --enable-jitserver'
                 ]
+        ],
 
+        ppc64leLinuxXL    : [
+                os                   : 'linux',
+                arch                 : 'ppc64le',
+                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                additionalFileNameTag: "linuxXL",
+                configureArgs        : '--with-noncompressedrefs --disable-ccache --enable-dtrace'
         ],
 
         arm32Linux    : [
                 os                  : 'linux',
                 arch                : 'arm',
                 // TODO Temporarily remove the ARM tests because we don't have fast enough hardware
-                //test                : ['sanity.openjdk', 'sanity.perf']
+                //test                : ['sanity.openjdk', 'sanity.perf'],
                 test                : false,
-                configureArgs       : '--enable-dtrace=auto'
+                configureArgs       : '--enable-dtrace'
         ],
 
         aarch64Linux    : [
                 os                  : 'linux',
                 arch                : 'aarch64',
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
-                test                : [
-                        nightly: false,
-                        release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
-                ],
+                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
                 configureArgs       : '--enable-dtrace'
+        ],
+
+        aarch64LinuxXL    : [
+                os                   : 'linux',
+                dockerImage          : 'adoptopenjdk/centos7_build_image',
+                arch                 : 'aarch64',
+                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                additionalFileNameTag: "linuxXL",
+                configureArgs        : '--with-noncompressedrefs --disable-ccache --enable-dtrace=auto'
         ],
   ]
 


### PR DESCRIPTION
This is being done because we've passed the last release for jdk14,
and we need start testing 15 in preparation for the September release.

Most JDK15 builds are already active, but there are a few platforms
(windows 32bit and XL variants) that needed to be added, based on the
fact that jdk14 was creating builds for them.

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>