### PR TITLE
skip installer stage for PR testing

### DIFF
--- a/pipelines/jobs/pipeline_job_template.groovy
+++ b/pipelines/jobs/pipeline_job_template.groovy
@@ -7,6 +7,7 @@ if(!binding.hasVariable('triggerSchedule')) {
 gitRefSpec = ""
 propagateFailures = false
 runTests = true
+runInstaller = true
 
 // if true means this is running in the pr builder pipeline
 if (binding.hasVariable('PR_BUILDER')) {
@@ -14,6 +15,7 @@ if (binding.hasVariable('PR_BUILDER')) {
     gitRefSpec = "+refs/pull/*:refs/remotes/origin/pr/* +refs/heads/master:refs/remotes/origin/master +refs/heads/*:refs/remotes/origin/*"
     propagateFailures = true
     runTests = false
+    runInstaller = false
 }
 
 if (!binding.hasVariable('disableJob')) {
@@ -61,7 +63,7 @@ pipelineJob("${BUILD_FOLDER}/${JOB_NAME}") {
         stringParam('overridePublishName', "", '<strong>REQUIRED for OpenJ9</strong>: Name that determines the publish name (and is used by the meta-data file), defaults to scmReference(minus _adopt if present).<br/>Nightly builds: Leave blank (defaults to a date_time stamp).<br/>OpenJ9 Release build Java 8 example <code>jdk8u192-b12_openj9-0.12.1</code> and for OpenJ9 Java 11 example <code>jdk-11.0.2+9_openj9-0.12.1</code>.')
         stringParam('scmReference', "", 'Tag name or Branch name from which to build. Nightly builds: Defaults to, Hotspot=dev, OpenJ9=openj9, others=master.</br>Release builds: For hotspot JDK8 this would be the OpenJDK tag, for hotspot JDK11+ this would be the Adopt merge tag for the desired OpenJDK tag eg.jdk-11.0.4+10_adopt, and for OpenJ9 this will be the release branch, eg.openj9-0.14.0.')
         booleanParam('enableTests', runTests, 'If set to true the test pipeline will be executed')
-        booleanParam('enableInstallers', true, 'If set to true the installer pipeline will be executed')
+        booleanParam('enableInstallers', runInstaller, 'If set to true the installer pipeline will be executed')
         stringParam('additionalConfigureArgs', "", "Additional arguments that will be ultimately passed to OpenJDK's <code>./configure</code>")
         stringParam('additionalBuildArgs', "", "Additional arguments to be passed to <code>makejdk-any-platform.sh</code>")
         stringParam('overrideFileNameVersion', "", "When forming the filename, ignore the part of the filename derived from the publishName or timestamp and override it.<br/>For instance if you set this to 'FOO' the final file name will be of the form: <code>OpenJDK8U-jre_ppc64le_linux_openj9_FOO.tar.gz</code>")


### PR DESCRIPTION
Currently the PR tester triggers lots of installer jobs which all back up and can add up to an hour to the pipeline.

fixes: https://github.com/AdoptOpenJDK/openjdk-build/issues/2030