### PR TITLE
add Dragonwell on windows

### DIFF
--- a/build-farm/platform-specific-configurations/windows.sh
+++ b/build-farm/platform-specific-configurations/windows.sh
@@ -19,6 +19,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "$SCRIPT_DIR/../../sbin/common/constants.sh"
 
 export ANT_HOME=/cygdrive/C/Projects/OpenJDK/apache-ant-1.10.1
+export DRAGONWELL8_BOOTSTRAP=/cygdrive/C/openjdk/dragonwell-bootstrap/jdk8u272-ga
 export ALLOW_DOWNLOADS=true
 export LANG=C
 export OPENJ9_NASM_VERSION=2.13.03
@@ -189,6 +190,13 @@ then
     then
       TOOLCHAIN_VERSION="2017"
       export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-ccache"
+    fi
+  fi
+
+  if [ "${VARIANT}" == "${BUILD_VARIANT_DRAGONWELL}" ] && [ "${JAVA_TO_BUILD}" == "${JDK8_VERSION}" ]
+  then
+    if [[ -d "${DRAGONWELL8_BOOTSTRAP}" ]]; then
+      export JDK_BOOT_DIR="${DRAGONWELL8_BOOTSTRAP}"
     fi
   fi
 fi

--- a/pipelines/jobs/configurations/jdk11u.groovy
+++ b/pipelines/jobs/configurations/jdk11u.groovy
@@ -14,7 +14,8 @@ targetConfigurations = [
         ],
         "x64Windows"  : [
                 "hotspot",
-                "openj9"
+                "openj9",
+                "dragonwell"
         ],
         "x64WindowsXL"  : [
                 "openj9"

--- a/pipelines/jobs/configurations/jdk8u.groovy
+++ b/pipelines/jobs/configurations/jdk8u.groovy
@@ -15,7 +15,8 @@ targetConfigurations = [
         ],
         "x64Windows"    : [
                 "hotspot",
-                "openj9"
+                "openj9",
+                "dragonwell"
         ],
         "x64WindowsXL"  : [
                 "openj9"


### PR DESCRIPTION
We could use AdoptOpenJDK pipelines to build Dragonwell on windows.

Dragonwell got a building limitation:

Dragonwell 8 Have to depend on bootstrap
So we may need to pull dragonwell windows release during build.

Also, we need this https://github.com/AdoptOpenJDK/openjdk-build/pull/2232 to build dragonwell on windows.