### PR TITLE
Move location of platform sourcing so JDK_BOOT_DIR processed correctly

### DIFF
--- a/build-farm/make-adopt-build-farm.sh
+++ b/build-farm/make-adopt-build-farm.sh
@@ -79,6 +79,9 @@ then
 fi
 echo "Required boot JDK version: ${JDK_BOOT_VERSION}"
 
+# shellcheck source=build-farm/set-platform-specific-configurations.sh
+source "${PLATFORM_SCRIPT_DIR}/set-platform-specific-configurations.sh"
+
 case "${JDK_BOOT_VERSION}" in
       "7")    export JDK_BOOT_DIR="${JDK_BOOT_DIR:-$JDK7_BOOT_DIR}";;
       "8")    export JDK_BOOT_DIR="${JDK_BOOT_DIR:-$JDK8_BOOT_DIR}";;
@@ -92,6 +95,7 @@ case "${JDK_BOOT_VERSION}" in
       *)      export JDK_BOOT_DIR="${JDK_BOOT_DIR:-$JDK16_BOOT_DIR}";;
 esac
 
+
 if [ ! -d "${JDK_BOOT_DIR}" ]
 then
   echo Setting JDK_BOOT_DIR to \$JAVA_HOME
@@ -100,10 +104,9 @@ then
   # Without this, a blank value can be passed into makejdk-any-platform.sh which causes an obscure parsing failure
   if [ ! -d "${JDK_BOOT_DIR}" ]
   then
-    echo "[ERROR] No JDK Boot Directory has been found, the likelyhood is that neither JDK${JDK_BOOT_VERSION}_BOOT_DIR or JAVA_HOME are set on this machine"
+    echo "[ERROR] No JDK Boot Directory has been found, the likelihood is that neither JDK${JDK_BOOT_VERSION}_BOOT_DIR or JAVA_HOME are set on this machine"
     exit 2
   fi
-
 fi
 
 echo "Boot jdk directory: ${JDK_BOOT_DIR}:"
@@ -133,8 +136,6 @@ fi
 echo "BRANCH: ${BRANCH} (For release either BRANCH or TAG should be set)"
 echo "TAG: ${TAG}"
 
-# shellcheck source=build-farm/set-platform-specific-configurations.sh
-source "${PLATFORM_SCRIPT_DIR}/set-platform-specific-configurations.sh"
 
 if [ "x${FILENAME}" = "x" ] ; then
     echo "FILENAME must be set in the environment"


### PR DESCRIPTION
Moving the reading of the platform specific environment variable as it can adjust the `JDK_BOOT_DIR` and the `make-adopt-build-farm.sh` processes it. https://github.com/AdoptOpenJDK/openjdk-build/pull/2004 introduced an additional check which showed up this problem where if the logic has to kick in to auto-download a boot JDK within the platform script the build would abort.

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>