### PR TITLE
Temporarily remove weekly test list

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -58,8 +58,8 @@ class Builder implements Serializable {
 
     final List<String> nightly = ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external']
     final List<String> weekly = [
-                           'extended.openjdk', 'extended.perf', 'extended.external',
-                           'special.openjdk','special.functional', 'special.system', 'special.perf'
+     /*                      'extended.openjdk', 'extended.perf', 'extended.external',
+                           'special.openjdk','special.functional', 'special.system', 'special.perf' */
                            ]
         
     IndividualBuildConfig buildConfiguration(Map<String, ?> platformConfig, String variant) {

--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -58,7 +58,8 @@ class Builder implements Serializable {
 
     final List<String> nightly = ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external']
     final List<String> weekly = [
-     /*                      'extended.openjdk', 'extended.perf', 'extended.external',
+     /*    Temporarily remove weekly tests due to lack of machine capacity during release                  
+                           'extended.openjdk', 'extended.perf', 'extended.external',
                            'special.openjdk','special.functional', 'special.system', 'special.perf' */
                            ]
         


### PR DESCRIPTION
Many jobs in queue during release, we will have to assess what is possible during the surge of capacity requirements during a release.