### PR TITLE
Set OPENJ9_BRANCH only if buiding openj9

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -194,7 +194,7 @@ class Build {
         List testList = []
         def jdkBranch = getJDKBranch()
         def jdkRepo = getJDKRepo()
-        def openj9Branch = buildConfig.SCM_REF ? buildConfig.SCM_REF : "master"
+        def openj9Branch = (buildConfig.SCM_REF && buildConfig.VARIANT == "openj9") ? buildConfig.SCM_REF : "master"
 
         if (buildConfig.VARIANT == "corretto") {
             testList = buildConfig.TEST_LIST.minus(['sanity.external'])


### PR DESCRIPTION
Fix https://github.com/AdoptOpenJDK/openjdk-build/issues/2210
Only propagate OPENJ9_BRANCH to tests when building openj9.