### PR TITLE
Ensure CONFIGURE_ARGS isn't replaced on ARM

### DIFF
--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -74,12 +74,12 @@ fi
 
 if [ "${ARCHITECTURE}" == "arm" ]
 then
-  export CONFIGURE_ARGS_FOR_ANY_PLATFORM="--with-jobs=4 --with-memory-size=2000"
+  export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-jobs=4 --with-memory-size=2000"
   if [ "$JAVA_FEATURE_VERSION" -eq 8 ]; then
-    export CONFIGURE_ARGS_FOR_ANY_PLATFORM="$CONFIGURE_ARGS_FOR_ANY_PLATFORM --with-extra-ldflags=-latomic"
+    export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-extra-ldflags=-latomic"
   fi
   if [ "$JAVA_FEATURE_VERSION" -ge 11 ]; then
-    export CONFIGURE_ARGS_FOR_ANY_PLATFORM="$CONFIGURE_ARGS_FOR_ANY_PLATFORM --disable-warnings-as-errors"
+    export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-warnings-as-errors"
   fi
   if [ ! -z "${NUM_PROCESSORS}" ]
   then


### PR DESCRIPTION
This change will ensure arm-specific config options are appended to
CONFIGURE_ARGS_FOR_ANY_PLATFORM, instead of the arm options erasing
and replacing CONFIGURE_ARGS_FOR_ANY_PLATFORM's contents.

Signed-off-by: Adam Farley <adfarley@redhat.com>