### PR TITLE
Increase build timeout as Solaris/SPARC builds are currently >6 hrs

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -64,7 +64,7 @@ class Build {
         API_REQUEST_TIMEOUT : 1,
         NODE_CLEAN_TIMEOUT : 1,
         NODE_CHECKOUT_TIMEOUT : 1,
-        BUILD_JDK_TIMEOUT : 6,
+        BUILD_JDK_TIMEOUT : 8,
         BUILD_ARCHIVE_TIMEOUT : 3,
         AIX_CLEAN_TIMEOUT : 1,
         MASTER_CLEAN_TIMEOUT : 1,


### PR DESCRIPTION
Solaris sparc builds are currently over 6 hours (in part due to problems in the gradle phase causing a ~2 hour delay) so we cannot get releases out with the current setting.

Ref:
- https://ci.adoptopenjdk.net/job/build-scripts/job/jobs/job/jdk8u/job/jdk8u-solaris-sparcv9-hotspot/
- https://github.com/AdoptOpenJDK/openjdk-build/issues/2206

Signed-off-by: Stewart X Addison <sxa@redhat.com>