### PR TITLE
Improve error message on prereq download failures

### DIFF
--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -408,9 +408,13 @@ downloadFile() {
 
   # Temporary fudge as curl on my windows boxes is exiting with RC=127
   if [[ "$OSTYPE" == "cygwin" ]] || [[ "$OSTYPE" == "msys" ]]; then
-    wget -O "${targetFileName}" "${url}" || exit 2
-  else
-    curl --fail -L -o "${targetFileName}" "${url}" || exit 2
+    if ! wget -O "${targetFileName}" "${url}"; then
+       echo ERROR: Failed to download "${url}" - exiting
+       exit 2
+    fi
+  elif ! curl --fail -L -o "${targetFileName}" "${url}"; then
+    echo ERROR: Failed to download "${url}" - exiting
+    exit 2
   fi
 
   if [ $# -ge 3 ]; then
@@ -419,7 +423,7 @@ downloadFile() {
     local actualChecksum=$(sha256File ${targetFileName})
 
     if [ "${actualChecksum}" != "${expectedChecksum}" ]; then
-      echo "Failed to verify checksum on ${targetFileName} ${url}"
+      echo "ERROR: Failed to verify checksum on ${targetFileName} ${url}"
 
       echo "Expected ${expectedChecksum} got ${actualChecksum}"
       exit 1


### PR DESCRIPTION
Had an issue today where we had this. the `downloadFile:` message says `url` which is no use, and we should make the error message afterwards be explicit to assist debugging. This PR improves the messages to expedite people trying to resolve bulid issues.
```
00:39:41  downloadFile: Saving url to alsa-lib.tar.bz2
00:39:41    % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
00:39:41                                   Dload  Upload   Total   Spent    Left  Speed
00:40:10  
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:02 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:03 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:04 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:05 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:06 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:07 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:08 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:09 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:10 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:11 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:12 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:12 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:13 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:14 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:15 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:16 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:17 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:18 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:19 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:20 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:21 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:22 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:23 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:24 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:25 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:26 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:27 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:28 --:--:--     0
  0     0    0     0    0     0      0      0 --:--:--  0:00:29 --:--:--     0
00:40:10  curl: (35) gnutls_handshake() failed: The TLS connection was non-properly terminated.
```

Signed-off-by: Stewart X Addison <sxa@redhat.com>