### PR TITLE
enable OpenJ9 builds of JDK8 on Linux/aarch64

### DIFF
--- a/pipelines/jobs/configurations/jdk8u.groovy
+++ b/pipelines/jobs/configurations/jdk8u.groovy
@@ -32,7 +32,8 @@ targetConfigurations = [
                 "openj9"
         ],
         "aarch64Linux"  : [
-                "hotspot"
+                "hotspot",
+                "openj9"
         ],
         "arm32Linux"  : [
                 "hotspot"


### PR DESCRIPTION
@knn-k has confirmed to me that the JDK8 repositories for OpenJ9 now have all the changes in to build on the Linux/aarch64 platform so we should start building it along with JDK11 and JDK15 :-D

(For reference, parallel PR for the standalone OpenJ9 CI is at https://github.com/eclipse/openj9/pull/10291)

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>