### PR TITLE
pipelines: Manually delete problematic file for IBMCloud Windows

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -807,6 +807,8 @@ class Build {
                         context.sh(script: "rm -rf C:/workspace/openjdk-build/workspace/build/src/build/*/jdk/gensrc")
                         // https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1419
                         context.sh(script: "rm -rf J:/jenkins/tmp/workspace/build/src/build/*/jdk/gensrc")
+                        // https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1662
+                        context.sh(script: "rm -rf E:/jenkins/tmp/workspace/build/src/build/*/jdk/gensrc")
                         context.cleanWs notFailBuild: true, disableDeferredWipeout: true, deleteDirs: true
                     } else {
                         context.cleanWs notFailBuild: true


### PR DESCRIPTION
ref: #1956 , https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1662 , https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1396

Manually delete the `_the..` file that is unable to be cleared up. Like the referenced PR that proceeded this, it's a hacky way of fixing the issue, so I'll raise a separate issue to fix this properly.

(not sure of which label(s) to apply, sorry)

Signed-off-by: William Parker <wills.parker@outlook.com>