### PR TITLE
Top generator moved, disablePipelineSchedule param added

### DIFF
--- a/pipelines/build/regeneration/README.md
+++ b/pipelines/build/regeneration/README.md
@@ -75,5 +75,8 @@ Unreferenced items:
 [SUCCESS] Regenerated configuration for job build-scripts/jobs/jdk/jdk-mac-x64-hotspot
 ```
 
+# Build Pipeline Generator
+This generator generates the [top level](https://ci.adoptopenjdk.net/job/build-scripts/) pipeline jobs. It works by iterating through the config files, defining a job dsl configuration for each version that has a version config file. It then calls [pipeline_job_template.groovy](https://github.com/AdoptOpenJDK/openjdk-build/blob/master/pipelines/jobs/pipeline_job_template.groovy) to finalise the dsl. By default, the [job that runs this file](https://ci.adoptopenjdk.net/job/build-scripts/job/utils/job/build-pipeline-generator/) has restricted read access so you will likely need to contact a jenkins admin to see the results of the job.
+
 # Downstream Test Jobs
 The [downstream test jobs](https://ci.adoptopenjdk.net/view/Test_openjdk/) are generated separately from the build ones, via the [Test_Job_Auto_Gen](https://ci.adoptopenjdk.net/view/Test_grinder/job/Test_Job_Auto_Gen/), [testJobTemplate](https://github.com/AdoptOpenJDK/openjdk-tests/blob/master/buildenv/jenkins/testJobTemplate) and [testPipeline](https://github.com/AdoptOpenJDK/openjdk-tests/blob/master/buildenv/jenkins/wip/testpipeline.groovy) resources in the openjdk-tests repository.

--- a/pipelines/build/regeneration/build_pipeline_generator.groovy
+++ b/pipelines/build/regeneration/build_pipeline_generator.groovy
@@ -1,0 +1,59 @@
+node('master') {
+  def retiredVersions = [9, 10, 12, 13, 14]
+
+  (8..30).each({javaVersion -> 
+
+    if (retiredVersions.contains(javaVersion)) {
+      println "[INFO] $javaVersion is a retired version that isn't built anymore. Skipping generation..."
+      return
+    }
+    
+    def config = [
+      TEST                : false,
+      GIT_URL             : "https://github.com/AdoptOpenJDK/openjdk-build.git",
+      BRANCH              : "master",
+      BUILD_FOLDER        : "build-scripts",
+      JOB_NAME            : "openjdk${javaVersion}-pipeline",
+      SCRIPT              : "pipelines/build/openjdk${javaVersion}_pipeline.groovy",
+      disableJob          : false,
+      triggerSchedule     : ""
+    ];
+    checkout([$class: 'GitSCM', userRemoteConfigs: [[url: config.GIT_URL]]])
+    
+    def target;
+    try {
+      target = load "${WORKSPACE}/pipelines/jobs/configurations/jdk${javaVersion}u.groovy"
+    } catch(Exception e) {
+      try {
+        target = load "${WORKSPACE}/pipelines/jobs/configurations/jdk${javaVersion}.groovy"
+      } catch(Exception e2) {
+        println "[WARNING] No config found for JDK${javaVersion}"
+        return
+      }
+    }
+    
+    config.targetConfigurations = target.targetConfigurations
+
+    // hack as jenkins groovy does not seem to allow us to check if disableJob exists
+    try {
+      config.disableJob = target.disableJob;
+    } catch (Exception ex) {
+      config.disableJob = false;
+    }
+    
+    println "[INFO] JDK${javaVersion}: disableJob = ${config.disableJob}"
+
+    if (Boolean.parseBoolean(enableAutomation) == true) {
+      try {
+        config.triggerSchedule = target.triggerSchedule
+      } catch (Exception ex) {
+        config.triggerSchedule = "@daily";
+      }
+    }
+
+    println "[INFO] JDK${javaVersion}: triggerSchedule = ${config.triggerSchedule}"
+
+    def create = jobDsl targets: "pipelines/jobs/pipeline_job_template.groovy", ignoreExisting: false, additionalParameters: config
+    target.disableJob = false
+  })
+}

--- a/pipelines/build/regeneration/build_pipeline_generator.groovy
+++ b/pipelines/build/regeneration/build_pipeline_generator.groovy
@@ -43,7 +43,7 @@ node('master') {
     
     println "[INFO] JDK${javaVersion}: disableJob = ${config.disableJob}"
 
-    if (Boolean.parseBoolean(enableAutomation) == true) {
+    if (Boolean.parseBoolean(enablePipelineSchedule) == true) {
       try {
         config.triggerSchedule = target.triggerSchedule
       } catch (Exception ex) {


### PR DESCRIPTION
* Moves the current build-pipeline-generator script into github
* Adds a retired versions array to skip non existent versions
* Also modifies it to account for a new parameter, disablePipelineSchedule
* By default, we generate top level pipeline jobs with triggerSchedule pulled from config files. If param false, default logic is overridden pipeline jobs are generated without a trigger

Closes: #2016 
Fixes: #2017 
Signed-off-by: Morgan Davies <morgan.davies@ibm.com>