### PR TITLE
Convert false values to empty arrays to prevent boolean error

### DIFF
--- a/pipelines/jobs/configurations/jdk16_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk16_pipeline_config.groovy
@@ -37,9 +37,9 @@ class Config16 {
                 dockerImage         : 'adoptopenjdk/alpine3_build_image',
                 test                : [
                         // TODO: enable tests
-                        nightly: false,
+                        nightly: [],
                         // release: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external', 'special.functional']
-                        release: false
+                        release: []
                 ]
         ],
 


### PR DESCRIPTION
Passing "false" in as the value of these variables appears to cause
a Groovy error where it says "No signature of method:
java.lang.Boolean.clear() is applicable for argument types: ()
values: []"

Switching the values to empty arrays, as on the other platforms, to
fix this.

Signed-off-by: Adam Farley <adfarley@redhat.com>