### PR TITLE
Change location of windows.p12 file for signing/installer jobs

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -230,7 +230,7 @@ class Build {
 
                 if (buildConfig.TARGET_OS == "windows") {
                     filter = "**/OpenJDK*_windows_*.zip"
-                    certificate = "C:\\Users\\jenkins\\windows.p12"
+                    certificate = "C:\\openjdk\\windows.p12"
                     nodeFilter = "${nodeFilter}&&build"
 
                 } else if (buildConfig.TARGET_OS == "mac") {
@@ -338,7 +338,7 @@ class Build {
 
     private void buildWindowsInstaller(VersionInfo versionData) {
         def filter = "**/OpenJDK*jdk_*_windows*.zip"
-        def certificate = "C:\\Users\\jenkins\\windows.p12"
+        def certificate = "C:\\openjdk\\windows.p12"
 
         def buildNumber = versionData.build
 


### PR DESCRIPTION
Ref (& possible fix): https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1556

The windows installer jobs and the sign build jobs have intermittent issues of finding the `windows.p12` file that is stored in `C:/Users/Jenkins`, despite the file being there. The current theory is that this is due to there being other directories on the build machines in the `C:\Users` folder following the format `jenkins.<something_random>`, that may be confusing these sign/installer jobs. 
I've made copies of the `windows.p12` files and put them in `C:\openjdk` directory on all 4 of the Windows build machines. I've kept them in their original place as well, in case this PR doesn't fix the issue and needs to be reverted.