### PR TITLE
Update OpenSSL to version 1.1.1h for all non-Windows platforms

### DIFF
--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -256,7 +256,7 @@ updateOpenj9Sources() {
   # Building OpenJDK with OpenJ9 must run get_source.sh to clone openj9 and openj9-omr repositories
   if [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_OPENJ9}" ]; then
     cd "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}" || return
-    bash get_source.sh --openssl-version=1.1.1g
+    bash get_source.sh --openssl-version=1.1.1h
     cd "${BUILD_CONFIG[WORKSPACE_DIR]}"
   fi
 }


### PR DESCRIPTION
This will fetch the current latest version (1.1.1h)
for MacOS as well as all linuxs and AIX

Fixes #2123

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>