### PR TITLE
Output metadata to log

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -658,6 +658,12 @@ class Build {
             data.binary_type = type
             data.sha256 = hash
 
+            String feedbackWord = initialWrite == true ? "INITIALISED" : "OVERWRITTEN"
+            context.println "[INFO] METADATA ${feedbackWord}!"
+            context.println "===NEW METADATA OUTPUT==="
+            context.println JsonOutput.prettyPrint(JsonOutput.toJson(data.asMap()))
+            context.println "=/=NEW METADATA OUTPUT=/="
+
             context.writeFile file: "${file}.json", text: JsonOutput.prettyPrint(JsonOutput.toJson(data.asMap()))
         })
     }


### PR DESCRIPTION
* The JSON files of all builds except the latest are deleted from Jenkins, making it hard to debug historical metadata issues.
* This PR will spit out the metadata to the console each time there is a writeout to it, allowing you to see what the metadata was and is, even if the JSON files have been deleted

Spun off from effort to debug #2172 (doesn't fix or close it)
Signed-off-by: Morgan Davies <morgandavies2020@gmail.com>