### PR TITLE
Remove Node Existence Check Prior to Docker Build

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -814,7 +814,6 @@ class Build {
                                 label = "codebuild"
                             }
 
-                            waitForANodeToBecomeActive(label)
                             context.node(label) {
                                 // Cannot clean workspace from inside docker container
                                 if (cleanWorkspace) {


### PR DESCRIPTION
Docker nodes do not exist prior to us trying to use them, as they
are dynamically generated.

So waiting for one to become active prior to use is a futile effort,
and the inevitable timeout causes build failure.

So this change removes the "wait for active node" step from the
docker builds.

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>