### PR TITLE
Remove use of buildj9 label on Windows and zLinux

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -238,13 +238,6 @@ class Builder implements Serializable {
      */
     def formAdditionalBuildNodeLabels(Map<String, ?> configuration, String variant) {
         def buildTag = "build"
-
-        if (configuration.os == "windows" && variant == "openj9") {
-            buildTag = "buildj9"
-        } else if (configuration.arch == "s390x" && variant == "openj9") {
-            buildTag = "(buildj9||build)&&openj9"
-        }
-
         def labels = "${buildTag}"
 
         if (configuration.containsKey("additionalNodeLabels")) {

--- a/pipelines/build/common/config_regeneration.groovy
+++ b/pipelines/build/common/config_regeneration.groovy
@@ -138,13 +138,6 @@ class Regeneration implements Serializable {
     */
     def formAdditionalBuildNodeLabels(Map<String, ?> configuration, String variant) {
         def buildTag = "build"
-
-        if (configuration.os == "windows" && variant == "openj9") {
-            buildTag = "buildj9"
-        } else if (configuration.arch == "s390x" && variant == "openj9") {
-            buildTag = "(buildj9||build)&&openj9"
-        }
-
         def labels = "${buildTag}"
 
         if (configuration.containsKey("additionalNodeLabels")) {


### PR DESCRIPTION
Since all machines are configured the same way, this PR removes the need for the `buildj9` tag on the machines (The rather convoluted `(buildj9||build)&&openj9` we had on some of the builds was pointless.

All Windows and zLinux machines have all relevant tags. The only place we have differences in in AIX (due to the base OS level we build on) and therefore I believe this code is now superfluous.

As a side observation, it's a shame we have to have what looks like an identical code block duplicated in the generation code.

Signed-off-by: Stewart X Addison <sxa@redhat.com>