### PR TITLE
Trigger tests with standard set

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -55,7 +55,12 @@ class Builder implements Serializable {
     def context
     def currentBuild
 
-
+    final List<String> nightly = ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external']
+    final List<String> weekly = [
+                           'extended.openjdk', 'extended.perf', 'extended.external',
+                           'special.openjdk','special.functional', 'special.system', 'special.perf'
+                           ]
+        
     IndividualBuildConfig buildConfiguration(Map<String, ?> platformConfig, String variant) {
 
         def additionalNodeLabels = formAdditionalBuildNodeLabels(platformConfig, variant)
@@ -122,17 +127,36 @@ class Builder implements Serializable {
 
         return ""
     }
-
+    
+    /*
+    * Get the list of tests from jdk*_pipeline_config.groovy. 
+    * @param configuration
+    */
     List<String> getTestList(Map<String, ?> configuration) {
-        if (configuration.containsKey("test")) {
+        List<String> testList = []
+        /* 
+        * No test key or key value is test: false  --- test disabled
+        * Key value is test: 'default' --- nightly build trigger 'nightly' test set, release build trigger 'nightly' + 'weekly' test sets
+        * Key value is test: [customized map] specified nightly and weekly test lists
+        */
+        if (configuration.containsKey("test") && configuration.get("test")) {
             def testJobType = release ? "release" : "nightly"
             if (isMap(configuration.test)) {
-                return (configuration.test as Map).get(testJobType) as List<String>
+                if ( testJobType == "nightly" ) {
+                    testList = (configuration.test as Map).get("nightly") as List<String>
+                } else {
+                    testList = ((configuration.test as Map).get("nightly") as List<String>) + ((configuration.test as Map).get("weekly") as List<String>)
+                }
             } else {
-                return configuration.test as List<String>
+                if ( testJobType == "nightly" ) {
+                    testList = nightly
+                } else {
+                    testList = nightly + weekly
+                }
             }
         }
-        return []
+        testList.unique()
+        return testList
     }
 
     def dockerOverride(Map<String, ?> configuration, String variant) {

--- a/pipelines/build/common/config_regeneration.groovy
+++ b/pipelines/build/common/config_regeneration.groovy
@@ -34,6 +34,7 @@ class Regeneration implements Serializable {
 
     private final def jenkinsBuildRoot
     private String javaToBuild
+    private final List<String> defaultTestList = ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external']
 
     public Regeneration(
         String javaVersion,
@@ -163,14 +164,15 @@ class Regeneration implements Serializable {
     * @param configuration
     */
     List<String> getTestList(Map<String, ?> configuration) {
-        if (configuration.containsKey("test")) {
+        List<String> testList = []
+        if (configuration.containsKey("test") && configuration.get("test")) {
             if (isMap(configuration.test)) {
-                return (configuration.test as Map).get("nightly") as List<String> // no need to check for release
-            } else {
-                return configuration.test as List<String>
+                testList = (configuration.test as Map).get("nightly") as List<String> // no need to check for release
             }
+            testList = defaultTestList
         }
-        return []
+        testList.unique()
+        return testList
     }
 
     /*

--- a/pipelines/jobs/configurations/jdk10u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk10u_pipeline_config.groovy
@@ -4,14 +4,20 @@ class Config10 {
                 os                  : 'mac',
                 arch                : 'x64',
                 additionalNodeLabels: 'build-macstadium-macos1010-1',
-                test                : ['sanity.openjdk', 'sanity.system'],
+                test                : [
+                        nightly: ['sanity.openjdk', 'sanity.system'],
+                        weekly : []
+                ],
                 configureArgs       : '--enable-dtrace=auto'
         ],
         x64Linux  : [
                 os                  : 'linux',
                 arch                : 'x64',
                 additionalNodeLabels: 'centos6',
-                test                : ['sanity.openjdk', 'sanity.system', 'sanity.external'],
+                test                : [
+                        nightly: ['sanity.openjdk', 'sanity.system', 'sanity.external'],
+                        weekly : []
+                ],
                 configureArgs       : '--enable-dtrace=auto'
         ],
 
@@ -23,7 +29,10 @@ class Config10 {
                         hotspot: 'win2012',
                         openj9:  'win2012&&mingw-cygwin'
                 ],
-                test                : ['sanity.openjdk']
+                test                : [
+                        nightly: ['sanity.openjdk'],
+                        weekly : []
+                ]
         ],
 
         ppc64Aix    : [
@@ -38,7 +47,10 @@ class Config10 {
                 additionalNodeLabels: [
                         hotspot: 'rhel7'
                 ],
-                test                : ['sanity.openjdk', 'sanity.system'],
+                test                : [
+                        nightly: ['sanity.openjdk', 'sanity.system'],
+                        weekly : []
+                ],
                 configureArgs       : '--enable-dtrace=auto'
         ],
 
@@ -52,14 +64,20 @@ class Config10 {
         ppc64leLinux    : [
                 os                  : 'linux',
                 arch                : 'ppc64le',
-                test                : ['sanity.openjdk', 'sanity.system'],
+                test                : [
+                        nightly: ['sanity.openjdk', 'sanity.system'],
+                        weekly : []
+                ],
                 configureArgs       : '--enable-dtrace=auto'
         ],
 
         arm32Linux    : [
                 os                  : 'linux',
                 arch                : 'arm',
-                test                : ['sanity.openjdk'],
+                test                : [
+                        nightly: ['sanity.openjdk'],
+                        weekly : []
+                ],
                 configureArgs       : '--enable-dtrace=auto'
         ],
 
@@ -67,7 +85,10 @@ class Config10 {
                 os                  : 'linux',
                 arch                : 'aarch64',
                 additionalNodeLabels: 'centos7',
-                test                : ['sanity.openjdk'],
+                test                : [
+                        nightly: ['sanity.openjdk'],
+                        weekly : []
+                ],
                 configureArgs       : '--enable-dtrace=auto'
         ],
 

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -4,7 +4,7 @@ class Config11 {
                 os                  : 'mac',
                 arch                : 'x64',
                 additionalNodeLabels : 'macos10.14',
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                test                : 'default',
                 configureArgs       : [
                         "openj9"      : '--enable-dtrace=auto --with-cmake',
                         "hotspot"     : '--enable-dtrace=auto'
@@ -15,7 +15,7 @@ class Config11 {
                 os                   : 'mac',
                 arch                 : 'x64',
                 additionalNodeLabels : 'macos10.14',
-                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                test                 : 'default',
                 additionalFileNameTag: "macosXL",
                 configureArgs        : '--with-noncompressedrefs --enable-dtrace=auto --with-cmake'
         ],
@@ -27,10 +27,7 @@ class Config11 {
                 dockerFile: [
                         openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],
-                test                : [
-                        nightly: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external'],
-                        release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external', 'special.functional']
-                ],
+                test                : 'default',
                 configureArgs       : [
                         "openj9"      : '--enable-jitserver --enable-dtrace=auto',
                         "hotspot"     : '--enable-dtrace=auto',
@@ -51,14 +48,14 @@ class Config11 {
                 buildArgs : [
                         hotspot : '--jvm-variant client,server'
                 ],
-                test                : ['sanity.openjdk', 'sanity.perf', 'sanity.system', 'extended.system']
+                test                : 'default'
         ],
 
         x64WindowsXL    : [
                 os                   : 'windows',
                 arch                 : 'x64',
                 additionalNodeLabels : 'win2012&&vs2017',
-                test                 : ['sanity.openjdk', 'sanity.system'],
+                test                 : 'default',
                 additionalFileNameTag: "windowsXL",
                 configureArgs        : '--with-noncompressedrefs'
         ],
@@ -73,7 +70,7 @@ class Config11 {
                 buildArgs : [
                         hotspot : '--jvm-variant client,server'
                 ],
-                test                : ['sanity.openjdk']
+                test                : 'default'
         ],
 
         ppc64Aix    : [
@@ -83,16 +80,13 @@ class Config11 {
                         hotspot: 'xlc13&&aix710',
                         openj9:  'xlc13&&aix715'
                 ],
-                test                : [
-                        nightly: ['sanity.openjdk'],
-                        release: ['sanity.openjdk', 'sanity.system', 'extended.system']
-                ]
+                test                : 'default'
         ],
 
         s390xLinux    : [
                 os                  : 'linux',
                 arch                : 's390x',
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                test                : 'default',
                 configureArgs       : '--enable-dtrace=auto'
         ],
 
@@ -106,7 +100,7 @@ class Config11 {
         ppc64leLinux    : [
                 os                  : 'linux',
                 arch                : 'ppc64le',
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                test                : 'default',
                 configureArgs       : [
                         "hotspot"     : '--enable-dtrace=auto',
                         "openj9"      : '--enable-dtrace=auto --enable-jitserver'
@@ -127,7 +121,7 @@ class Config11 {
                 os                  : 'linux',
                 arch                : 'aarch64',
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                test                : 'default',
                 configureArgs       : '--enable-dtrace=auto'
         ],
 
@@ -146,21 +140,21 @@ class Config11 {
                         openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],
                 arch                 : 'x64',
-                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                test                 : "default",
                 additionalFileNameTag: "linuxXL",
                 configureArgs        : '--with-noncompressedrefs --enable-jitserver --enable-dtrace=auto'
         ],
         s390xLinuxXL    : [
                 os                   : 'linux',
                 arch                 : 's390x',
-                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                test                 : 'default',
                 additionalFileNameTag: "linuxXL",
                 configureArgs        : '--with-noncompressedrefs --enable-dtrace=auto'
         ],
         ppc64leLinuxXL    : [
                 os                   : 'linux',
                 arch                 : 'ppc64le',
-                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                test                 : 'default',
                 additionalFileNameTag: "linuxXL",
                 configureArgs        : '--with-noncompressedrefs --enable-dtrace=auto --enable-jitserver'
         ],
@@ -168,7 +162,7 @@ class Config11 {
                 os                   : 'linux',
                 dockerImage          : 'adoptopenjdk/centos7_build_image',
                 arch                 : 'aarch64',
-                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                test                 : 'default',
                 additionalFileNameTag: "linuxXL",
                 configureArgs        : '--with-noncompressedrefs --enable-dtrace=auto'
         ],

--- a/pipelines/jobs/configurations/jdk12u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk12u_pipeline_config.groovy
@@ -4,7 +4,10 @@ class Config12 {
                 os                  : 'mac',
                 arch                : 'x64',
                 additionalNodeLabels : 'macos10.12',
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                test                : [
+                        nightly: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                        weekly : []
+                ],
                 configureArgs       : '--enable-dtrace=auto'
         ],
 
@@ -12,7 +15,10 @@ class Config12 {
                 os                   : 'mac',
                 arch                 : 'x64',
                 additionalNodeLabels : 'macos10.12',
-                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                test                : [
+                        nightly: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                        weekly : []
+                ],
                 additionalFileNameTag: "macosXL",
                 configureArgs        : '--with-noncompressedrefs --enable-dtrace=auto'
         ],
@@ -22,8 +28,8 @@ class Config12 {
                 arch                : 'x64',
                 additionalNodeLabels: 'centos6',
                 test                : [
-                        nightly: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external'],
-                        release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external', 'special.functional']
+                        nightly: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf','sanity.external'],
+                        weekly : ['special.functional']
                 ],
                 configureArgs        : '--disable-ccache --enable-dtrace=auto'
         ],
@@ -39,14 +45,20 @@ class Config12 {
                 buildArgs : [
                         hotspot : '--jvm-variant client,server'
                 ],
-                test                : ['sanity.openjdk', 'sanity.perf', 'sanity.system', 'extended.system']
+                test                : [
+                        nightly: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                        weekly : []
+                ]
         ],
 
         x64WindowsXL    : [
                 os                   : 'windows',
                 arch                 : 'x64',
                 additionalNodeLabels : 'win2012&&vs2017',
-                test                 : ['sanity.openjdk', 'sanity.perf', 'sanity.system', 'extended.system'],
+                test                : [
+                        nightly: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                        weekly : []
+                ],
                 additionalFileNameTag: "windowsXL",
                 configureArgs        : '--with-noncompressedrefs'
         ],
@@ -61,22 +73,28 @@ class Config12 {
                 buildArgs : [
                         hotspot : '--jvm-variant client,server'
                 ],
-                test                : ['sanity.openjdk']
+                test                : [
+                        nightly: ['sanity.openjdk'],
+                        weekly : []
+                ]
         ],
 
         ppc64Aix    : [
                 os                  : 'aix',
                 arch                : 'ppc64',
                 test                : [
-                        nightly: false,
-                        release: ['sanity.openjdk', 'sanity.system', 'extended.system']
+                        nightly: [],
+                        weekly : ['sanity.openjdk', 'sanity.system', 'extended.system']
                 ]
         ],
 
         s390xLinux    : [
                 os                  : 'linux',
                 arch                : 's390x',
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                test                : [
+                        nightly: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                        weekly : []
+                ],
                 configureArgs        : '--disable-ccache --enable-dtrace=auto'
         ],
 
@@ -90,7 +108,10 @@ class Config12 {
         ppc64leLinux    : [
                 os                  : 'linux',
                 arch                : 'ppc64le',
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                test                : [
+                        nightly: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                        weekly : []
+                ],
                 configureArgs       : '--disable-ccache --enable-dtrace=auto'
 
         ],
@@ -108,7 +129,10 @@ class Config12 {
                 os                  : 'linux',
                 arch                : 'aarch64',
                 additionalNodeLabels: 'centos7',
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                test                : [
+                        nightly: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                        weekly : []
+                ],
                 configureArgs       : '--enable-dtrace=auto'
         ],
 
@@ -124,7 +148,10 @@ class Config12 {
                 os                   : 'linux',
                 additionalNodeLabels : 'centos6',
                 arch                 : 'x64',
-                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                test                : [
+                        nightly: ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                        weekly : []
+                ],
                 additionalFileNameTag: "linuxXL",
                 configureArgs        : '--with-noncompressedrefs --disable-ccache --enable-dtrace=auto'
         ],

--- a/pipelines/jobs/configurations/jdk13u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk13u_pipeline_config.groovy
@@ -4,7 +4,10 @@ class Config13 {
                 os                  : 'mac',
                 arch                : 'x64',
                 additionalNodeLabels : 'macos10.12',
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                test                : [
+                        nightly: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                        weekly : []
+                ],
                 configureArgs       : '--enable-dtrace=auto'
         ],
 
@@ -12,7 +15,10 @@ class Config13 {
                 os                   : 'mac',
                 arch                 : 'x64',
                 additionalNodeLabels : 'macos10.12',
-                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                test                : [
+                        nightly: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                        weekly : []
+                ],
                 additionalFileNameTag: "macosXL",
                 configureArgs        : '--with-noncompressedrefs --enable-dtrace=auto'
         ],
@@ -23,7 +29,7 @@ class Config13 {
                 additionalNodeLabels: 'centos6',
                 test                : [
                         nightly: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external'],
-                        release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external', 'special.functional']
+                        weekly : ['special.functional']
                 ],
                 configureArgs        : '--disable-ccache --enable-dtrace=auto'
         ],
@@ -39,14 +45,20 @@ class Config13 {
                 buildArgs : [
                         hotspot : '--jvm-variant client,server'
                 ],
-                test                : ['sanity.openjdk', 'sanity.perf', 'sanity.system', 'extended.system']
+                test                : [
+                        nightly: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                        weekly : []
+                ]
         ],
 
         x64WindowsXL    : [
                 os                   : 'windows',
                 arch                 : 'x64',
                 additionalNodeLabels : 'win2012&&vs2017',
-                test                 : ['sanity.openjdk', 'sanity.perf', 'sanity.system', 'extended.system'],
+                test                : [
+                        nightly: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                        weekly : []
+                ],
                 additionalFileNameTag: "windowsXL",
                 configureArgs        : '--with-noncompressedrefs'
         ],
@@ -61,7 +73,10 @@ class Config13 {
                 buildArgs : [
                         hotspot : '--jvm-variant client,server'
                 ],
-                test                : ['sanity.openjdk']
+                test                : [
+                        nightly: ['sanity.openjdk'],
+                        weekly : []
+                ]
         ],
 
         ppc64Aix    : [
@@ -69,15 +84,18 @@ class Config13 {
                 arch                : 'ppc64',
                 additionalNodeLabels: 'xlc16',
                 test                : [
-                        nightly: false,
-                        release: ['sanity.openjdk', 'sanity.system', 'extended.system']
+                        nightly: []
+                        weekly: ['sanity.openjdk', 'sanity.system', 'extended.system']
                 ]
         ],
 
         s390xLinux    : [
                 os                  : 'linux',
                 arch                : 's390x',
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                test                : [
+                        nightly: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                        weekly : []
+                ],
                 configureArgs        : '--disable-ccache --enable-dtrace=auto'
         ],
 
@@ -91,7 +109,10 @@ class Config13 {
         ppc64leLinux    : [
                 os                  : 'linux',
                 arch                : 'ppc64le',
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                test                : [
+                        nightly: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                        weekly : []
+                ],
                 configureArgs       : '--disable-ccache --enable-dtrace=auto'
 
         ],
@@ -109,7 +130,10 @@ class Config13 {
                 os                  : 'linux',
                 arch                : 'aarch64',
                 additionalNodeLabels: 'centos7',
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                test                : [
+                        nightly: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                        weekly : []
+                ],
                 configureArgs       : '--enable-dtrace=auto'
         ],
 
@@ -125,21 +149,30 @@ class Config13 {
                 os                   : 'linux',
                 additionalNodeLabels : 'centos6',
                 arch                 : 'x64',
-                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                test                : [
+                        nightly: ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                        weekly : []
+                ],
                 additionalFileNameTag: "linuxXL",
                 configureArgs        : '--with-noncompressedrefs --disable-ccache --enable-dtrace=auto'
         ],
         s390xLinuxXL    : [
                 os                   : 'linux',
                 arch                 : 's390x',
-                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                test                : [
+                        nightly: ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                        weekly : []
+                ],
                 additionalFileNameTag: "linuxXL",
                 configureArgs        : '--with-noncompressedrefs --disable-ccache --enable-dtrace=auto'
         ],
         ppc64leLinuxXL    : [
                 os                   : 'linux',
                 arch                 : 'ppc64le',
-                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                test                : [
+                        nightly: ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                        weekly : []
+                ],
                 additionalFileNameTag: "linuxXL",
                 configureArgs        : '--with-noncompressedrefs --disable-ccache --enable-dtrace=auto'
         ],

--- a/pipelines/jobs/configurations/jdk14u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk14u_pipeline_config.groovy
@@ -4,7 +4,10 @@ class Config14 {
                 os                  : 'mac',
                 arch                : 'x64',
                 additionalNodeLabels : 'macos10.14',
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                test                : [
+                        nightly: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                        weekly : []
+                ],
                 configureArgs       : '--enable-dtrace=auto'
         ],
 
@@ -12,7 +15,10 @@ class Config14 {
                 os                   : 'mac',
                 arch                 : 'x64',
                 additionalNodeLabels : 'macos10.14',
-                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                test                : [
+                        nightly: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                        weekly : []
+                ],
                 additionalFileNameTag: "macosXL",
                 configureArgs        : '--with-noncompressedrefs --enable-dtrace=auto'
         ],
@@ -24,7 +30,10 @@ class Config14 {
                 dockerFile: [
                         openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external', 'special.functional'],
+                test                : [
+                        nightly: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external', 'special.functional'],
+                        weekly : []
+                ],
                 configureArgs       : [
                         "openj9"      : '--disable-ccache --enable-dtrace=auto --enable-jitserver',
                         "hotspot"     : '--disable-ccache --enable-dtrace=auto',
@@ -39,7 +48,10 @@ class Config14 {
                         openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],
                 arch                 : 'x64',
-                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                test                : [
+                        nightly: ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                        weekly : []
+                ],
                 additionalFileNameTag: "linuxXL",
                 configureArgs        : '--with-noncompressedrefs --disable-ccache --enable-dtrace=auto --enable-jitserver'
         ],
@@ -54,14 +66,20 @@ class Config14 {
                 buildArgs : [
                         hotspot : '--jvm-variant client,server'
                 ],
-                test                : ['sanity.openjdk', 'sanity.perf', 'sanity.system', 'extended.system']
+                test                : [
+                        nightly: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                        weekly : []
+                ]
         ],
 
         x64WindowsXL    : [
                 os                   : 'windows',
                 arch                 : 'x64',
                 additionalNodeLabels : 'win2012&&vs2017',
-                test                 : ['sanity.openjdk', 'sanity.perf', 'sanity.system', 'extended.system'],
+                test                : [
+                        nightly: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                        weekly : []
+                ],
                 additionalFileNameTag: "windowsXL",
                 configureArgs        : '--with-noncompressedrefs'
         ],
@@ -75,7 +93,10 @@ class Config14 {
                 buildArgs : [
                         hotspot : '--jvm-variant client,server'
                 ],
-                test                : ['sanity.openjdk']
+                test                : [
+                        nightly: ['sanity.openjdk'],
+                        weekly : []
+                ]
         ],
 
         ppc64Aix    : [
@@ -87,21 +108,27 @@ class Config14 {
                 ],
                 test                : [
                         nightly: ['sanity.openjdk'],
-                        release: ['sanity.openjdk', 'sanity.system', 'extended.system']
+                        weekly : ['sanity.system', 'extended.system']
                 ]
         ],
 
         s390xLinux    : [
                 os                  : 'linux',
                 arch                : 's390x',
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                test                : [
+                        nightly: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                        weekly : []
+                ],
                 configureArgs        : '--disable-ccache --enable-dtrace=auto'
         ],
 
         s390xLinuxXL    : [
                 os                   : 'linux',
                 arch                 : 's390x',
-                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                test                : [
+                        nightly: ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                        weekly : []
+                ],
                 additionalFileNameTag: "linuxXL",
                 configureArgs        : '--with-noncompressedrefs --disable-ccache --enable-dtrace=auto'
         ],
@@ -109,7 +136,10 @@ class Config14 {
         ppc64leLinux    : [
                 os                  : 'linux',
                 arch                : 'ppc64le',
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                test                : [
+                        nightly: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                        weekly : []
+                ],
                 configureArgs       : [
                         "hotspot"     : '--disable-ccache --enable-dtrace=auto',
                         "openj9"      : '--disable-ccache --enable-dtrace=auto --enable-jitserver'
@@ -128,7 +158,10 @@ class Config14 {
         ppc64leLinuxXL    : [
                 os                   : 'linux',
                 arch                 : 'ppc64le',
-                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                test                : [
+                        nightly: ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                        weekly : []
+                ],
                 additionalFileNameTag: "linuxXL",
                 configureArgs        : '--with-noncompressedrefs --disable-ccache --enable-dtrace=auto'
         ],
@@ -137,7 +170,10 @@ class Config14 {
                 os                  : 'linux',
                 arch                : 'aarch64',
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                test                : [
+                        nightly: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                        weekly : []
+                ],
                 configureArgs       : '--enable-dtrace=auto'
         ],
   ]

--- a/pipelines/jobs/configurations/jdk15u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk15u_pipeline_config.groovy
@@ -4,7 +4,7 @@ class Config15 {
                 os                  : 'mac',
                 arch                : 'x64',
                 additionalNodeLabels: 'macos10.14',
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                test                : 'default',
                 configureArgs       : '--enable-dtrace'
         ],
 
@@ -12,7 +12,7 @@ class Config15 {
                 os                   : 'mac',
                 arch                 : 'x64',
                 additionalNodeLabels : 'macos10.14',
-                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                test                 : 'default',
                 additionalFileNameTag: "macosXL",
                 configureArgs        : '--with-noncompressedrefs --enable-dtrace'
         ],
@@ -24,7 +24,7 @@ class Config15 {
                 dockerFile: [
                         openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external', 'special.functional'],
+                test                : 'default',
                 configureArgs       : [
                         "openj9"      : '--enable-dtrace --enable-jitserver',
                         "hotspot"     : '--enable-dtrace'
@@ -38,7 +38,7 @@ class Config15 {
                 dockerFile: [
                         openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                test                : 'default',
                 additionalFileNameTag: "linuxXL",
                 configureArgs       : '--with-noncompressedrefs --enable-dtrace --enable-jitserver'
         ],
@@ -50,14 +50,14 @@ class Config15 {
                 additionalNodeLabels: [
                         hotspot: 'win2012&&vs2017'
                 ],
-                test                : ['sanity.openjdk', 'sanity.perf', 'sanity.system', 'extended.system']
+                test                : 'default'
         ],
 
         x64WindowsXL: [
                 os                  : 'windows',
                 arch                : 'x64',
                 additionalNodeLabels: 'win2012&&vs2017',
-                test                : ['sanity.openjdk', 'sanity.perf', 'sanity.system', 'extended.system'],
+                test                : 'default',
                 additionalFileNameTag: "windowsXL",
                 configureArgs        : '--with-noncompressedrefs'
         ],
@@ -71,7 +71,7 @@ class Config15 {
                 buildArgs : [
                         hotspot : '--jvm-variant client,server'
                 ],
-                test                : ['sanity.openjdk']
+                test                : 'default'
         ],
 
         ppc64Aix    : [
@@ -81,24 +81,20 @@ class Config15 {
                         hotspot: 'xlc16&&aix710',
                         openj9:  'xlc16&&aix715'
                 ],
-                test                : [
-                        nightly: ['sanity.openjdk'],
-                        release: ['sanity.openjdk', 'sanity.system', 'extended.system']
-                ]
+                test                : 'default'
         ],
 
         s390xLinux    : [
                 os                  : 'linux',
                 arch                : 's390x',
-
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                test                : 'default',
                 configureArgs       : '--enable-dtrace'
         ],
 
         s390xLinuxXL  : [
                 os                   : 'linux',
                 arch                 : 's390x',
-                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                test                 : 'default',
                 additionalFileNameTag: "linuxXL",
                 configureArgs        : '--with-noncompressedrefs --enable-dtrace'
         ],
@@ -106,7 +102,7 @@ class Config15 {
         ppc64leLinux    : [
                 os                  : 'linux',
                 arch                : 'ppc64le',
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                test                : 'default',
                 configureArgs       : [
                         "hotspot"     : '--enable-dtrace',
                         "openj9"      : '--enable-dtrace --enable-jitserver'
@@ -116,7 +112,7 @@ class Config15 {
         ppc64leLinuxXL    : [
                 os                   : 'linux',
                 arch                 : 'ppc64le',
-                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                test                 : 'default',
                 additionalFileNameTag: "linuxXL",
                 configureArgs        : '--with-noncompressedrefs --disable-ccache --enable-dtrace'
         ],
@@ -134,7 +130,7 @@ class Config15 {
                 os                  : 'linux',
                 arch                : 'aarch64',
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf'],
+                test                : 'default',
                 configureArgs       : '--enable-dtrace'
         ],
 
@@ -142,7 +138,7 @@ class Config15 {
                 os                   : 'linux',
                 dockerImage          : 'adoptopenjdk/centos7_build_image',
                 arch                 : 'aarch64',
-                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system'],
+                test                 : 'default',
                 additionalFileNameTag: "linuxXL",
                 configureArgs        : '--with-noncompressedrefs --enable-dtrace'
         ],

--- a/pipelines/jobs/configurations/jdk16_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk16_pipeline_config.groovy
@@ -5,8 +5,8 @@ class Config16 {
                 arch                : 'x64',
                 additionalNodeLabels: 'macos10.14',
                 test                : [
-                        nightly: false,
-                        release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
+                        nightly: [],
+                        weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
                 ],
                 configureArgs       : '--enable-dtrace'
         ],
@@ -19,8 +19,8 @@ class Config16 {
                         openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],
                 test                : [
-                        nightly: false,
-                        release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external', 'special.functional']
+                        nightly: [],
+                        weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external', 'special.functional']
                 ],
                 configureArgs       : [
                         "openj9"      : '--enable-dtrace --enable-jitserver',
@@ -36,8 +36,8 @@ class Config16 {
                         hotspot: 'win2012&&vs2017'
                 ],
                 test                : [
-                        nightly: false,
-                        release: ['sanity.openjdk', 'sanity.perf', 'sanity.system', 'extended.system']
+                        nightly: [],
+                        weekly : ['sanity.openjdk', 'sanity.perf', 'sanity.system', 'extended.system']
                 ]
         ],
 
@@ -49,8 +49,8 @@ class Config16 {
                         openj9:  'xlc16&&aix715'
                 ],
                 test                : [
-                        nightly: false,
-                        release: ['sanity.openjdk', 'sanity.system', 'extended.system']
+                        nightly: [],
+                        weekly : ['sanity.openjdk', 'sanity.system', 'extended.system']
                 ]
         ],
 
@@ -59,8 +59,8 @@ class Config16 {
                 os                  : 'linux',
                 arch                : 's390x',
                 test                : [
-                        nightly: false,
-                        release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
+                        nightly: [],
+                        weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
                 ],
                 configureArgs       : '--enable-dtrace'
         ],
@@ -69,8 +69,8 @@ class Config16 {
                 os                  : 'linux',
                 arch                : 'ppc64le',
                 test                : [
-                        nightly: false,
-                        release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
+                        nightly: [],
+                        weekly: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
                 ],
                 configureArgs       : [
                         "hotspot"     : '--enable-dtrace',
@@ -84,8 +84,8 @@ class Config16 {
                 arch                : 'aarch64',
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
                 test                : [
-                        nightly: false,
-                        release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
+                        nightly: [],
+                        weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
                 ],
                 configureArgs       : '--enable-dtrace'
         ],

--- a/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
@@ -8,14 +8,14 @@ class Config8 {
                         corretto: 'build-macstadium-macos1010-1',
                         openj9  : 'macos10.14'
                 ],
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk']
+                test                 : 'default'
         ],
 
         x64MacXL      : [
                 os                   : 'mac',
                 arch                 : 'x64',
                 additionalNodeLabels : 'macos10.14',
-                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'special.openjdk'],
+                test                 : 'default',
                 additionalFileNameTag: "macosXL",
                 configureArgs        : '--with-noncompressedrefs'
         ],
@@ -28,7 +28,7 @@ class Config8 {
                         openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile',
                         dragonwell: 'pipelines/build/dockerFiles/dragonwell.dockerfile'
                 ],
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external', 'special.functional', 'special.openjdk'],
+                test                 : 'default',
                 configureArgs       : [
                         "openj9"      : '--enable-jitserver',
                         "dragonwell"  : '--enable-jfr --enable-unlimited-crypto --with-jvm-variants=server  --with-zlib=system',
@@ -44,14 +44,14 @@ class Config8 {
                         corretto: 'win2012',
                         openj9  : 'win2012&&mingw-cygwin'
                 ],
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk']
+                test                 : 'default'
         ],
 
         x64WindowsXL    : [
                 os                   : 'windows',
                 arch                 : 'x64',
                 additionalNodeLabels : 'win2012&&mingw-cygwin',
-                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk'],
+                test                 : 'default',
                 additionalFileNameTag: "windowsXL",
                 configureArgs        : '--with-noncompressedrefs'
         ],
@@ -67,7 +67,7 @@ class Config8 {
                 buildArgs : [
                         hotspot : '--jvm-variant client,server'
                 ],
-                test                : ['sanity.openjdk', 'special.openjdk']
+                test                 : 'default'
         ],
 
         ppc64Aix      : [
@@ -77,16 +77,13 @@ class Config8 {
                         hotspot: 'xlc13&&aix710',
                         openj9:  'xlc13&&aix715'
                 ],
-                test: [
-                        nightly: ['sanity.openjdk'],
-                        release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk']
-                ]
+                test                 : 'default'
         ],
 
         s390xLinux    : [
                 os  : 'linux',
                 arch: 's390x',
-                test: ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk']
+                test                 : 'default'
         ],
 
         sparcv9Solaris: [
@@ -104,7 +101,7 @@ class Config8 {
         ppc64leLinux  : [
                 os  : 'linux',
                 arch: 'ppc64le',
-                test: ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk'],
+                test                 : 'default',
                 configureArgs       : [
                         "openj9"      : '--enable-jitserver'
                 ]
@@ -113,14 +110,14 @@ class Config8 {
         arm32Linux    : [
                 os  : 'linux',
                 arch: 'arm',
-                test                : ['sanity.openjdk']
+                test: 'default'
         ],
 
         aarch64Linux  : [
                 os                  : 'linux',
                 arch                : 'aarch64',
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
-                test                : ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk']
+                test                 : 'default'
         ],
 
         x64LinuxXL       : [
@@ -132,20 +129,20 @@ class Config8 {
                 arch                 : 'x64',
                 additionalFileNameTag: "linuxXL",
                 configureArgs        : '--with-noncompressedrefs --enable-jitserver',
-                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk'],
+                test                 : 'default'
         ],
         s390xLinuxXL       : [
                 os                   : 'linux',
                 arch                 : 's390x',
                 additionalFileNameTag: "linuxXL",
-                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk'],
+                test                 : 'default',
                 configureArgs        : '--with-noncompressedrefs'
         ],
         ppc64leLinuxXL       : [
                 os                   : 'linux',
                 arch                 : 'ppc64le',
                 additionalFileNameTag: "linuxXL",
-                test                 : ['sanity.openjdk', 'sanity.system', 'extended.system', 'special.openjdk'],
+                test                 : 'default',
                 configureArgs        : '--with-noncompressedrefs --enable-jitserver'
         ],
   ]

--- a/pipelines/jobs/configurations/jdk9u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk9u_pipeline_config.groovy
@@ -4,7 +4,10 @@ class Config9 {
                 os                  : 'mac',
                 arch                : 'x64',
                 additionalNodeLabels: 'build-macstadium-macos1010-1',
-                test                : ['sanity.openjdk', 'sanity.system'],
+                test                : [
+                        nightly: ['sanity.openjdk', 'sanity.system'],
+                        weekly : []
+                ],
                 configureArgs       : '--enable-dtrace=auto'
         ],
 
@@ -12,7 +15,10 @@ class Config9 {
                 os                  : 'linux',
                 arch                : 'x64',
                 additionalNodeLabels: 'centos6',
-                test                : ['sanity.openjdk', 'sanity.system', 'sanity.external'],
+                test                : [
+                        nightly: ['sanity.openjdk', 'sanity.system', 'sanity.external'],
+                        weekly : []
+                ],
                 configureArgs       : '--enable-dtrace=auto'
         ],
 
@@ -24,7 +30,10 @@ class Config9 {
                         hotspot: 'win2012',
                         openj9:  'win2012&&mingw-cygwin'
                 ],
-                test                : ['sanity.openjdk']
+                test                : [
+                        nightly: ['sanity.openjdk'],
+                        weekly : []
+                ]
         ],
 
         ppc64Aix    : [
@@ -37,7 +46,10 @@ class Config9 {
                 os                  : 'linux',
                 arch                : 's390x',
                 additionalNodeLabels: 'rhel7',
-                test                : ['sanity.openjdk', 'sanity.system'],
+                test                : [
+                        nightly: ['sanity.openjdk', 'sanity.system'],
+                        weekly : []
+                ],
                 configureArgs       : '--enable-dtrace=auto'
         ],
 
@@ -52,14 +64,20 @@ class Config9 {
                 os                  : 'linux',
                 arch                : 'ppc64le',
                 additionalNodeLabels: 'centos7',
-                test                : ['sanity.openjdk', 'sanity.system'],
+                test                : [
+                        nightly: ['sanity.openjdk', 'sanity.system'],
+                        weekly : []
+                ],
                 configureArgs       : '--enable-dtrace=auto'
         ],
 
         arm32Linux    : [
                 os                  : 'linux',
                 arch                : 'arm',
-                test                : ['sanity.openjdk'],
+                test                : [
+                        nightly: ['sanity.openjdk'],
+                        weekly : []
+                ],
                 configureArgs       : '--enable-dtrace=auto'
         ],
 
@@ -67,7 +85,10 @@ class Config9 {
                 os                  : 'linux',
                 arch                : 'aarch64',
                 additionalNodeLabels: 'centos7',
-                test                : ['sanity.openjdk'],
+                test                : [
+                        nightly: ['sanity.openjdk'],
+                        weekly : []
+                ],
                 configureArgs       : '--enable-dtrace=auto'
         ],
 


### PR DESCRIPTION
Set standard set of top-level test targets run nightly, weekly. Per release combined nightly and weekly targets will run

1. Keep all pipeline jobs runs the same targets as before.
2. Keep job configuration testList as simple as a placeholder
3. Possible key value for testlist

> no test enabled: test: false, or no test as key of configuration.
> standard set -->  test: "default"
> others --> 

```
                test                : [
                        nightly: [customized target lists, could be empty too],
                        weekly : [customized target lists, could be empty too]
                ],
```

Close #1116 

Signed-off-by: Sophia Guo <sophia.gwf@gmail.com>