### PR TITLE
Initiate NodeHelper before running build

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -803,6 +803,11 @@ class Build {
                     def cleanWorkspace = Boolean.valueOf(buildConfig.CLEAN_WORKSPACE)
 
                     context.stage("queue") {
+                        // This loads the library containing two Helper classes, and causes them to be
+                        // imported/updated from their repo. Without the library being imported here, runTests 
+                        // method will fail to execute the post-build test jobs for reasons unknown.
+                        context.library(identifier: 'openjdk-jenkins-helper@master')
+
                         if (buildConfig.DOCKER_IMAGE) {
                             // Docker build environment
                             def label = buildConfig.NODE_LABEL + "&&dockerBuild"


### PR DESCRIPTION
There a chance something downstream is preventing test runs on
Docker platforms because the NodeHelper isn't initiated prior to
the build (which was the case prior to an earlier commit).


Signed-off-by: Adam Farley <adfarley@redhat.com>