### PR TITLE
switch riscv builds to use dockerfile

### DIFF
--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -173,7 +173,7 @@ class Config11 {
         ],
         riscv64Linux      :  [
                 os                   : 'linux',
-                additionalNodeLabels : 'riscvcross',
+                dockerImage          : 'adoptopenjdk/centos6_build_image',
                 arch                 : 'riscv64',
                 configureArgs        : '--disable-ddr --openjdk-target=riscv64-unknown-linux-gnu --with-sysroot=/opt/fedora28_riscv_root'
         ],


### PR DESCRIPTION
test build: https://ci.adoptopenjdk.net/job/build-scripts/job/jobs/job/jdk11u/job/jdk11u-linux-riscv64-openj9/92/