### PR TITLE
Stop building shared libs as it hangs on Solaris

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -1110,7 +1110,11 @@ if [[ "${BUILD_CONFIG[ASSEMBLE_EXPLODED_IMAGE]}" == "true" ]]; then
   exit 0
 fi
 
-buildSharedLibs
+# Our Solaris build environment has performance issues so disabling this for now
+# Refhttps://github.com/AdoptOpenJDK/openjdk-build/issues/2206
+if [ "${ARCHITECTURE}" != "sparcv9" ]; then
+  buildSharedLibs
+fi
 
 wipeOutOldTargetDir
 createTargetDir


### PR DESCRIPTION
Since this is currently causing [significant delays](https://github.com/AdoptOpenJDK/openjdk-build/issues/2206) in the Solaris/SPARC pipelines and [this Slack discussion](https://adoptopenjdk.slack.com/archives/C09NW3L2J/p1605110513432600) did not provide a full conclusion as to whether it was needed (I've seen people hit issues with it on ARM builds as well in the past) we should remove this stage unless we can determine whether it is really required for something (metadata is all I can see that might utilise it but if the only reason for the shared lib is to use parseVersion during the build then we should perhaps come up with an alternate method)

[VPC run to check across build environments](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/924/)

Signed-off-by: Stewart X Addison <sxa@redhat.com>