### PR TITLE
Add note to timeout error log

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -603,7 +603,7 @@ class Builder implements Serializable {
                         publishBinary()
                     }
                 } catch (FlowInterruptedException e) {
-                    context.println "[ERROR] Publish binary timeout (${pipelineTimeouts.PUBLISH_ARTIFACTS_TIMEOUT} HOURS) has been reached. Exiting..."
+                    context.println "[ERROR] Publish binary timeout (${pipelineTimeouts.PUBLISH_ARTIFACTS_TIMEOUT} HOURS) has been reached OR the downstream publish job failed. Exiting..."
                     throw new Exception()
                 }
             } else if (publish && release) {

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -1065,7 +1065,7 @@ class Build {
                         sign(versionInfo)
                     }
                 } catch (FlowInterruptedException e) {
-                    context.println "[ERROR] Sign job timeout (${buildTimeouts.SIGN_JOB_TIMEOUT} HOURS) has been reached. Exiting..."
+                    context.println "[ERROR] Sign job timeout (${buildTimeouts.SIGN_JOB_TIMEOUT} HOURS) has been reached OR the downstream sign job failed. Exiting..."
                     throw new Exception()
                 }
 
@@ -1086,7 +1086,7 @@ class Build {
                             buildInstaller(versionInfo)
                         }
                     } catch (FlowInterruptedException e) {
-                        context.println "[ERROR] Installer job timeout (${buildTimeouts.INSTALLER_JOBS_TIMEOUT} HOURS) has been reached. Exiting..."
+                        context.println "[ERROR] Installer job timeout (${buildTimeouts.INSTALLER_JOBS_TIMEOUT} HOURS) has been reached OR the downstream installer job failed. Exiting..."
                         throw new Exception()
                     }    
                 }


### PR DESCRIPTION
* Sometimes a FlowInterruptedException occurs that isn't from timeout
* Usually from the failure of a downstream job
* This PR adds notes to the error message in these unique cases
* That the user should check the downstream job results
* And not assume a timeout was reached

Signed-off-by: Morgan Davies <morgandavies2020@gmail.com>