### PR TITLE
Stop using docker for JDK15/16 ppc64le builds

### DIFF
--- a/pipelines/jobs/configurations/jdk15u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk15u_pipeline_config.groovy
@@ -105,10 +105,6 @@ class Config15 {
         ppc64leLinux    : [
                 os                  : 'linux',
                 arch                : 'ppc64le',
-                dockerImage          : 'adoptopenjdk/centos7_build_image',
-                dockerFile: [
-                        openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
-                ],
                 test                : 'default',
                 configureArgs       : [
                         "hotspot"     : '--enable-dtrace',
@@ -119,10 +115,6 @@ class Config15 {
         ppc64leLinuxXL    : [
                 os                   : 'linux',
                 arch                 : 'ppc64le',
-                dockerImage          : 'adoptopenjdk/centos7_build_image',
-                dockerFile: [
-                        openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
-                ],
                 test                 : 'default',
                 additionalFileNameTag: "linuxXL",
                 configureArgs        : '--with-noncompressedrefs --disable-ccache --enable-dtrace'

--- a/pipelines/jobs/configurations/jdk16_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk16_pipeline_config.groovy
@@ -95,10 +95,6 @@ class Config16 {
         ppc64leLinux    : [
                 os                  : 'linux',
                 arch                : 'ppc64le',
-                dockerImage         : 'adoptopenjdk/centos7_build_image',
-                dockerFile: [
-                        openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
-                ],
                 test                : [
                         nightly: [],
                         weekly: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']


### PR DESCRIPTION
Fixes https://github.com/AdoptOpenJDK/openjdk-build/issues/2244.
If the underlying issue is not being addressed then this is the right solution to get the nightly builds stable again.