### PR TITLE
Add buildConfig enableSigner to skip signing step

### DIFF
--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -134,7 +134,12 @@ if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
     "$JDK_BOOT_DIR/bin/java" -version 2>&1 | sed 's/^/BOOT JDK: /'
 fi
 
-if [ -r /usr/local/gcc/bin/gcc-7.5 ]; then
+if [ -r /usr/local/gcc/bin/gcc-9.2.0/bin/gcc ]; then
+  export PATH=/usr/local/gcc/bin/gcc-9.2.0/bin:$PATH
+  [ -r /usr/local/gcc/bin/gcc-9.2.0 ] && export CC=/usr/local/gcc/bin/gcc-9.2.0
+  [ -r /usr/local/gcc/bin/g++-9.2.0 ] && export CXX=/usr/local/gcc/bin/g++-9.2.0
+  export LD_LIBRARY_PATH=/usr/local/gcc/lib64:/usr/local/gcc/lib
+elif [ -r /usr/local/gcc/bin/gcc-7.5 ]; then
   export PATH=/usr/local/gcc/bin:$PATH
   [ -r /usr/local/gcc/bin/gcc-7.5 ] && export CC=/usr/local/gcc/bin/gcc-7.5
   [ -r /usr/local/gcc/bin/g++-7.5 ] && export CXX=/usr/local/gcc/bin/g++-7.5

--- a/pipelines/build/dockerFiles/gcc9.dockerfile
+++ b/pipelines/build/dockerFiles/gcc9.dockerfile
@@ -1,0 +1,22 @@
+ARG image
+
+FROM $image
+
+RUN yum update -y
+RUN yum groupinstall "Development Tools" -y
+RUN yum install wget -y
+RUN curl -O https://ftp.gnu.org/gnu/gcc/gcc-9.2.0/gcc-9.2.0.tar.gz
+RUN tar xzf gcc-9.2.0.tar.gz
+WORKDIR /gcc-9.2.0
+RUN ./contrib/download_prerequisites
+WORKDIR /
+RUN mkdir gcc-build
+WORKDIR /gcc-build
+RUN ../gcc-9.2.0/configure                           \
+    --enable-shared                                  \
+    --enable-threads=posix                           \
+    --enable-__cxa_atexit                            \
+    --enable-clocale=gnu                             \
+    --disable-multilib                               \
+    --enable-languages=all
+RUN make -j 50

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -119,7 +119,11 @@ class Config11 {
         aarch64Linux    : [
                 os                  : 'linux',
                 arch                : 'aarch64',
-                dockerImage         : 'adoptopenjdk/centos7_build_image',
+                dockerImage         : [
+                        openj9:  'adoptopenjdk/centos7_build_image',
+                        hotspot: 'adoptopenjdk/centos7_build_image',
+                        dragonwell: 'registry.cn-hangzhou.aliyuncs.com/dragonwell/centos7_gcc9_build_image'
+                ],
                 test                : 'default',
                 configureArgs       : '--enable-dtrace=auto'
         ],


### PR DESCRIPTION
All installer related jobs are private so we need to skip these steps when built on other Jenkins. So I propose we use "enableInstallers" to skip the signing step as well.
A failure example in ci.dragonwell : http://ci.dragonwell-jdk.io/view/build_scripts/job/build-scripts/job/jobs/job/jdk11u/job/jdk11u-windows-x64-dragonwell/48/

Issue: https://github.com/AdoptOpenJDK/openjdk-build/issues/2231, #2149 