### PR TITLE
Stop building client VM on Windows for 15, 16

### DIFF
--- a/pipelines/jobs/configurations/jdk15u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk15u_pipeline_config.groovy
@@ -51,7 +51,7 @@ class Config15 {
                         hotspot: 'win2012&&vs2017'
                 ],
                 buildArgs : [
-                        hotspot : '--jvm-variant client,server'
+                        hotspot : '--jvm-variant server'
                 ],
                 test                : ['sanity.openjdk', 'sanity.perf', 'sanity.system', 'extended.system']
         ],

--- a/pipelines/jobs/configurations/jdk15u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk15u_pipeline_config.groovy
@@ -50,9 +50,6 @@ class Config15 {
                 additionalNodeLabels: [
                         hotspot: 'win2012&&vs2017'
                 ],
-                buildArgs : [
-                        hotspot : '--jvm-variant server'
-                ],
                 test                : ['sanity.openjdk', 'sanity.perf', 'sanity.system', 'extended.system']
         ],
 

--- a/pipelines/jobs/configurations/jdk16_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk16_pipeline_config.groovy
@@ -35,9 +35,6 @@ class Config16 {
                 additionalNodeLabels: [
                         hotspot: 'win2012&&vs2017'
                 ],
-                buildArgs : [
-                        hotspot : '--jvm-variant server'
-                ],
                 test                : [
                         nightly: false,
                         release: ['sanity.openjdk', 'sanity.perf', 'sanity.system', 'extended.system']

--- a/pipelines/jobs/configurations/jdk16_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk16_pipeline_config.groovy
@@ -36,7 +36,7 @@ class Config16 {
                         hotspot: 'win2012&&vs2017'
                 ],
                 buildArgs : [
-                        hotspot : '--jvm-variant client,server'
+                        hotspot : '--jvm-variant server'
                 ],
                 test                : [
                         nightly: false,


### PR DESCRIPTION
Starting with 15, building the client VM together with the server VM on Windows causes the exclusion of modules/functionality related to Graal, namely:

```
jdk.internal.vm.compiler@15
jdk.internal.vm.compiler.management@15
```

Windows is the last x64 platform that we build the client VM on together with the server VM. Of the other vendors I checked (OpenJDK, Oracle, Azul, Bellsoft), only Bellsoft Liberica still has a client VM bundled with their Windows x64 build of OpenJDK **14**. The state of 15 for Bellsoft is unknown to me. From a technical standpoint, the server VM is superior nowadays (higher memory limits, ...) and the slower start-up compared to the client VM shouldn't really be an issue anymore.

I therefore propose dropping the client/server combination VM on Windows x64 starting with 15.

Fixes #2047.