### PR TITLE
Add option to create debug-symbols in a separate file

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ branch which may contain a very small diff set to the master branch
 (which is a clone from the OpenJDK mercurial forest).
 
 -B, --build-number <build_number>
-specify the OpenJDK build number to build from, e.g. b12.
+specify the OpenJDK build number to build hfrom, e.g. b12.
 For reference, OpenJDK version numbers look like 1.8.0_162-b12 (for Java 8) or
 9.0.4+11 (for Java 9+) with the build number being the suffix at the end.
 
@@ -138,7 +138,7 @@ specify any custom user configuration arguments.
 clean out any 'bad' local git repo you already have.
 
 --create-debug-symbols-package
-create a debug-symbols only archive if debug symbols are generated.
+create a debug-symbols only archive (if debug symbols were generated).
 
 -d, --destination <path>
 specify the location for the built binary, e.g. /path/.

--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ specify any custom user configuration arguments.
 --clean-git-repo
 clean out any 'bad' local git repo you already have.
 
+--create-debug-symbols-package
+create a debug-symbols only archive if debug symbols are generated.
+
 -d, --destination <path>
 specify the location for the built binary, e.g. /path/.
 This is typically used in conjunction with -T to create a custom path

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -297,14 +297,19 @@ configureDebugParameters() {
   # other options include fastdebug and slowdebug.
   addConfigureArg "--with-debug-level=" "release"
 
-  if [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK8_CORE_VERSION}" ]; then
-    addConfigureArg "--disable-zip-debug-info" ""
-    if [[ "${BUILD_CONFIG[BUILD_VARIANT]}" != "${BUILD_VARIANT_OPENJ9}" ]]; then
-      addConfigureArg "--disable-debug-symbols" ""
-    fi
+  # If debug symbols package is requested, generate them separately
+  if [ ${BUILD_CONFIG[CREATE_DEBUG_SYMBOLS_PACKAGE]} == true ]; then
+    addConfigureArg "--with-native-debug-symbols=" "external"
   else
-    if [[ "${BUILD_CONFIG[BUILD_VARIANT]}" != "${BUILD_VARIANT_OPENJ9}" ]]; then
-      addConfigureArg "--with-native-debug-symbols=" "none"
+    if [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK8_CORE_VERSION}" ]; then
+      addConfigureArg "--disable-zip-debug-info" ""
+      if [[ "${BUILD_CONFIG[BUILD_VARIANT]}" != "${BUILD_VARIANT_OPENJ9}" ]]; then
+        addConfigureArg "--disable-debug-symbols" ""
+      fi
+    else
+      if [[ "${BUILD_CONFIG[BUILD_VARIANT]}" != "${BUILD_VARIANT_OPENJ9}" ]]; then
+        addConfigureArg "--with-native-debug-symbols=" "none"
+      fi
     fi
   fi
 }
@@ -671,6 +676,7 @@ removingUnnecessaryFiles() {
         ;;
     esac
 
+    # if debug symbols were found, copy them to a different folder 
     if [ -n "${debugSymbols}" ] ; then
       local debugSymbolsTargetPath=$(getDebugSymbolsArchivePath)
       echo "${debugSymbols}" | cpio -pdm ${debugSymbolsTargetPath}

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -583,6 +583,11 @@ getDebugImageArchivePath() {
   echo "${jdkArchivePath}-debug-image"
 }
 
+getDebugSymbolsArchivePath() {
+  local jdkArchivePath=$(getJdkArchivePath)
+  echo "${jdkArchivePath}-debug-symbols"
+}
+
 # Clean up
 removingUnnecessaryFiles() {
   local jdkTargetPath=$(getJdkArchivePath)
@@ -647,28 +652,56 @@ removingUnnecessaryFiles() {
   # but if they were explicitly requested via the configure option
   # '--with-native-debug-symbols=(external|zipped)' leave them alone.
   if [[ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_OPENJ9}" ]] ; then
-    # .diz files may be present on any platform
-    # Note that on AIX, find does not support the '-delete' option.
-    find "${jdkTargetPath}" "${jreTargetPath}" -type f -name "*.diz" | xargs rm -f || true
+    deleteDebugSymbols
+  fi
 
+  if [ ${BUILD_CONFIG[CREATE_DEBUG_SYMBOLS_PACKAGE]} == true ]; then
     case "${BUILD_CONFIG[OS_KERNEL_NAME]}" in
       *cygwin*)
-        # on Windows, we want to remove .map and .pdb files
-        find "${jdkTargetPath}" "${jreTargetPath}" -type f -name "*.map" -delete || true
-        find "${jdkTargetPath}" "${jreTargetPath}" -type f -name "*.pdb" -delete || true
+        # on Windows, we want to take .pdb files
+        debugSymbols=$(find "${jdkTargetPath}" -type f -name "*.pdb")
         ;;
       darwin)
-        # on MacOSX, we want to remove .dSYM folders
-        find "${jdkTargetPath}" "${jreTargetPath}" -type d -name "*.dSYM" | xargs -I "{}" rm -rf "{}"
+        # on MacOSX, we want to take .dSYM folders
+        debugSymbols=$(find "${jdkTargetPath}" -print -type d -name "*.dSYM")
         ;;
       *)
-        # on other platforms, we want to remove .debuginfo files
-        find "${jdkTargetPath}" "${jreTargetPath}" -type f -name "*.debuginfo" | xargs rm -f || true
+        # on other platforms, we want to take .debuginfo files
+        debugSymbols=$(find "${jdkTargetPath}" -type f -name "*.debuginfo")
         ;;
     esac
+
+    if [ -n "${debugSymbols}" ] ; then
+      local debugSymbolsTargetPath=$(getDebugSymbolsArchivePath)
+      echo "${debugSymbols}" | cpio -pdm ${debugSymbolsTargetPath}
+    fi
+
+    deleteDebugSymbols
   fi
 
   echo "Finished removing unnecessary files from ${jdkTargetPath}"
+}
+
+deleteDebugSymbols() {
+  # .diz files may be present on any platform
+  # Note that on AIX, find does not support the '-delete' option.
+  find "${jdkTargetPath}" "${jreTargetPath}" -type f -name "*.diz" | xargs rm -f || true
+
+  case "${BUILD_CONFIG[OS_KERNEL_NAME]}" in
+    *cygwin*)
+      # on Windows, we want to remove .map and .pdb files
+      find "${jdkTargetPath}" "${jreTargetPath}" -type f -name "*.map" -delete || true
+      find "${jdkTargetPath}" "${jreTargetPath}" -type f -name "*.pdb" -delete || true
+      ;;
+    darwin)
+      # on MacOSX, we want to remove .dSYM folders
+      find "${jdkTargetPath}" "${jreTargetPath}" -type d -name "*.dSYM" | xargs -I "{}" rm -rf "{}"
+      ;;
+    *)
+      # on other platforms, we want to remove .debuginfo files
+      find "${jdkTargetPath}" "${jreTargetPath}" -type f -name "*.debuginfo" | xargs rm -f || true
+      ;;
+  esac
 }
 
 moveFreetypeLib() {
@@ -799,6 +832,7 @@ createOpenJDKTarArchive()
   local jreTargetPath=$(getJreArchivePath)
   local testImageTargetPath=$(getTestImageArchivePath)
   local debugImageTargetPath=$(getDebugImageArchivePath)
+  local debugSymbolsTargetPath=$(getDebugSymbolsArchivePath)
 
   echo "OpenJDK JDK path will be ${jdkTargetPath}. JRE path will be ${jreTargetPath}"
 
@@ -815,6 +849,11 @@ createOpenJDKTarArchive()
     echo "OpenJDK debug image path will be ${debugImageTargetPath}."
     local debugImageName=$(echo "${BUILD_CONFIG[TARGET_FILE_NAME]//-jdk/-debugimage}")
     createArchive "${debugImageTargetPath}" "${debugImageName}"
+  fi
+  if [ -d "${debugSymbolsTargetPath}" ]; then
+    echo "OpenJDK debug symbols path will be ${debugSymbolsTargetPath}."
+    local debugSymbolsName=$(echo "${BUILD_CONFIG[TARGET_FILE_NAME]//-jdk/-debug-symbols}")
+    createArchive "${debugSymbolsTargetPath}" "${debugSymbolsName}"
   fi
   createArchive "${jdkTargetPath}" "${BUILD_CONFIG[TARGET_FILE_NAME]}"
 }

--- a/sbin/common/config_init.sh
+++ b/sbin/common/config_init.sh
@@ -47,6 +47,7 @@ CONTAINER_NAME
 COPY_MACOSX_FREE_FONT_LIB_FOR_JDK_FLAG
 COPY_MACOSX_FREE_FONT_LIB_FOR_JRE_FLAG
 COPY_TO_HOST
+CREATE_DEBUG_SYMBOLS_PACKAGE
 DEBUG_DOCKER
 DEBUG_IMAGE_PATH
 DISABLE_ADOPT_BRANCH_SAFETY
@@ -218,6 +219,9 @@ function parseConfigurationArguments() {
 
         "--clean-libs" )
         BUILD_CONFIG[CLEAN_LIBS]=true;;
+
+        "--create-debug-symbols-package" )
+        BUILD_CONFIG[CREATE_DEBUG_SYMBOLS_PACKAGE]="true";;
 
         "--disable-adopt-branch-safety" )
         BUILD_CONFIG[DISABLE_ADOPT_BRANCH_SAFETY]=true;;
@@ -391,6 +395,9 @@ function configDefaults() {
       BUILD_CONFIG[MAKE_COMMAND_NAME]="make"
       ;;
   esac
+
+  # The default behavior of whether we want to create a separate debug symbols archive
+  BUILD_CONFIG[CREATE_DEBUG_SYMBOLS_PACKAGE]="false"
 
   BUILD_CONFIG[SIGN]="false"
   BUILD_CONFIG[JDK_BOOT_DIR]=""


### PR DESCRIPTION
Currently, we either have the option to make the images alone or with the debug symbols included in the same tar.gz/zip file.

This change is to have the option of including the debug symbols in a separate package, outside the JDK archive. If this option is called, we basically take the debug symbols of each platform, copy them to a new folder and then delete them from the images folder, and that folder just created is zipped as an artifact.

Issue: https://github.com/AdoptOpenJDK/openjdk-build/issues/2042