### PR TITLE
solaris: only specify freetype location on sparcv9

### DIFF
--- a/build-farm/platform-specific-configurations/solaris.sh
+++ b/build-farm/platform-specific-configurations/solaris.sh
@@ -25,10 +25,11 @@ if [ "${ARCHITECTURE}" == "x64" ]; then
   export MEMORY=4000
 elif [ "${ARCHITECTURE}" == "sparcv9" ]; then
   export CUPS="--with-cups=/opt/csw/lib/ --with-cups-include=/usr/local/cups-1.5.4-src"
+  export FREETYPE="--with-freetype=/usr/local/"
   export MEMORY=16000
 fi
 
-export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} ${CUPS} --with-freetype=/usr/local/ --with-memory-size=${MEMORY}"
+export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} ${CUPS} ${FREETYPE} --with-memory-size=${MEMORY}"
 export PATH=/opt/solarisstudio12.3/bin/:/opt/csw/bin/:/usr/ccs/bin:$PATH
 
 export LC_ALL=C


### PR DESCRIPTION
the ansible setup machines seem to have freetype installed in the correct location