### PR TITLE
Fix RISC-V version string so it gets sorted correctly in API

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -517,7 +517,7 @@ printJavaVersionString()
        local jdkversion=$(getOpenJdkVersion)
        cat << EOT > "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/version.txt"
 openjdk version "${jdkversion%%+*}" "$(date +%Y-%m-%d)"
-OpenJDK Runtime Environment AdoptOpenJDK (build ${jdkversion%%+*}+0-$(date +%Y%m%d%H%M))
+OpenJDK Runtime Environment AdoptOpenJDK (build ${jdkversion}-$(date +%Y%m%d%H%M))
 Eclipse OpenJ9 VM AdoptOpenJDK (build master-000000000, JRE 11 Linux riscv-64-Bit Compressed References $(date +%Y%m%d)_00 (JIT disabled, AOT disabled)
 OpenJ9   - 000000000
 OMR      - 000000000


### PR DESCRIPTION
This only impacts RISC-V and won't touch JDK15 or any production platform so I'd quite like to get this tested ASAP since I'm getting asked about it. Happy to force it back immedaitely if it causes any issues.

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>