### PR TITLE
Use basic sleep on groovy scripts

### DIFF
--- a/pipelines/build/common/config_regeneration.groovy
+++ b/pipelines/build/common/config_regeneration.groovy
@@ -393,7 +393,9 @@ class Regeneration implements Serializable {
                             if (inProgress) {
                                 // Sleep for a bit, then check again...
                                 context.println "[INFO] ${pipeline} is running. Sleeping for ${sleepTime} seconds while waiting for ${pipeline} to complete..."
-                                context.sleep "${sleepTime}s"
+
+                                // Unfortunately, we can't use advanced sleep time here ("900s") since it must be an int
+                                context.sleep sleepTime
                             }
 
                         }


### PR DESCRIPTION
* Advanced sleep doesn't work correctly on groovy scripts

Follow up to #2070 
Signed-off-by: Morgan Davies <morgandavies2020@gmail.com>