### PR TITLE
Correct dtrace argument for jdk15

### DIFF
--- a/pipelines/jobs/configurations/jdk15_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk15_pipeline_config.groovy
@@ -147,7 +147,7 @@ class Config15 {
                 arch                 : 'aarch64',
                 test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
                 additionalFileNameTag: "linuxXL",
-                configureArgs        : '--with-noncompressedrefs --enable-dtrace=auto'
+                configureArgs        : '--with-noncompressedrefs --enable-dtrace'
         ],
   ]
 


### PR DESCRIPTION
Dtrace does not accept the "auto" option on jdk15, and configure
fails if it is set. Changing this so it matches the other usages
in the same groovy file.

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>