### PR TITLE
Revert "Skip solaris sparcv9"

### DIFF
--- a/pipelines/jobs/configurations/jdk8u.groovy
+++ b/pipelines/jobs/configurations/jdk8u.groovy
@@ -39,6 +39,9 @@ targetConfigurations = [
         "arm32Linux"  : [
                 "hotspot"
         ],
+        "sparcv9Solaris": [
+                "hotspot"
+        ],
         "x64Solaris": [
                 "hotspot"
         ],


### PR DESCRIPTION
Sparc builds are rather slow, but they do complete in an acceptable time for the overnight runs, so we should re-enable them
This reverts commit ec72cf53e326b6b77377c63719c9ba423a7310de.