### PR TITLE
Give build pipeline user priority control over config options

### DIFF
--- a/build-farm/make-adopt-build-farm.sh
+++ b/build-farm/make-adopt-build-farm.sh
@@ -67,7 +67,8 @@ OPTIONS=""
 
 EXTENSION=""
 # shellcheck disable=SC2034
-CONFIGURE_ARGS_FOR_ANY_PLATFORM=${CONFIGURE_ARGS:-""}
+CONFIGURE_ARGS_FOR_ANY_PLATFORM=""
+CONFIGURE_ARGS=${CONFIGURE_ARGS:-""}
 BUILD_ARGS=${BUILD_ARGS:-""}
 VARIANT_ARG=""
 
@@ -81,6 +82,9 @@ echo "Required boot JDK version: ${JDK_BOOT_VERSION}"
 
 # shellcheck source=build-farm/set-platform-specific-configurations.sh
 source "${PLATFORM_SCRIPT_DIR}/set-platform-specific-configurations.sh"
+
+# Adding the externally-supplied CONFIGURE_ARGS last, so any user-supplied arguments have priority.
+CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} ${CONFIGURE_ARGS}"
 
 case "${JDK_BOOT_VERSION}" in
       "7")    export JDK_BOOT_DIR="${JDK_BOOT_DIR:-$JDK7_BOOT_DIR}";;


### PR DESCRIPTION
The user should always have the ability to specify options on the
commandline. It's useful for debugging, releasing, prototyping fixes,
etc.

However, giving the user a lower priority than the options provided
by the platform-specific scripts means that the user's options can
be overridden, and the user then has to go digging around in
various files to figure out why the scripts aren't doing why they're
told.

I think this is effort wasted, and the user's commands should always
have priority, even if it breaks things.

This command ensures that the user (or at least the surface params
that the user can trivially see and change in jenkins) always has
priority.

Signed-off-by: Adam Farley <adfarley@redhat.com>