### PR TITLE
mac: Specify which keychain to unlock when signing mac builds

### DIFF
--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -57,7 +57,7 @@ then
   # Login to KeyChain
   # shellcheck disable=SC2046
   # shellcheck disable=SC2006
-  security unlock-keychain -p `cat ~/.password`
+  security unlock-keychain -p `cat ~/.password` login.keychain-db
   export BUILD_ARGS="${BUILD_ARGS} --codesign-identity 'Developer ID Application: London Jamocha Community CIC'"
 fi
 

--- a/sign.sh
+++ b/sign.sh
@@ -88,7 +88,7 @@ signRelease()
       # Login to KeyChain
       # shellcheck disable=SC2046
       # shellcheck disable=SC2006
-      security unlock-keychain -p `cat ~/.password`
+      security unlock-keychain -p `cat ~/.password` login.keychain-db
 
       ENTITLEMENTS="$WORKSPACE/entitlements.plist"
       xattr -cr .


### PR DESCRIPTION
Ref: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1382

When unlocking a keychain, according to the `security unlock-keychain` syntax, if a keychain isn't specified, it will attempt to unlock the system keychain, which the Jenkins user isn't able to do. This can lead to the infra issue referenced above. 