### PR TITLE
Prevent --help from running build

### DIFF
--- a/sbin/common/config_init.sh
+++ b/sbin/common/config_init.sh
@@ -249,7 +249,7 @@ function parseConfigurationArguments() {
         BUILD_CONFIG[FREETYPE]=false;;
 
         "--help" | "-h" )
-        man ./makejdk-any-platform.1;;
+        man ./makejdk-any-platform.1 && exit 0;;
 
         "--ignore-container" | "-i" )
         BUILD_CONFIG[REUSE_CONTAINER]=false;;


### PR DESCRIPTION
Works locally:
```bash
➜  openjdk-build git:(master) ✗ ./makejdk-any-platform.sh --help
Starting ./makejdk-any-platform.sh to configure, build (Adopt)OpenJDK binary
Parsing opt: --help
➜  openjdk-build git:(manpage) ✗ 
```
Fixes: #2060 
Signed-off-by: Morgan Davies <morgandavies2020@gmail.com>