### PR TITLE
Retrieve RISC-V Version String job

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -177,16 +177,16 @@ class Build {
 
         return jdkBranch
     }
-    
+
     /*
     Retrieve the corresponding OpenJDK source code repository. This is used the downstream tests to determine what source code the tests should run against.
     */
     private def getJDKRepo() {
-        
+
         def jdkRepo
         def suffix
         def javaNumber = getJavaVersionNumber()
-        
+
         if (buildConfig.VARIANT == "corretto") {
             suffix="corretto/corretto-${javaNumber}"
         } else if (buildConfig.VARIANT == "openj9") {
@@ -199,15 +199,15 @@ class Build {
             context.error("Unrecognised build variant '${buildConfig.VARIANT}' ")
             throw new Exception()
         }
-        
+
         jdkRepo = "https://github.com/${suffix}"
         if (buildConfig.BUILD_ARGS.count("--ssh") > 0) {
             jdkRepo = "git@github.com:${suffix}"
         }
-        
+
         return jdkRepo
     }
-    
+
     /*
     Run the downstream test jobs based off the configuration passed down from the top level pipeline jobs.
     If we try to call a test job that doesn't exist, the pipeline will not fail but it will print out a warning.
@@ -227,7 +227,7 @@ class Build {
         }
 
         testList.each { testType ->
-			
+
 			// For each requested test, i.e 'sanity.openjdk', 'sanity.system', 'sanity.perf', 'sanity.external', call test job
 			try {
 				context.println "Running test: ${testType}"
@@ -326,12 +326,12 @@ class Build {
                 def signJob = context.build job: "build-scripts/release/sign_build",
                         propagate: true,
                         parameters: params
-                
+
                 // Output notification of downstream failure (the build will fail automatically)
                 def jobResult = signJob.getResult()
                 if (jobResult != 'SUCCESS') {
                     context.println "ERROR: downstream sign_build ${jobResult}.\nSee ${signJob.getAbsoluteUrl()} for details"
-                } 
+                }
 
                 context.node('master') {
                     //Copy signed artifact back and archive again
@@ -376,7 +376,7 @@ class Build {
                         context.string(name: 'CERTIFICATE', value: "${certificate}"),
                         ['$class': 'LabelParameterValue', name: 'NODE_LABEL', label: "${nodeFilter}"]
                 ]
-        
+
         context.copyArtifacts(
                 projectName: "build-scripts/release/create_installer_mac",
                 selector: context.specific("${installerJob.getNumber()}"),
@@ -413,7 +413,7 @@ class Build {
                         context.string(name: 'ARCHITECTURE', value: "${buildConfig.ARCHITECTURE}"),
                         ['$class': 'LabelParameterValue', name: 'NODE_LABEL', label: "${nodeFilter}"]
                 ]
-        
+
     }
 
     /*
@@ -461,7 +461,7 @@ class Build {
         listArchives().each({ file ->
 
             if (file.contains("-jre")) {
-                
+
                 context.println("We have a JRE. Running another installer for it...")
                 def jreinstallerJob = context.build job: "build-scripts/release/create_installer_windows",
                         propagate: true,
@@ -490,8 +490,8 @@ class Build {
                     target: "workspace/target/",
                     flatten: true
                 )
-            } 
-            
+            }
+
         })
     }
 
@@ -532,7 +532,7 @@ class Build {
 
 
     /*
-    Lists and returns any compressed archived contents of the top directory of the build node 
+    Lists and returns any compressed archived contents of the top directory of the build node
     */
     List<String> listArchives() {
         return context.sh(
@@ -693,7 +693,7 @@ class Build {
     /*
     Calculates and writes out the metadata to a file.
     The metadata defines and summarises a build and the jdk it creates.
-    The adopt v3 api makes use of it in its endpoints to quickly display information about the jdk binaries that are stored on github. 
+    The adopt v3 api makes use of it in its endpoints to quickly display information about the jdk binaries that are stored on github.
     */
     def writeMetadata(VersionInfo version, Boolean initialWrite) {
         /*
@@ -820,6 +820,46 @@ class Build {
     }
 
     /*
+    Run the Riscv version reader downstream job.
+    In short, we archive the build artifacts to expose them to the job and run ./java version, copying the output back to here.
+    See riscv_version_out.groovy.
+    */
+    def readRiscvVersionString() {
+        // Archive the artifacts early so we can copy them over to the downstream job
+        try {
+            context.timeout(time: buildTimeouts.BUILD_ARCHIVE_TIMEOUT, unit: "HOURS") {
+                context.archiveArtifacts artifacts: "workspace/target/*"
+            }
+        } catch (FlowInterruptedException e) {
+            context.println "[ERROR] Build archive timeout (${buildTimeouts.BUILD_ARCHIVE_TIMEOUT} HOURS) has been reached. Exiting..."
+            throw new Exception()
+        }
+
+        // Setup params for downstream job & execute
+        String shortJobName = env.JOB_NAME.split('/').last()
+        String copyFileFilter = "${shortJobName}_${env.BUILD_NUMBER}_version.txt"
+
+        def riscvJob = context.build job: "build-scripts/utils/riscv-version-out",
+            propagate: true,
+            parameters: [
+                context.string(name: 'UPSTREAM_JOB_NAME', value: "${env.JOB_NAME}"),
+                context.string(name: 'UPSTREAM_JOB_NUMBER', value: "${env.BUILD_NUMBER}"),
+                context.string(name: 'JDK_FILE_FILTER', value: "OpenJDK*-jdk*_linux_*.tar.gz"),
+                context.string(name: 'FILENAME', value: "${copyFileFilter}")
+            ]
+
+        context.copyArtifacts(
+            projectName: "build-scripts/utils/riscv-version-out",
+            selector: context.specific("${riscvJob.getNumber()}"),
+            filter: "RiscvVersionOuts/${copyFileFilter}",
+            target: "workspace/target/",
+            flatten: true
+        )
+
+        return context.readFile("workspace/target/${copyFileFilter}")
+    }
+
+    /*
     Executed on a build node, the function checks out the repository and executes the build via ./make-adopt-build-farm.sh
     Once the build completes, it will calculate its version output, commit the first metadata writeout, and archive the build results.
     */
@@ -879,7 +919,16 @@ class Build {
                         throw new Exception()
                     }
 
-                    String versionOut = context.readFile("workspace/target/metadata/version.txt")
+                    // Run a downstream job on riscv machine that returns the java version
+                    // otherwise, just read the version.txt
+                    String versionOut
+                    if (buildConfig.ARCHITECTURE.contains("riscv")) {
+                        context.println "[WARNING] Don't read faked version.txt on riscv! Archiving early and running downstream job on riscv machine to retrieve java version..."
+                        versionOut = readRiscvVersionString()
+                    } else {
+                        versionOut = context.readFile("workspace/target/metadata/version.txt")
+                    }
+
                     versionInfo = parseVersionOutput(versionOut)
                 }
 
@@ -887,7 +936,10 @@ class Build {
 
                 try {
                     context.timeout(time: buildTimeouts.BUILD_ARCHIVE_TIMEOUT, unit: "HOURS") {
-                        context.archiveArtifacts artifacts: "workspace/target/*"
+                        // We have already archived riscv artifacts
+                        if (!buildConfig.ARCHITECTURE.contains("riscv")) {
+                            context.archiveArtifacts artifacts: "workspace/target/*"
+                        }
                     }
                 } catch (FlowInterruptedException e) {
                     context.println "[ERROR] Build archive timeout (${buildTimeouts.BUILD_ARCHIVE_TIMEOUT} HOURS) has been reached. Exiting..."
@@ -975,7 +1027,7 @@ class Build {
                     method will fail to execute the post-build test jobs for reasons unknown.
                     */
                     context.library(identifier: 'openjdk-jenkins-helper@master')
-                    
+
                     if (buildConfig.DOCKER_IMAGE) {
                         // Docker build environment
                         def label = buildConfig.NODE_LABEL + "&&dockerBuild"
@@ -1008,7 +1060,7 @@ class Build {
                                     context.println "[ERROR] Master clean workspace timeout (${buildTimeouts.MASTER_CLEAN_TIMEOUT} HOURS) has been reached. Exiting..."
                                     throw new Exception()
                                 }
-                                
+
                             }
 
                             // Use our docker file if DOCKER_FILE is defined
@@ -1022,7 +1074,7 @@ class Build {
                                     throw new Exception()
                                 }
 
-                                context.docker.build("build-image", "--build-arg image=${buildConfig.DOCKER_IMAGE} -f ${buildConfig.DOCKER_FILE} .").inside {    
+                                context.docker.build("build-image", "--build-arg image=${buildConfig.DOCKER_IMAGE} -f ${buildConfig.DOCKER_FILE} .").inside {
                                     buildScripts(cleanWorkspace, filename)
                                 }
                             // Otherwise, pull the docker image from DockerHub
@@ -1042,7 +1094,7 @@ class Build {
                             }
                         }
                         context.println "[NODE SHIFT] OUT OF DOCKER NODE (LABELNAME ${label}!)"
-                    
+
                     // Build the jdk outside of docker container...
                     } else {
                         waitForANodeToBecomeActive(buildConfig.NODE_LABEL)
@@ -1097,7 +1149,7 @@ class Build {
                     } catch (FlowInterruptedException e) {
                         context.println "[ERROR] Installer job timeout (${buildTimeouts.INSTALLER_JOBS_TIMEOUT} HOURS) has been reached. Exiting..."
                         throw new Exception()
-                    }    
+                    }
                 }
 
             // Generic catch all. Will usually be the last message in the log.

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -824,7 +824,7 @@ class Build {
     }
 
     /*
-    Run the Riscv version reader downstream job.
+    Run the RISC-V version reader downstream job.
     In short, we archive the build artifacts to expose them to the job and run ./java version, copying the output back to here.
     See riscv_version_out.groovy.
     */

--- a/pipelines/build/common/riscv_version_out.groovy
+++ b/pipelines/build/common/riscv_version_out.groovy
@@ -1,0 +1,116 @@
+import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
+/**
+ * This file is a jenkins job for extracting a version string from a cross-compiled, riscv binary.
+ * See https://github.com/AdoptOpenJDK/openjdk-build/issues/1773 for the inspiration for this.
+ *
+ * This file is referenced by the upstream job at pipelines/build/common/openjdk_build_pipeline.groovy.
+ * This job is run at build-scripts/job/utils/job/riscv-version-out/.
+ *
+ * The job looks like:
+ *  1. Switch into a riscv node
+ *  2. Retrieve the artifacts built in the upstream job
+ *  3. Run java -version and export to file
+ *  4. Expose to the upstream job by archiving file
+ */
+
+// TODO: ADD THE ACTIVE NODE TIMEOUT LOGIC HERE OR GET IT MERGED INTO JOB HELPER (https://github.com/AdoptOpenJDK/openjdk-build/issues/2235)
+
+node ("riscv&&ci.role.test") {
+    timestamps {
+        try {
+            Integer JOB_TIMEOUT = 1
+            timeout(time: JOB_TIMEOUT, unit: "HOURS") {
+                String jobName = params.UPSTREAM_JOB_NAME ? params.UPSTREAM_JOB_NAME : ""
+                String jobNumber = params.UPSTREAM_JOB_NUMBER ? params.UPSTREAM_JOB_NUMBER : ""
+                String jdkFileFilter = params.JDK_FILE_FILTER ? params.JDK_FILE_FILTER : ""
+                String fileName = params.FILENAME ? params.FILENAME : ""
+
+                println "[INFO] PARAMS:"
+                println "UPSTREAM_JOB_NAME = ${jobName}"
+                println "UPSTREAM_JOB_NUMBER = ${jobNumber}"
+                println "JDK_FILE_FILTER = ${jdkFileFilter}"
+                println "FILENAME = ${fileName}"
+
+                // Verify any previous binaries and versions have been cleaned out
+                if (fileExists('OpenJDKBinary')) {
+                    dir('OpenJDKBinary') {
+                        deleteDir()
+                    }
+                }
+
+                if (fileExists('RiscvVersionOuts')) {
+                    dir('RiscvVersionOuts') {
+                        deleteDir()
+                    }
+                }
+
+                String versionOut = ""
+
+                dir ("OpenJDKBinary") {
+                    // Retrieve built JDK & unzip
+                    println "[INFO] Retrieving build artifact from ${jobName}/${jobNumber} matching filter ${jdkFileFilter}"
+                    copyArtifacts(
+                        projectName: "${jobName}",
+                        selector: specific("${jobNumber}"),
+                        filter: "workspace/target/${jdkFileFilter}",
+                        fingerprintArtifacts: true,
+                        flatten: true
+                    )
+
+                    println "[INFO] Unzipping..."
+                    sh "tar -zxvf ${jdkFileFilter} && rm ${jdkFileFilter}"
+
+                    String jdkDir = sh(
+                        script: "ls | grep jdk*",
+                        returnStdout: true,
+                        returnStatus: false
+                    ).trim()
+
+                    // Run java version and save to variable
+                    dir(jdkDir) {
+                        dir ("bin") {
+
+                            println "[INFO] Running java -version on extracted binary ${jdkDir}..."
+
+                            versionOut = sh(
+                                script: "./java -version 2>&1",
+                                returnStdout: true,
+                                returnStatus: false
+                            ).trim()
+
+                            if (versionOut == "") {
+                                throw new Exception("[ERROR] Java version was not retrieved or found!")
+                            } else {
+                                println "[INFO] Retrieved version string:\n${versionOut}"
+                            }
+
+                        }
+                    }
+
+                }
+
+                // Write java version to file
+                dir ("RiscvVersionOuts") {
+                    println "[INFO] Writing java version to ${fileName}..."
+                    writeFile (
+                        file: fileName,
+                        text: versionOut
+                    )
+                    println "[INFO] ${fileName} contents:\n${readFile(fileName)}"
+                }
+
+                // Archive version.txt file
+                println "[INFO] Archiving RiscvVersionOuts/${fileName} to artifactory..."
+                archiveArtifacts artifacts: "RiscvVersionOuts/${fileName}"
+
+                println "[SUCCESS] ${fileName} archived! Cleaning up..."
+            }
+        } catch (FlowInterruptedException e) {
+            println "[ERROR] Job timeout (${JOB_TIMEOUT} HOURS) has been reached. Exiting..."
+            throw new Exception()
+        } finally {
+            // Clean up and return to upstream job
+            cleanWs notFailBuild: true, deleteDirs: true
+        }
+    }
+}

--- a/pipelines/build/common/riscv_version_out.groovy
+++ b/pipelines/build/common/riscv_version_out.groovy
@@ -61,7 +61,7 @@ node ("riscv&&ci.role.test") {
                     sh "tar -zxvf ${jdkFileFilter} && rm ${jdkFileFilter}"
 
                     String jdkDir = sh(
-                        script: "ls | grep jdk*",
+                        script: "ls | grep jdk",
                         returnStdout: true,
                         returnStatus: false
                     ).trim()

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -539,10 +539,11 @@ printJavaVersionString() {
      elif [ "${ARCHITECTURE}" == "riscv64" ]; then
        # riscv is cross compiled, so we cannot run it on the build system
        # So we fake it for now and retrive the version out from a downstream job on a riscv machine after the build
+       echo "Warning: java version can't be run on RISC-V build system. Faking version for now..."
        local jdkversion=$(getOpenJdkVersion)
        local jdkversionNoPrefix=${jdkversion#jdk-}
        local jdkShortVersion=${jdkversionNoPrefix%%+*}
-       cat << EOT > "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/version.txt"
+       cat << EOT > "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/fakedVersion.txt"
 openjdk version "${jdkShortVersion}" "$(date +%Y-%m-%d)"
 OpenJDK Runtime Environment AdoptOpenJDK (build ${jdkversionNoPrefix}-$(date +%Y%m%d%H%M))
 Eclipse OpenJ9 VM AdoptOpenJDK (build master-000000000, JRE 11 Linux riscv-64-Bit Compressed References $(date +%Y%m%d)_00 (JIT disabled, AOT disabled)

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -538,7 +538,7 @@ printJavaVersionString() {
        exit -1
      elif [ "${ARCHITECTURE}" == "riscv64" ]; then
        # riscv is cross compiled, so we cannot run it on the build system
-       # This is a temporary plausible solution in the absence of another fix
+       # So we fake it for now and retrive the version out from a downstream job on a riscv machine after the build
        local jdkversion=$(getOpenJdkVersion)
        local jdkversionNoPrefix=${jdkversion#jdk-}
        local jdkShortVersion=${jdkversionNoPrefix%%+*}

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -538,19 +538,8 @@ printJavaVersionString() {
        exit -1
      elif [ "${ARCHITECTURE}" == "riscv64" ]; then
        # riscv is cross compiled, so we cannot run it on the build system
-       # So we fake it for now and retrive the version out from a downstream job on a riscv machine after the build
+       # So we leave it for now and retrive the version from a downstream job on riscv machine after the build
        echo "Warning: java version can't be run on RISC-V build system. Faking version for now..."
-       local jdkversion=$(getOpenJdkVersion)
-       local jdkversionNoPrefix=${jdkversion#jdk-}
-       local jdkShortVersion=${jdkversionNoPrefix%%+*}
-       cat << EOT > "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[TARGET_DIR]}/metadata/fakedVersion.txt"
-openjdk version "${jdkShortVersion}" "$(date +%Y-%m-%d)"
-OpenJDK Runtime Environment AdoptOpenJDK (build ${jdkversionNoPrefix}-$(date +%Y%m%d%H%M))
-Eclipse OpenJ9 VM AdoptOpenJDK (build master-000000000, JRE 11 Linux riscv-64-Bit Compressed References $(date +%Y%m%d)_00 (JIT disabled, AOT disabled)
-OpenJ9   - 000000000
-OMR      - 000000000
-JCL      - 000000000 based on ${jdkversion})
-EOT
      else
        # print version string around easy to find output
        # do not modify these strings as jenkins looks for them


### PR DESCRIPTION
* Instead of retrieving the faked version string, we run a downstream job on a riscv machine after the build that runs java version and passes it back to the pipeline in time for parseVersionOutput()
* Also clears up white spaces in openjdk_build_pipeline.groovy

Fixes: #1773 
Signed-off-by: Morgan Davies <morgandavies2020@gmail.com>