### PR TITLE
vendor-version-string should default to AdoptOpenJDK

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -195,7 +195,7 @@ configureVersionStringParameter() {
   addConfigureArg "--with-vendor-bug-url=" "${BUILD_CONFIG[VENDOR_BUG_URL]:-"https://github.com/AdoptOpenJDK/openjdk-support/issues"}"
   addConfigureArg "--with-vendor-vm-bug-url=" "${BUILD_CONFIG[VENDOR_VM_BUG_URL]:-"https://github.com/AdoptOpenJDK/openjdk-support/issues"}"
   if [ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" -gt 8 ]; then
-    addConfigureArg "--with-vendor-version-string=" "${BUILD_CONFIG[VENDOR_VERSION]:-"${BUILD_CONFIG[BUILD_VARIANT]^}"}"
+    addConfigureArg "--with-vendor-version-string=" "${BUILD_CONFIG[VENDOR_VERSION]:-"AdoptOpenJDK"}"
   fi
 
   if [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK8_CORE_VERSION}" ]; then


### PR DESCRIPTION
The vendor-version-string has historically defaulted to AdoptOpenJDK.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>