### PR TITLE
Skip freetype build and bundling on Linux

### DIFF
--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -18,6 +18,9 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # shellcheck source=sbin/common/constants.sh
 source "$SCRIPT_DIR/../../sbin/common/constants.sh"
 
+# Bundling our own freetype can cause problems, so we skip that on linux.
+export BUILD_ARGS="${BUILD_ARGS} --skip-freetype"
+
 if [ "${ARCHITECTURE}" == "x64" ]
 then
   export PATH=/opt/rh/devtoolset-2/root/usr/bin:$PATH


### PR DESCRIPTION
Freetype itself has various dependencies on external libraries,
some of which are not present on certain Linux distros.

Better to use the system's freetype library, so the user can handle
their own affairs, reducing the risk of issues (e.g. segmentation
faults on Fedora 28 while starting Eclipse).

Signed-off-by: Adam Farley <adfarley@redhat.com>