### PR TITLE
Solaris "sort" does not support stable sort option for sorting JDK tag sequence

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -785,11 +785,12 @@ getFirstTagFromOpenJDKGitRepo()
     # Tag Format "jdk8uLLL-bBB"
     # cut chars 1-5 => LLL-bBB
     # awk "-b" separator into a single "-" => LLL-BB
+    # prefix "-" to allow line numbering stable sorting using nl => -LLL-BB
     # Sort by build level BB first
-    # Then do "stable" sort (keeping BBB order) by build level LLL
-    local jdk8_tag_sort1="sort -t- -k2n"
-    local jdk8_tag_sort2="sort -t- -k1n -s"
-    local jdk8_get_tag_cmd="grep -v _openj9 | grep -v _adopt | cut -c6- | awk -F'[\-b]+' '{print \$1\"-\"\$2}' | $jdk8_tag_sort1 | $jdk8_tag_sort2 | sed 's/^/jdk8u/' | sed 's/-/-b/' | tail -1"
+    # Then do "stable" sort (keeping BB order) by build level LLL
+    local jdk8_tag_sort1="sort -t- -k3n"
+    local jdk8_tag_sort2="sort -t- -k2n"
+    local jdk8_get_tag_cmd="grep -v _openj9 | grep -v _adopt | cut -c6- | awk -F'[\-b]+' '{print \$1\"-\"\$2}' | sed 's/^/-/' | $jdk8_tag_sort1 | nl | $jdk8_tag_sort2 | cut -f2- | sed 's/^-/jdk8u/' | sed 's/-/-b/' | tail -1"
 
     # JDK11+ tag sorting:
     # We use sort and tail to choose the latest tag in case more than one refers the same commit.
@@ -798,8 +799,8 @@ getFirstTagFromOpenJDKGitRepo()
     # First, sort on build number (B):
     local jdk11plus_tag_sort1="sort -t+ -k2n"
     # Second, (stable) sort on (V), (W), (X):
-    local jdk11plus_tag_sort2="sort -t. -k2n -k3n -k4n -s"
-    jdk11plus_get_tag_cmd="grep -v _openj9 | grep -v _adopt | sed 's/jdk-/jdk./g' | $jdk11plus_tag_sort1 | $jdk11plus_tag_sort2 | sed 's/jdk./jdk-/g' | tail -1"
+    local jdk11plus_tag_sort2="sort -t. -k2n -k3n -k4n"
+    jdk11plus_get_tag_cmd="grep -v _openj9 | grep -v _adopt | sed 's/jdk-/jdk./g' | $jdk11plus_tag_sort1 | nl | $jdk11plus_tag_sort2 | cut -f2- | sed 's/jdk./jdk-/g' | tail -1"
 
     # Choose tag search keyword and get cmd based on version
     local TAG_SEARCH="jdk-${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}*+*"


### PR DESCRIPTION
Solaris sort does not support "-s" option, so this PR changes the stable sort to simply use line numbering to achieve the same...

Signed-off-by: Andrew Leonard <andrew_m_leonard@uk.ibm.com>