### PR TITLE
enable sanity and extended.functional testing to Aarch64 nightly builds

### DIFF
--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -121,7 +121,10 @@ class Config11 {
                 os                  : 'linux',
                 arch                : 'aarch64',
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
-                test                : 'default',
+                test                : [
+                        nightly: ['sanity.functional', 'extended.functional', 'sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external'],
+                        weekly : ['extended.openjdk', 'extended.perf', 'extended.external', 'special.openjdk','special.functional', 'special.system', 'special.perf']
+                ],
                 configureArgs       : '--enable-dtrace=auto'
         ],
 


### PR DESCRIPTION
- enable sanity and extended.functional testing to Aarch64 nightly builds
- Issue:AdoptOpenJDK/openjdk-build#2085

Signed-off-by: Longyu Zhang <longyu.zhang@ibm.com>