### PR TITLE
Terminate build on invalid boot jdk

### DIFF
--- a/sbin/common/common.sh
+++ b/sbin/common/common.sh
@@ -176,7 +176,7 @@ function setBootJdk() {
     echo "If this is incorrect explicitly configure JDK_BOOT_DIR using --jdk-boot-dir"
 
     # Calculate version number of boot jdk. Output on Windows contains \r, hence gsub("\r", "", $3).
-    export BOOT_JDK_VERSION_NUMBER=$("${BUILD_CONFIG[JDK_BOOT_DIR]}/bin/java" -XshowSettings:properties -version 2>&1 | awk '/java.specification.version/{gsub(/1\./,"",$3);gsub("\r", "", $3);print $3}' | tr -d \\r)
+    export BOOT_JDK_VERSION_NUMBER=$("${BUILD_CONFIG[JDK_BOOT_DIR]}/bin/java" -XshowSettings:properties -version 2>&1 | awk '/java.specification.version/{gsub(/1\./,"",$3);gsub("\r", "", $3);print $3}')
     if [ -z "$BOOT_JDK_VERSION_NUMBER" ]; then
       echo "[ERROR] The BOOT_JDK_VERSION_NUMBER was not found. Likelihood is that the boot jdk settings properties don't contain a java.specification.version..."
       "${BUILD_CONFIG[JDK_BOOT_DIR]}/bin/java" -XshowSettings:properties -version 2>&1

--- a/sbin/common/common.sh
+++ b/sbin/common/common.sh
@@ -173,7 +173,25 @@ function setBootJdk() {
     fi
 
     echo "Guessing JDK_BOOT_DIR: ${BUILD_CONFIG[JDK_BOOT_DIR]}"
-    echo "If this is incorrect explicitly configure JDK_BOOT_DIR"
+    echo "If this is incorrect explicitly configure JDK_BOOT_DIR using --jdk-boot-dir"
+
+    # Calculate version number of boot jdk
+    export BOOT_JDK_VERSION_NUMBER=$(${BUILD_CONFIG[JDK_BOOT_DIR]}/bin/java -XshowSettings:properties -version 2>&1 | awk '/java.specification.version/{gsub(/1\./,"",$3);print $3}')
+    if [ -z "$BOOT_JDK_VERSION_NUMBER" ]; then
+      echo "[ERROR] The BOOT_JDK_VERSION_NUMBER was not found. Likelihood is that the boot jdk settings properties don't contain a java.specification.version..."
+      ${BUILD_CONFIG[JDK_BOOT_DIR]}/bin/java -XshowSettings:properties -version 2>&1
+      exit 2
+    fi
+
+    # If bootjdk isn't the same version and isn't a n-1 version, crash out with informational message
+    export REQUIRED_BOOT_JDK=$((${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}-1))
+
+    if [ ${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]} -ne $BOOT_JDK_VERSION_NUMBER ] && [ $REQUIRED_BOOT_JDK -ne $BOOT_JDK_VERSION_NUMBER ]; then
+      echo "[ERROR] A JDK${BOOT_JDK_VERSION_NUMBER} boot jdk cannot build a JDK${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]} binary"
+      echo "[ERROR] Please download a JDK${REQUIRED_BOOT_JDK} (preferable) OR JDK${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]} binary and pass it into this script using -J, --jdk-boot-dir"
+      exit 2
+    fi
+
   else
     echo "Overriding JDK_BOOT_DIR, set to ${BUILD_CONFIG[JDK_BOOT_DIR]}"
   fi

--- a/sbin/common/common.sh
+++ b/sbin/common/common.sh
@@ -176,7 +176,7 @@ function setBootJdk() {
     echo "If this is incorrect explicitly configure JDK_BOOT_DIR using --jdk-boot-dir"
 
     # Calculate version number of boot jdk
-    export BOOT_JDK_VERSION_NUMBER=$(${BUILD_CONFIG[JDK_BOOT_DIR]}/bin/java -XshowSettings:properties -version 2>&1 | awk '/java.specification.version/{gsub(/1\./,"",$3);print $3}')
+    export BOOT_JDK_VERSION_NUMBER=$(${BUILD_CONFIG[JDK_BOOT_DIR]}/bin/java -XshowSettings:properties -version 2>&1 | awk '/java.specification.version/{print $3}' | awk -F. '{print$NF}')
     if [ -z "$BOOT_JDK_VERSION_NUMBER" ]; then
       echo "[ERROR] The BOOT_JDK_VERSION_NUMBER was not found. Likelihood is that the boot jdk settings properties don't contain a java.specification.version..."
       ${BUILD_CONFIG[JDK_BOOT_DIR]}/bin/java -XshowSettings:properties -version 2>&1
@@ -186,7 +186,7 @@ function setBootJdk() {
     # If bootjdk isn't the same version and isn't a n-1 version, crash out with informational message
     export REQUIRED_BOOT_JDK=$((${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}-1))
 
-    if [ ${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]} -ne $BOOT_JDK_VERSION_NUMBER ] && [ $REQUIRED_BOOT_JDK -ne $BOOT_JDK_VERSION_NUMBER ]; then
+    if [[ ${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]} -ne $BOOT_JDK_VERSION_NUMBER ]] && [[ $REQUIRED_BOOT_JDK -ne $BOOT_JDK_VERSION_NUMBER ]]; then
       echo "[ERROR] A JDK${BOOT_JDK_VERSION_NUMBER} boot jdk cannot build a JDK${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]} binary"
       echo "[ERROR] Please download a JDK${REQUIRED_BOOT_JDK} (preferable) OR JDK${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]} binary and pass it into this script using -J, --jdk-boot-dir"
       exit 2

--- a/sbin/common/common.sh
+++ b/sbin/common/common.sh
@@ -175,18 +175,18 @@ function setBootJdk() {
     echo "Guessing JDK_BOOT_DIR: ${BUILD_CONFIG[JDK_BOOT_DIR]}"
     echo "If this is incorrect explicitly configure JDK_BOOT_DIR using --jdk-boot-dir"
 
-    # Calculate version number of boot jdk
-    export BOOT_JDK_VERSION_NUMBER=$(${BUILD_CONFIG[JDK_BOOT_DIR]}/bin/java -XshowSettings:properties -version 2>&1 | awk '/java.specification.version/{print $3}' | awk -F. '{print$NF}')
+    # Calculate version number of boot jdk. Output on Windows contains \r, hence gsub("\r", "", $3).
+    export BOOT_JDK_VERSION_NUMBER=$("${BUILD_CONFIG[JDK_BOOT_DIR]}/bin/java" -XshowSettings:properties -version 2>&1 | awk '/java.specification.version/{gsub(/1\./,"",$3);gsub("\r", "", $3);print $3}' | tr -d \\r)
     if [ -z "$BOOT_JDK_VERSION_NUMBER" ]; then
       echo "[ERROR] The BOOT_JDK_VERSION_NUMBER was not found. Likelihood is that the boot jdk settings properties don't contain a java.specification.version..."
-      ${BUILD_CONFIG[JDK_BOOT_DIR]}/bin/java -XshowSettings:properties -version 2>&1
+      "${BUILD_CONFIG[JDK_BOOT_DIR]}/bin/java" -XshowSettings:properties -version 2>&1
       exit 2
     fi
 
     # If bootjdk isn't the same version and isn't a n-1 version, crash out with informational message
     export REQUIRED_BOOT_JDK=$((${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}-1))
 
-    if [[ ${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]} -ne $BOOT_JDK_VERSION_NUMBER ]] && [[ $REQUIRED_BOOT_JDK -ne $BOOT_JDK_VERSION_NUMBER ]]; then
+    if [ ${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]} -ne $BOOT_JDK_VERSION_NUMBER ] && [ $REQUIRED_BOOT_JDK -ne $BOOT_JDK_VERSION_NUMBER ]; then
       echo "[ERROR] A JDK${BOOT_JDK_VERSION_NUMBER} boot jdk cannot build a JDK${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]} binary"
       echo "[ERROR] Please download a JDK${REQUIRED_BOOT_JDK} (preferable) OR JDK${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]} binary and pass it into this script using -J, --jdk-boot-dir"
       exit 2


### PR DESCRIPTION
I did experiment with adding some code to download a jdk if an invalid one is detected but it proved a little too convoluted, proving easier just to ask the user to download one themselves

Closes: #2054 
Signed-off-by: Morgan Davies <morgandavies2020@gmail.com>