### PR TITLE
Build JDK 15, 16 (x64) on CentOS 6

### DIFF
--- a/pipelines/jobs/configurations/jdk15u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk15u_pipeline_config.groovy
@@ -20,7 +20,7 @@ class Config15 {
         x64Linux  : [
                 os                  : 'linux',
                 arch                : 'x64',
-                dockerImage         : 'adoptopenjdk/centos7_build_image',
+                dockerImage         : 'adoptopenjdk/centos6_build_image',
                 dockerFile: [
                         openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],
@@ -34,7 +34,7 @@ class Config15 {
         x64LinuxXL  : [
                 os                  : 'linux',
                 arch                : 'x64',
-                dockerImage         : 'adoptopenjdk/centos7_build_image',
+                dockerImage         : 'adoptopenjdk/centos6_build_image',
                 dockerFile: [
                         openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],

--- a/pipelines/jobs/configurations/jdk16_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk16_pipeline_config.groovy
@@ -14,7 +14,7 @@ class Config16 {
         x64Linux  : [
                 os                  : 'linux',
                 arch                : 'x64',
-                dockerImage         : 'adoptopenjdk/centos7_build_image',
+                dockerImage         : 'adoptopenjdk/centos6_build_image',
                 dockerFile: [
                         openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],


### PR DESCRIPTION
Restores glibc 2.12 support and aligns us with upstream (https://wiki.openjdk.java.net/display/Build/Supported+Build+Platforms).

Fixes #2097.