### PR TITLE
WIP: Active Node Timeout for Build Pipelines

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -33,6 +33,7 @@ limitations under the License.
 //@CompileStatic(extensions = "JenkinsTypeCheckHelperExtension")
 class Builder implements Serializable {
     String javaToBuild
+    String activeNodeTimeout
     String adoptBuildNumber
     String overrideFileNameVersion
     String additionalBuildArgs
@@ -94,6 +95,7 @@ class Builder implements Serializable {
                 SCM_REF: scmReference,
                 BUILD_ARGS: buildArgs,
                 NODE_LABEL: "${additionalNodeLabels}&&${platformConfig.os}&&${platformConfig.arch}",
+                ACTIVE_NODE_TIMEOUT: activeNodeTimeout,
                 CODEBUILD: platformConfig.codebuild as Boolean,
                 DOCKER_IMAGE: dockerImage,
                 DOCKER_FILE: dockerFile,
@@ -490,6 +492,7 @@ return {
     String javaToBuild,
     Map<String, Map<String, ?>> buildConfigurations,
     String targetConfigurations,
+    String activeNodeTimeout,
     String dockerExcludes,
     String enableTests,
     String enableInstallers,
@@ -536,6 +539,7 @@ return {
             javaToBuild: javaToBuild,
             buildConfigurations: buildConfigurations,
             targetConfigurations: new JsonSlurper().parseText(targetConfigurations) as Map,
+            activeNodeTimeout: activeNodeTimeout,
             dockerExcludes: buildsExcludeDocker,
             enableTests: Boolean.parseBoolean(enableTests),
             enableInstallers: Boolean.parseBoolean(enableInstallers),

--- a/pipelines/build/common/config_regeneration.groovy
+++ b/pipelines/build/common/config_regeneration.groovy
@@ -266,6 +266,7 @@ class Regeneration implements Serializable {
                 SCM_REF: "",
                 BUILD_ARGS: buildArgs,
                 NODE_LABEL: "${additionalNodeLabels}&&${platformConfig.os}&&${platformConfig.arch}",
+                ACTIVE_NODE_TIMEOUT: "",
                 CODEBUILD: platformConfig.codebuild as Boolean,
                 DOCKER_IMAGE: dockerImage,
                 DOCKER_FILE: dockerFile,

--- a/pipelines/build/common/create_job_from_template.groovy
+++ b/pipelines/build/common/create_job_from_template.groovy
@@ -71,6 +71,7 @@ pipelineJob("$buildFolder/$JOB_NAME") {
                 <dt><strong>SCM_REF</strong></dt><dd>Source code ref to build, i.e branch, tag, commit id</dd>
                 <dt><strong>BUILD_ARGS</strong></dt><dd>args to pass to makejdk-any-platform.sh</dd>
                 <dt><strong>NODE_LABEL</strong></dt><dd>Labels of node to build on</dd>
+                <dt><strong>ACTIVE_NODE_TIMEOUT</strong></dt><dd>Number of minutes we will wait for a label-matching node to become active.</dd>
                 <dt><strong>CODEBUILD</strong></dt><dd>Use a dynamic codebuild machine if no other machine is available</dd>
                 <dt><strong>DOCKER_IMAGE</strong></dt><dd>Use a docker build environment</dd>
                 <dt><strong>DOCKER_FILE</strong></dt><dd>Relative path to a dockerfile to be built and used on top of the DOCKER_IMAGE</dd>

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -659,6 +659,40 @@ class Build {
         }
     }
 
+    def waitForANodeToBecomeActive(def label) {
+        def NodeHelper = context.library(identifier: 'openjdk-jenkins-helper@master').NodeHelper
+
+        if (NodeHelper.nodeIsOnline(label)) {
+            return
+        }
+
+        context.println("No active node matches this label: " + label)
+
+        int activeNodeTimeout = 0
+        if (buildConfig.ACTIVE_NODE_TIMEOUT.isInteger()) {
+            activeNodeTimeout = buildConfig.ACTIVE_NODE_TIMEOUT as Integer
+        }
+
+
+        if (activeNodeTimeout > 0) {
+            context.println("Will check again periodically until a node labelled " + label + " comes online, or " + buildConfig.ACTIVE_NODE_TIMEOUT + " minutes (ACTIVE_NODE_TIMEOUT) has passed.")
+            int x = 0
+            while (x < activeNodeTimeout) {
+                context.sleep(60 * 1000)  // 1 minute sleep
+                if (NodeHelper.nodeIsOnline(label)) {
+                    context.println("A node which matches this label is now active: " + label)
+                    return
+                }
+                x++
+            }
+            context.error("No node matching this label became active prior to the timeout: " + label)
+            throw new Exception()
+        } else {
+            context.error("As the timeout value is set to 0, we will not wait for a node to become active.")
+            throw new Exception()
+        }
+    }
+
     def build() {
         context.timestamps {
             context.timeout(time: 18, unit: "HOURS") {
@@ -678,8 +712,6 @@ class Build {
                     def cleanWorkspace = Boolean.valueOf(buildConfig.CLEAN_WORKSPACE)
 
                     context.stage("queue") {
-                        def NodeHelper = context.library(identifier: 'openjdk-jenkins-helper@master').NodeHelper
-
                         if (buildConfig.DOCKER_IMAGE) {
                             // Docker build environment
                             def label = buildConfig.NODE_LABEL + "&&dockerBuild"
@@ -690,6 +722,8 @@ class Build {
                             if (buildConfig.CODEBUILD) {
                                 label = "codebuild"
                             }
+
+                            waitForANodeToBecomeActive(label)
                             context.node(label) {
                                 // Cannot clean workspace from inside docker container
                                 if (cleanWorkspace) {
@@ -714,27 +748,23 @@ class Build {
                             }
 
                         } else {
-                            if (NodeHelper.nodeIsOnline(buildConfig.NODE_LABEL)) {
-                                context.node(buildConfig.NODE_LABEL) {
-                                    // This is to avoid windows path length issues.
-                                    context.echo("checking ${buildConfig.TARGET_OS}")
-                                    if (buildConfig.TARGET_OS == "windows") {
-                                        // See https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1284#issuecomment-621909378 for justification of the below path
-                                        def workspace = "C:/workspace/openjdk-build/"
-                                        if (env.CYGWIN_WORKSPACE) {
-                                            workspace = env.CYGWIN_WORKSPACE
-                                        }
-                                        context.echo("changing ${workspace}")
-                                        context.ws(workspace) {
-                                            buildScripts(cleanWorkspace, filename)
-                                        }
-                                    } else {
+                            waitForANodeToBecomeActive(buildConfig.NODE_LABEL)
+                            context.node(buildConfig.NODE_LABEL) {
+                                // This is to avoid windows path length issues.
+                                context.echo("checking ${buildConfig.TARGET_OS}")
+                                if (buildConfig.TARGET_OS == "windows") {
+                                    // See https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1284#issuecomment-621909378 for justification of the below path
+                                    def workspace = "C:/workspace/openjdk-build/"
+                                    if (env.CYGWIN_WORKSPACE) {
+                                        workspace = env.CYGWIN_WORKSPACE
+                                    }
+                                    context.echo("changing ${workspace}")
+                                    context.ws(workspace) {
                                         buildScripts(cleanWorkspace, filename)
                                     }
-                                }   
-                            } else {
-                                context.error("No node of this type exists: ${buildConfig.NODE_LABEL}")
-                                return
+                                } else {
+                                    buildScripts(cleanWorkspace, filename)
+                                }
                             }
                         }
                     }

--- a/pipelines/build/openjdk10_pipeline.groovy
+++ b/pipelines/build/openjdk10_pipeline.groovy
@@ -29,6 +29,7 @@ if (scmVars != null && configureBuild != null && buildConfigurations != null) {
         javaToBuild,
         buildConfigurations,
         targetConfigurations,
+        activeNodeTimeout,
         dockerExcludes,
         enableTests,
         enableInstallers,

--- a/pipelines/build/openjdk11_pipeline.groovy
+++ b/pipelines/build/openjdk11_pipeline.groovy
@@ -29,6 +29,7 @@ if (scmVars != null && configureBuild != null && buildConfigurations != null) {
         javaToBuild,
         buildConfigurations,
         targetConfigurations,
+        activeNodeTimeout,
         dockerExcludes,
         enableTests,
         enableInstallers,

--- a/pipelines/build/openjdk12_pipeline.groovy
+++ b/pipelines/build/openjdk12_pipeline.groovy
@@ -29,6 +29,7 @@ if (scmVars != null && configureBuild != null && buildConfigurations != null) {
         javaToBuild,
         buildConfigurations,
         targetConfigurations,
+        activeNodeTimeout,
         dockerExcludes,
         enableTests,
         enableInstallers,

--- a/pipelines/build/openjdk13_pipeline.groovy
+++ b/pipelines/build/openjdk13_pipeline.groovy
@@ -29,6 +29,7 @@ if (scmVars != null && configureBuild != null && buildConfigurations != null) {
         javaToBuild,
         buildConfigurations,
         targetConfigurations,
+        activeNodeTimeout,
         dockerExcludes,
         enableTests,
         enableInstallers,

--- a/pipelines/build/openjdk14_pipeline.groovy
+++ b/pipelines/build/openjdk14_pipeline.groovy
@@ -29,6 +29,7 @@ if (scmVars != null && configureBuild != null && buildConfigurations != null) {
         javaToBuild,
         buildConfigurations,
         targetConfigurations,
+        activeNodeTimeout,
         dockerExcludes,
         enableTests,
         enableInstallers,

--- a/pipelines/build/openjdk15_pipeline.groovy
+++ b/pipelines/build/openjdk15_pipeline.groovy
@@ -29,6 +29,7 @@ if (scmVars != null && configureBuild != null && buildConfigurations != null) {
         javaToBuild,
         buildConfigurations,
         targetConfigurations,
+        activeNodeTimeout,
         dockerExcludes,
         enableTests,
         enableInstallers,

--- a/pipelines/build/openjdk16_pipeline.groovy
+++ b/pipelines/build/openjdk16_pipeline.groovy
@@ -29,6 +29,7 @@ if (scmVars != null && configureBuild != null && buildConfigurations != null) {
         javaToBuild,
         buildConfigurations,
         targetConfigurations,
+        activeNodeTimeout,
         dockerExcludes,
         enableTests,
         enableInstallers,

--- a/pipelines/build/openjdk8_pipeline.groovy
+++ b/pipelines/build/openjdk8_pipeline.groovy
@@ -29,6 +29,7 @@ if (scmVars != null && configureBuild != null && buildConfigurations != null) {
         javaToBuild,
         buildConfigurations,
         targetConfigurations,
+        activeNodeTimeout,
         dockerExcludes,
         enableTests,
         enableInstallers,

--- a/pipelines/build/openjdk9_pipeline.groovy
+++ b/pipelines/build/openjdk9_pipeline.groovy
@@ -29,6 +29,7 @@ if (scmVars != null && configureBuild != null && buildConfigurations != null) {
         javaToBuild,
         buildConfigurations,
         targetConfigurations,
+        activeNodeTimeout,
         dockerExcludes,
         enableTests,
         enableInstallers,

--- a/pipelines/jobs/pipeline_job_template.groovy
+++ b/pipelines/jobs/pipeline_job_template.groovy
@@ -58,6 +58,7 @@ pipelineJob("${BUILD_FOLDER}/${JOB_NAME}") {
 
     parameters {
         textParam('targetConfigurations', JsonOutput.prettyPrint(JsonOutput.toJson(targetConfigurations)))
+        stringParam('activeNodeTimeout', "0", 'Number of minutes we will wait for a label-matching node to become active.')
         stringParam('dockerExcludes', "", 'Map of targetConfigurations to exclude from docker building. If a targetConfiguration (i.e. { "x64LinuxXL": [ "openj9" ], "aarch64Linux": [ "hotspot", "openj9" ] }) has been entered into this field, jenkins will build the jdk without using docker. This param overrides the dockerImage and dockerFile downstream job parameters.')
         choiceParam('releaseType', ['Nightly', 'Nightly Without Publish', 'Release'], 'Nightly - release a standard nightly build.<br/>Nightly Without Publish - run a nightly but do not publish.<br/>Release - this is a release, this will need to be manually promoted.')
         stringParam('overridePublishName', "", '<strong>REQUIRED for OpenJ9</strong>: Name that determines the publish name (and is used by the meta-data file), defaults to scmReference(minus _adopt if present).<br/>Nightly builds: Leave blank (defaults to a date_time stamp).<br/>OpenJ9 Release build Java 8 example <code>jdk8u192-b12_openj9-0.12.1</code> and for OpenJ9 Java 11 example <code>jdk-11.0.2+9_openj9-0.12.1</code>.')

--- a/pipelines/library/src/common/IndividualBuildConfig.groovy
+++ b/pipelines/library/src/common/IndividualBuildConfig.groovy
@@ -12,6 +12,7 @@ class IndividualBuildConfig implements Serializable {
     final String SCM_REF
     final String BUILD_ARGS
     final String NODE_LABEL
+    final String ACTIVE_NODE_TIMEOUT
     final boolean CODEBUILD
     final String DOCKER_IMAGE
     final String DOCKER_FILE
@@ -48,6 +49,7 @@ class IndividualBuildConfig implements Serializable {
         SCM_REF = map.get("SCM_REF")
         BUILD_ARGS = map.get("BUILD_ARGS")
         NODE_LABEL = map.get("NODE_LABEL")
+        ACTIVE_NODE_TIMEOUT = map.get("ACTIVE_NODE_TIMEOUT")
         CODEBUILD = map.get("CODEBUILD")
         DOCKER_IMAGE = map.get("DOCKER_IMAGE")
         DOCKER_FILE = map.get("DOCKER_FILE")
@@ -89,6 +91,7 @@ class IndividualBuildConfig implements Serializable {
                 SCM_REF                   : SCM_REF,
                 BUILD_ARGS                : BUILD_ARGS,
                 NODE_LABEL                : NODE_LABEL,
+                ACTIVE_NODE_TIMEOUT       : ACTIVE_NODE_TIMEOUT,
                 CODEBUILD                 : CODEBUILD,
                 DOCKER_IMAGE              : DOCKER_IMAGE,
                 DOCKER_FILE               : DOCKER_FILE,

--- a/pipelines/src/test/groovy/IndividualBuildConfigTest.groovy
+++ b/pipelines/src/test/groovy/IndividualBuildConfigTest.groovy
@@ -16,6 +16,7 @@ class IndividualBuildConfigTest {
                  SCM_REF                   : "f",
                  BUILD_ARGS                : "g",
                  NODE_LABEL                : "h",
+                 ACTIVE_NODE_TIMEOUT       : "r",
                  CODEBUILD                 : false,
                  DOCKER_IMAGE              : "o",
                  DOCKER_FILE               : "p",


### PR DESCRIPTION
Currently, if there are no active nodes that match a build job's
labels, we fail immediately.

This change is intended to add a modifiable timeout value, so if we
don't find an active node that matches the build job's labels, we
wait for x minutes, periodically checking to see if a node matching
the labels has come online.

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>