### PR TITLE
Fix shenandoah conditional so it is correctly enabled

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -78,7 +78,7 @@ configureBootJDKConfigureParameter() {
 # Shenandaoh was backported to Java 11 as of 11.0.9 but requires this build
 # parameter to ensure its inclusion. For Java 12+ this is automatically set
 configureShenandoahBuildParameter() {
-  if [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_HOTSPOT}" ] && [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" -eq "${JDK11_CORE_VERSION}" ]; then
+  if [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_HOTSPOT}" ] && [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK11_CORE_VERSION}" ]; then
       addConfigureArg "--with-jvm-features=" "shenandoahgc"
   fi
 }


### PR DESCRIPTION
Shenandoah was not being correctly enabled in https://github.com/AdoptOpenJDK/openjdk-build/pull/2125 due the the use of a numeric `-eq` comparison on a string field that was `jdk11`.

Error in the log:
`/home/adoptopenjdk/workspace/build-scripts/jobs/jdk11u/jdk11u-linux-x64-hotspot/sbin/build.sh: line 81: [: jdk11: integer expression expected`

This fixes it so that Shendandoah will be correctly enabled on the builds where it should have been.

Fixes #2176 

Signed-off-by: Stewart X Addison <sxa@redhat.com>