### PR TITLE
Correct Corretto version.txt location

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -133,7 +133,7 @@ getOpenJdkVersion() {
   local version
 
   if [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_CORRETTO}" ]; then
-    local corrVerFile=${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/metadata/version.txt
+    local corrVerFile=${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/version.txt
 
     local corrVersion="$(cut -d'.' -f 1 <${corrVerFile})"
 


### PR DESCRIPTION
Commit https://github.com/AdoptOpenJDK/openjdk-build/commit/433c6f2324d2b6f52a8fcf4611ab642c89ee77e3#diff-bf1a71b6b982bb100bd797f1aac5049b232b43398baf9494c8f2823c62c8aa82
accidentally changed the Corretto version.txt location.

Corretto has it's own src version.txt which contains the jdk version level, this is different to the build generated metadata/version.txt.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>