### PR TITLE
Adjust Metadata debug output during build

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -704,6 +704,7 @@ class Build {
 
         MetaData data = initialWrite ? formMetadata(version, true) : formMetadata(version, false)
 
+        Boolean metaWrittenOut = false
         listArchives().each({ file ->
             def type = "jdk"
             if (file.contains("-jre")) {
@@ -727,11 +728,13 @@ class Build {
             data.binary_type = type
             data.sha256 = hash
 
-            String feedbackWord = initialWrite == true ? "INITIALISED" : "OVERWRITTEN"
-            context.println "[INFO] METADATA ${feedbackWord}!"
-            context.println "===NEW METADATA OUTPUT==="
-            context.println JsonOutput.prettyPrint(JsonOutput.toJson(data.asMap()))
-            context.println "=/=NEW METADATA OUTPUT=/="
+            // To save on spam, only print out the metadata the first time
+            if (!metaWrittenOut && initialWrite) {
+                context.println "===METADATA OUTPUT==="
+                context.println JsonOutput.prettyPrint(JsonOutput.toJson(data.asMap()))
+                context.println "=/=METADATA OUTPUT=/="
+                metaWrittenOut = true
+            }
 
             context.writeFile file: "${file}.json", text: JsonOutput.prettyPrint(JsonOutput.toJson(data.asMap()))
         })


### PR DESCRIPTION
* Now will only output metadata on first writeout to prevent duped spam

Follow up to https://github.com/AdoptOpenJDK/openjdk-build/pull/2175
Signed-off-by: Morgan Davies <morgandavies2020@gmail.com>