### PR TITLE
add exploded image build to scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,9 @@ the one you are trying to build.
 -k, --keep
 if using docker, keep the container after the build.
 
+--make-exploded
+creates an exploded image (useful for codesigning jmods). Use --assemble-exploded-image once you have signed the jmods to complete the packaging steps.
+
 -n, --no-colour
 disable colour output.
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ the one you are trying to build.
 -k, --keep
 if using docker, keep the container after the build.
 
---make-exploded
+--make-exploded-image
 creates an exploded image (useful for codesigning jmods). Use --assemble-exploded-image once you have signed the jmods to complete the packaging steps.
 
 -n, --no-colour

--- a/configureBuild.sh
+++ b/configureBuild.sh
@@ -281,6 +281,9 @@ function setMakeArgs() {
     "darwin") BUILD_CONFIG[MAKE_ARGS_FOR_ANY_PLATFORM]=${BUILD_CONFIG[MAKE_ARGS_FOR_ANY_PLATFORM]:-"product-images mac-legacy-jre-bundle"} ;;
     *) BUILD_CONFIG[MAKE_ARGS_FOR_ANY_PLATFORM]=${BUILD_CONFIG[MAKE_ARGS_FOR_ANY_PLATFORM]:-"product-images legacy-jre-image"} ;;
     esac
+    if [ "${BUILD_CONFIG[MAKE_EXPLODED]}" == "true" ]; then
+      BUILD_CONFIG[MAKE_ARGS_FOR_ANY_PLATFORM]=""
+    fi
   else
     BUILD_CONFIG[MAKE_ARGS_FOR_ANY_PLATFORM]=${BUILD_CONFIG[MAKE_ARGS_FOR_ANY_PLATFORM]:-"images"}
   fi

--- a/configureBuild.sh
+++ b/configureBuild.sh
@@ -281,6 +281,7 @@ function setMakeArgs() {
     "darwin") BUILD_CONFIG[MAKE_ARGS_FOR_ANY_PLATFORM]=${BUILD_CONFIG[MAKE_ARGS_FOR_ANY_PLATFORM]:-"product-images mac-legacy-jre-bundle"} ;;
     *) BUILD_CONFIG[MAKE_ARGS_FOR_ANY_PLATFORM]=${BUILD_CONFIG[MAKE_ARGS_FOR_ANY_PLATFORM]:-"product-images legacy-jre-image"} ;;
     esac
+    # In order to build an exploded image, no other make targets can be used
     if [ "${BUILD_CONFIG[MAKE_EXPLODED]}" == "true" ]; then
       BUILD_CONFIG[MAKE_ARGS_FOR_ANY_PLATFORM]=""
     fi

--- a/sbin/common/config_init.sh
+++ b/sbin/common/config_init.sh
@@ -200,7 +200,7 @@ function parseConfigurationArguments() {
         "--make-args" )
         BUILD_CONFIG[USER_SUPPLIED_MAKE_ARGS]="$1"; shift;;
 
-        "--make-exploded" )
+        "--make-exploded-image" )
         BUILD_CONFIG[MAKE_EXPLODED]=true;;
 
         "--assemble-exploded-image" )

--- a/sbin/common/config_init.sh
+++ b/sbin/common/config_init.sh
@@ -32,6 +32,7 @@
 # map. This is why we can't have nice things.
 CONFIG_PARAMS=(
 ADOPT_PATCHES
+ASSEMBLE_EXPLODED_IMAGE
 OPENJDK_BUILD_REPO_BRANCH
 OPENJDK_BUILD_REPO_URI
 BRANCH
@@ -65,6 +66,7 @@ TEST_IMAGE_PATH
 JVM_VARIANT
 MACOSX_CODESIGN_IDENTITY
 MAKE_ARGS_FOR_ANY_PLATFORM
+MAKE_EXPLODED
 MAKE_COMMAND_NAME
 NUM_PROCESSORS
 OPENJDK_BUILD_NUMBER
@@ -197,6 +199,12 @@ function parseConfigurationArguments() {
 
         "--make-args" )
         BUILD_CONFIG[USER_SUPPLIED_MAKE_ARGS]="$1"; shift;;
+
+        "--make-exploded" )
+        BUILD_CONFIG[MAKE_EXPLODED]=true;;
+
+        "--assemble-exploded-image" )
+        BUILD_CONFIG[ASSEMBLE_EXPLODED_IMAGE]=true;;
 
         "--codesign-identity" )
         BUILD_CONFIG[MACOSX_CODESIGN_IDENTITY]="$1"; shift;;
@@ -352,6 +360,9 @@ function configDefaults() {
 
   # The OpenJDK source code repository to build from, e.g. an AdoptOpenJDK repo
   BUILD_CONFIG[REPOSITORY]=""
+
+  BUILD_CONFIG[ASSEMBLE_EXPLODED_IMAGE]=${BUILD_CONFIG[ASSEMBLE_EXPLODED_IMAGE]:-"false"}
+  BUILD_CONFIG[MAKE_EXPLODED]=${BUILD_CONFIG[MAKE_EXPLODED]:-"false"}
 
   # The default AdoptOpenJDK/openjdk-build repo branch
   BUILD_CONFIG[OPENJDK_BUILD_REPO_BRANCH]="master"

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -631,9 +631,11 @@ applyPatches() {
 ##################################################################
 
 function configureWorkspace() {
-  createWorkspace
-  downloadingRequiredDependencies
-  relocateToTmpIfNeeded
-  checkoutAndCloneOpenJDKGitRepo
-  applyPatches
+  if [[ "${BUILD_CONFIG[ASSEMBLE_EXPLODED_IMAGE]}" != "true" ]]; then
+    createWorkspace
+    downloadingRequiredDependencies
+    relocateToTmpIfNeeded
+    checkoutAndCloneOpenJDKGitRepo
+    applyPatches
+  fi
 }


### PR DESCRIPTION
**By default, this PR changes nothing. It just adds the ability to pause a build before the jmods are created and then continue.**

This PR allows us to create an exploded image `--make-exploded-image` (an image before the jmods have been compressed)

This allows us to then codesign the jmods before the get packaged up and then continue the build job using the `--assemble-exploded-image` flag.