### PR TITLE
Increase gradlew java build to use -Xmx512m

### DIFF
--- a/pipelines/gradlew
+++ b/pipelines/gradlew
@@ -28,7 +28,8 @@ APP_NAME="Gradle"
 APP_BASE_NAME=`basename "$0"`
 
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-DEFAULT_JVM_OPTS='"-Xmx64m"'
+# Increased max heap to 512m to avoid java.lang.StackOverflowError with default setting
+DEFAULT_JVM_OPTS='"-Xmx512m"'
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD="maximum"


### PR DESCRIPTION
Likely cause of java.lang.StackOverflowError build failures, see: https://github.com/AdoptOpenJDK/openjdk-build/issues/2139

Signed-off-by: Andrew Leonard <anleonar@redhat.com>