### PR TITLE
Remove jdk14 from pr test pipeline

### DIFF
--- a/pipelines/build/prTester/pr_test_pipeline.groovy
+++ b/pipelines/build/prTester/pr_test_pipeline.groovy
@@ -130,7 +130,7 @@ Map<String, ?> defaultTestConfigurations = [
         ]
 ]
 
-List<Integer> defaultJavaVersions = [8, 11, 14, 15, 16]
+List<Integer> defaultJavaVersions = [8, 11, 15, 16]
 
 defaultGitRepo = "https://github.com/AdoptOpenJDK/openjdk-build"
 


### PR DESCRIPTION
JDK14 is done and dusted, so we gain nothing from testing on it.

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>