### PR TITLE
Autodetect boot JDK location based on playbook defaults

### DIFF
--- a/build-farm/platform-specific-configurations/aix.sh
+++ b/build-farm/platform-specific-configurations/aix.sh
@@ -46,16 +46,19 @@ if [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]; then
 fi
 echo LDR_CNTRL=$LDR_CNTRL
 
-# Any version above 8 (11 for now due to openjdk-build#1409
-if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
-    BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION-1))"
-    BOOT_JDK_VARIABLE="JDK$(echo $BOOT_JDK_VERSION)_BOOT_DIR"
-    if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then
-      bootDir="$PWD/jdk-$BOOT_JDK_VERSION"
-      # Note we export $BOOT_JDK_VARIABLE (i.e. JDKXX_BOOT_DIR) here
-      # instead of BOOT_JDK_VARIABLE (no '$').
-      export ${BOOT_JDK_VARIABLE}="${bootDir}"
-      if [ ! -d "${bootDir}/bin" ]; then
+  BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION-1))"
+  BOOT_JDK_VARIABLE="JDK$(echo $BOOT_JDK_VERSION)_BOOT_DIR"
+  if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then
+    bootDir="$PWD/jdk-$BOOT_JDK_VERSION"
+    # Note we export $BOOT_JDK_VARIABLE (i.e. JDKXX_BOOT_DIR) here
+    # instead of BOOT_JDK_VARIABLE (no '$').
+    export ${BOOT_JDK_VARIABLE}="${bootDir}"
+    if [ ! -x "$bootDir/bin/javac" ]; then
+      # Set to a default location as linked in the ansible playbooks
+      if [ -x /usr/java${BOOT_JDK_VERSION}_64/bin/javac ]; then
+        echo Could not use ${BOOT_JDK_VARIABLE} - using /usr/java${BOOT_JDK_VERSION}_64
+        export ${BOOT_JDK_VARIABLE}="/usr/java${BOOT_JDK_VERSION}_64"
+      else
         mkdir -p "${bootDir}"
         echo "Downloading GA release of boot JDK version ${BOOT_JDK_VERSION}..."
         releaseType="ga"
@@ -80,13 +83,14 @@ if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
         fi
       fi
     fi
-    export JDK_BOOT_DIR="$(eval echo "\$$BOOT_JDK_VARIABLE")"
-    "$JDK_BOOT_DIR/bin/java" -version
-    executedJavaVersion=$?
-    if [ $executedJavaVersion -ne 0 ]; then
-        echo "Failed to obtain or find a valid boot jdk"
-        exit 1
-    fi
+  fi
+  export JDK_BOOT_DIR="$(eval echo "\$$BOOT_JDK_VARIABLE")"
+  "$JDK_BOOT_DIR/bin/java" -version
+  executedJavaVersion=$?
+  if [ $executedJavaVersion -ne 0 ]; then
+      echo "Failed to obtain or find a valid boot jdk"
+      exit 1
+  fi
     "$JDK_BOOT_DIR/bin/java" -version 2>&1 | sed 's/^/BOOT JDK: /'
 fi
 

--- a/build-farm/platform-specific-configurations/aix.sh
+++ b/build-farm/platform-specific-configurations/aix.sh
@@ -46,6 +46,8 @@ if [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]; then
 fi
 echo LDR_CNTRL=$LDR_CNTRL
 
+# Any version above 8 (11 for now due to openjdk-build#1409
+if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then 
   BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION-1))"
   BOOT_JDK_VARIABLE="JDK$(echo $BOOT_JDK_VERSION)_BOOT_DIR"
   if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then

--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -101,7 +101,7 @@ fi
       # Set to a default location as linked in the ansible playbooks
       if [ -x /usr/lib/jvm/jdk-${BOOT_JDK_VERSION}/bin/javac ]; then
         echo Could not use ${BOOT_JDK_VARIABLE} - using /usr/lib/jvm/jdk-${BOOT_JDK_VERSION}
-        export BOOT_JDK_DIR="/usr/lib/jvm/jdk-${BOOT_JDK_VERSION}"
+        export ${BOOT_JDK_VARIABLE}="/usr/lib/jvm/jdk-${BOOT_JDK_VERSION}"
       else
         mkdir -p "$bootDir"
         echo "Downloading GA release of boot JDK version ${BOOT_JDK_VERSION}..."

--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -90,6 +90,8 @@ then
   fi
 fi
 
+# Any version above 8 (11 for now due to openjdk-build#1409
+if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then 
   BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION-1))"
   BOOT_JDK_VARIABLE="JDK$(echo $BOOT_JDK_VERSION)_BOOT_DIR"
   if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then
@@ -136,7 +138,7 @@ fi
       exit 1
   fi
   "$JDK_BOOT_DIR/bin/java" -version 2>&1 | sed 's/^/BOOT JDK: /'
-
+fi
 
 if [ "${VARIANT}" == "${BUILD_VARIANT_DRAGONWELL}" ] && [ "$JAVA_FEATURE_VERSION" -eq 11 ] && [ -r /usr/local/gcc9/ ]; then
   export PATH=/usr/local/gcc9/bin:$PATH

--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -90,16 +90,19 @@ then
   fi
 fi
 
-# Any version above 8 (11 for now due to openjdk-build#1409
-if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
-    BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION-1))"
-    BOOT_JDK_VARIABLE="JDK$(echo $BOOT_JDK_VERSION)_BOOT_DIR"
-    if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then
-      bootDir="$PWD/jdk-$BOOT_JDK_VERSION"
-      # Note we export $BOOT_JDK_VARIABLE (i.e. JDKXX_BOOT_DIR) here
-      # instead of BOOT_JDK_VARIABLE (no '$').
-      export ${BOOT_JDK_VARIABLE}="$bootDir"
-      if [ ! -d "$bootDir/bin" ]; then
+  BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION-1))"
+  BOOT_JDK_VARIABLE="JDK$(echo $BOOT_JDK_VERSION)_BOOT_DIR"
+  if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then
+    bootDir="$PWD/jdk-$BOOT_JDK_VERSION"
+    # Note we export $BOOT_JDK_VARIABLE (i.e. JDKXX_BOOT_DIR) here
+    # instead of BOOT_JDK_VARIABLE (no '$').
+    export ${BOOT_JDK_VARIABLE}="$bootDir"
+    if [ ! -x "$bootDir/bin/javac" ]; then
+      # Set to a default location as linked in the ansible playbooks
+      if [ -x /usr/lib/jvm/jdk-${BOOT_JDK_VERSION}/bin/javac ]; then
+        echo Could not use ${BOOT_JDK_VARIABLE} - using /usr/lib/jvm/jdk-${BOOT_JDK_VERSION}
+        export BOOT_JDK_DIR="/usr/lib/jvm/jdk-${BOOT_JDK_VERSION}"
+      else
         mkdir -p "$bootDir"
         echo "Downloading GA release of boot JDK version ${BOOT_JDK_VERSION}..."
         releaseType="ga"
@@ -124,15 +127,15 @@ if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
         fi
       fi
     fi
-    export JDK_BOOT_DIR="$(eval echo "\$$BOOT_JDK_VARIABLE")"
-    "$JDK_BOOT_DIR/bin/java" -version
-    executedJavaVersion=$?
-    if [ $executedJavaVersion -ne 0 ]; then
-        echo "Failed to obtain or find a valid boot jdk"
-        exit 1
-    fi
-    "$JDK_BOOT_DIR/bin/java" -version 2>&1 | sed 's/^/BOOT JDK: /'
-fi
+  fi
+  export JDK_BOOT_DIR="$(eval echo "\$$BOOT_JDK_VARIABLE")"
+  "$JDK_BOOT_DIR/bin/java" -version
+  executedJavaVersion=$?
+  if [ $executedJavaVersion -ne 0 ]; then
+      echo "Failed to obtain or find a valid boot jdk"
+      exit 1
+  fi
+  "$JDK_BOOT_DIR/bin/java" -version 2>&1 | sed 's/^/BOOT JDK: /'
 
 
 if [ "${VARIANT}" == "${BUILD_VARIANT_DRAGONWELL}" ] && [ "$JAVA_FEATURE_VERSION" -eq 11 ] && [ -r /usr/local/gcc9/ ]; then

--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -66,6 +66,8 @@ fi
 
 sudo xcode-select --switch "${XCODE_SWITCH_PATH}"
 
+# Any version above 8 (11 for now due to openjdk-build#1409
+if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then 
   BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION-1))"
   BOOT_JDK_VARIABLE="JDK$(echo $BOOT_JDK_VERSION)_BOOT_DIR"
   if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then

--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -66,16 +66,18 @@ fi
 
 sudo xcode-select --switch "${XCODE_SWITCH_PATH}"
 
-# Any version above 8 (11 for now due to openjdk-build#1409
-if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
-    BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION-1))"
-    BOOT_JDK_VARIABLE="JDK$(echo $BOOT_JDK_VERSION)_BOOT_DIR"
-    if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then
-      bootDir="$PWD/jdk-$BOOT_JDK_VERSION"
-      # Note we export $BOOT_JDK_VARIABLE (i.e. JDKXX_BOOT_DIR) here
-      # instead of BOOT_JDK_VARIABLE (no '$').
-      export ${BOOT_JDK_VARIABLE}="$bootDir/Contents/Home"
-      if [ ! -d "$bootDir/Contents/Home/bin" ]; then
+  BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION-1))"
+  BOOT_JDK_VARIABLE="JDK$(echo $BOOT_JDK_VERSION)_BOOT_DIR"
+  if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then
+    bootDir="$PWD/jdk-$BOOT_JDK_VERSION"
+    # Note we export $BOOT_JDK_VARIABLE (i.e. JDKXX_BOOT_DIR) here
+    # instead of BOOT_JDK_VARIABLE (no '$').
+    export ${BOOT_JDK_VARIABLE}="$bootDir/Contents/Home"
+    if [ ! -x "$bootDir/Contents/Home/bin/javac" ]; then
+      if [ -x /Library/Java/JavaVirtualMachines/adoptopenjdk-${BOOT_JDK_VERSION}/Contents/Home/bin/javac ]; then
+        echo Could not use ${BOOT_JDK_VARIABLE} - using /Library/Java/JavaVirtualMachines/adoptopenjdk-${BOOT_JDK_VERSION}/Contents/Home
+        export ${BOOT_JDK_VARIABLE}="/Library/Java/JavaVirtualMachines/adoptopenjdk-${BOOT_JDK_VERSION}/Contents/Home"
+      else
         mkdir -p "$bootDir"
         echo "Downloading GA release of boot JDK version ${BOOT_JDK_VERSION}..."
         releaseType="ga"
@@ -100,14 +102,15 @@ if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
         fi
       fi
     fi
-    export JDK_BOOT_DIR="$(eval echo "\$$BOOT_JDK_VARIABLE")"
-    "$JDK_BOOT_DIR/bin/java" -version
-    executedJavaVersion=$?
-    if [ $executedJavaVersion -ne 0 ]; then
-        echo "Failed to obtain or find a valid boot jdk"
-        exit 1
-    fi
-    "$JDK_BOOT_DIR/bin/java" -version 2>&1 | sed 's/^/BOOT JDK: /'
+  fi
+  export JDK_BOOT_DIR="$(eval echo "\$$BOOT_JDK_VARIABLE")"
+  "$JDK_BOOT_DIR/bin/java" -version
+  executedJavaVersion=$?
+  if [ $executedJavaVersion -ne 0 ]; then
+      echo "Failed to obtain or find a valid boot jdk"
+      exit 1
+  fi
+  "$JDK_BOOT_DIR/bin/java" -version 2>&1 | sed 's/^/BOOT JDK: /'
 fi
 
 if [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]; then

--- a/build-farm/platform-specific-configurations/windows.sh
+++ b/build-farm/platform-specific-configurations/windows.sh
@@ -27,21 +27,29 @@ export OPENSSL_VERSION=1.1.1i
 
 TOOLCHAIN_VERSION=""
 
+<<<<<<< HEAD
 # Any version above 8 (11 for now due to openjdk-build#1409
 if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
-    if [ "$ARCHITECTURE" == "aarch64" ]; then
-      # Windows aarch64 cross compiles requires same version boot jdk
-      BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION))"
-    else
-      BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION-1))"
-    fi
-    BOOT_JDK_VARIABLE="JDK$(echo $BOOT_JDK_VERSION)_BOOT_DIR"
-    if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then
-      bootDir="$PWD/jdk-$BOOT_JDK_VERSION"
-      # Note we export $BOOT_JDK_VARIABLE (i.e. JDKXX_BOOT_DIR) here
-      # instead of BOOT_JDK_VARIABLE (no '$').
-      export ${BOOT_JDK_VARIABLE}="$bootDir"
-      if [ ! -d "$bootDir/bin" ]; then
+  if [ "$ARCHITECTURE" == "aarch64" ]; then
+    # Windows aarch64 cross compiles requires same version boot jdk
+    BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION))"
+  else
+    BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION-1))"
+  fi
+  BOOT_JDK_VARIABLE="JDK$(echo $BOOT_JDK_VERSION)_BOOT_DIR"
+  if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then
+    bootDir="$PWD/jdk-$BOOT_JDK_VERSION"
+    # Note we export $BOOT_JDK_VARIABLE (i.e. JDKXX_BOOT_DIR) here
+    # instead of BOOT_JDK_VARIABLE (no '$').
+    export ${BOOT_JDK_VARIABLE}="$bootDir"
+    if [ ! -x "$bootDir/bin/javac" ]; then
+      # Set to a default location as linked in the ansible playbooks
+      if [ -x /cygdrive/c/openjdk/jdk-${BOOT_JDK_VERSION}/bin/javac ]; then
+        echo Could not use ${BOOT_JDK_VARIABLE} - using /cygdrive/c/openjdk/jdk-${BOOT_JDK_VERSION}
+        export ${BOOT_JDK_VARIABLE}="/usr/lib/jvm/jdk-${BOOT_JDK_VERSION}"
+      else
+        echo "Downloading GA release of boot JDK version ${BOOT_JDK_VERSION}..."
+        releaseType="ga"
         # This is needed to convert x86-32 to x32 which is what the API uses
         case "$ARCHITECTURE" in
           "x86-32") downloadArch="x32";;
@@ -73,14 +81,15 @@ if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
         mv $(ls -d jdk-${BOOT_JDK_VERSION}*) "$bootDir"
       fi
     fi
-    export JDK_BOOT_DIR="$(eval echo "\$$BOOT_JDK_VARIABLE")"
-    "$JDK_BOOT_DIR/bin/java" -version
-    executedJavaVersion=$?
-    if [ $executedJavaVersion -ne 0 ]; then
-        echo "Failed to obtain or find a valid boot jdk"
-        exit 1
-    fi
-    "$JDK_BOOT_DIR/bin/java" -version 2>&1 | sed 's/^/BOOT JDK: /'
+  fi
+  export JDK_BOOT_DIR="$(eval echo "\$$BOOT_JDK_VARIABLE")"
+  "$JDK_BOOT_DIR/bin/java" -version
+  executedJavaVersion=$?
+  if [ $executedJavaVersion -ne 0 ]; then
+      echo "Failed to obtain or find a valid boot jdk"
+      exit 1
+  fi
+  "$JDK_BOOT_DIR/bin/java" -version 2>&1 | sed 's/^/BOOT JDK: /'
 fi
 
 if [ "${ARCHITECTURE}" == "x86-32" ]

--- a/build-farm/platform-specific-configurations/windows.sh
+++ b/build-farm/platform-specific-configurations/windows.sh
@@ -27,7 +27,6 @@ export OPENSSL_VERSION=1.1.1i
 
 TOOLCHAIN_VERSION=""
 
-<<<<<<< HEAD
 # Any version above 8 (11 for now due to openjdk-build#1409
 if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
   if [ "$ARCHITECTURE" == "aarch64" ]; then
@@ -42,19 +41,17 @@ if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
     # Note we export $BOOT_JDK_VARIABLE (i.e. JDKXX_BOOT_DIR) here
     # instead of BOOT_JDK_VARIABLE (no '$').
     export ${BOOT_JDK_VARIABLE}="$bootDir"
-    if [ ! -x "$bootDir/bin/javac" ]; then
+    if [ ! -x "$bootDir/bin/javac.exe" ]; then
       # Set to a default location as linked in the ansible playbooks
       if [ -x /cygdrive/c/openjdk/jdk-${BOOT_JDK_VERSION}/bin/javac ]; then
         echo Could not use ${BOOT_JDK_VARIABLE} - using /cygdrive/c/openjdk/jdk-${BOOT_JDK_VERSION}
         export ${BOOT_JDK_VARIABLE}="/usr/lib/jvm/jdk-${BOOT_JDK_VERSION}"
       else
-        echo "Downloading GA release of boot JDK version ${BOOT_JDK_VERSION}..."
-        releaseType="ga"
         # This is needed to convert x86-32 to x32 which is what the API uses
         case "$ARCHITECTURE" in
-          "x86-32") downloadArch="x32";;
+           "x86-32") downloadArch="x32";;
           "aarch64") downloadArch="x64";;
-          *) downloadArch="$ARCHITECTURE";;
+                  *) downloadArch="$ARCHITECTURE";;
         esac
         echo "Downloading GA release of boot JDK version ${BOOT_JDK_VERSION}..."
         releaseType="ga"
@@ -228,6 +225,7 @@ fi
 if [ "${ARCHITECTURE}" == "aarch64" ]; then
   export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-ccache --openjdk-target=aarch64-unknown-cygwin --with-build-jdk=$JDK_BOOT_DIR"
 fi
+
 
 if [ ! -z "${TOOLCHAIN_VERSION}" ]; then
     export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-toolchain-version=${TOOLCHAIN_VERSION}"


### PR DESCRIPTION
Draft PR to auto-set JDK_BOOT_DIR based on default locations symlinked by the ansible playbooks. This should remove the need to have JDKxx_BOOT_DIR definitions on the build machines in jenkins and reduce the number of times a boot JDK is downloaded dynamically during the builds

[VPC run](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/912/)

Signed-off-by: Stewart X Addison <sxa@redhat.com>