### PR TITLE
Add XL builds to jdk16 pipeline

### DIFF
--- a/pipelines/jobs/configurations/jdk16.groovy
+++ b/pipelines/jobs/configurations/jdk16.groovy
@@ -3,8 +3,14 @@ targetConfigurations = [
                 "hotspot",
                 "openj9"
         ],
+        "x64MacXL"    : [
+                "openj9"
+        ],
         "x64Linux"    : [
                 "hotspot",
+                "openj9"
+        ],
+        "x64LinuxXL"  : [
                 "openj9"
         ],
         "x64AlpineLinux" : [
@@ -12,6 +18,9 @@ targetConfigurations = [
         ],
         "x64Windows"  : [
                 "hotspot",
+                "openj9"
+        ],
+        "x64WindowsXL": [
                 "openj9"
         ],
         "x32Windows"  : [
@@ -25,12 +34,21 @@ targetConfigurations = [
                 "hotspot",
                 "openj9"
         ],
+        "ppc64leLinuxXL": [
+                "openj9"
+        ],
         "s390xLinux"  : [
                 "hotspot",
                 "openj9"
         ],
+        "s390xLinuxXL": [
+                "openj9"
+        ],
         "aarch64Linux": [
                 "hotspot",
+                "openj9"
+        ],
+        "aarch64LinuxXL": [
                 "openj9"
         ],
         "arm32Linux"  : [

--- a/pipelines/jobs/configurations/jdk16_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk16_pipeline_config.groovy
@@ -10,6 +10,15 @@ class Config16 {
                 ],
                 configureArgs       : '--enable-dtrace'
         ],
+        
+        x64MacXL    : [
+                os                   : 'mac',
+                arch                 : 'x64',
+                additionalNodeLabels : 'macos10.14',
+                test                 : 'default'
+                additionalFileNameTag: "macosXL",
+                configureArgs        : '--with-noncompressedrefs --enable-dtrace'
+        ],
 
         x64Linux  : [
                 os                  : 'linux',
@@ -29,6 +38,18 @@ class Config16 {
                         "openj9"      : '--enable-dtrace --enable-jitserver',
                         "hotspot"     : '--enable-dtrace'
                 ]
+        ],
+        
+        x64LinuxXL  : [
+                os                   : 'linux',
+                arch                 : 'x64',
+                dockerImage          : 'adoptopenjdk/centos7_build_image',
+                dockerFile: [
+                        openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
+                ],
+                test                 : 'default'
+                additionalFileNameTag: "linuxXL",
+                configureArgs        : '--with-noncompressedrefs --enable-dtrace --enable-jitserver'
         ],
 
         x64AlpineLinux  : [
@@ -54,6 +75,15 @@ class Config16 {
                         nightly: [],
                         weekly : ['sanity.openjdk', 'sanity.perf', 'sanity.system', 'extended.system']
                 ]
+        ],
+        
+        x64WindowsXL: [
+                os                   : 'windows',
+                arch                 : 'x64',
+                additionalNodeLabels : 'win2012&&vs2017',
+                test                 : 'default'
+                additionalFileNameTag: "windowsXL",
+                configureArgs        : '--with-noncompressedrefs'
         ],
 
         x32Windows: [
@@ -91,6 +121,14 @@ class Config16 {
                 ],
                 configureArgs       : '--enable-dtrace'
         ],
+        
+        s390xLinuxXL  : [
+                os                   : 'linux',
+                arch                 : 's390x',
+                test                 : 'default'
+                additionalFileNameTag: "linuxXL",
+                configureArgs        : '--with-noncompressedrefs --enable-dtrace'
+        ],
 
         ppc64leLinux    : [
                 os                  : 'linux',
@@ -105,6 +143,14 @@ class Config16 {
                 ]
 
         ],
+        
+        ppc64leLinuxXL    : [
+                os                   : 'linux',
+                arch                 : 'ppc64le',
+                test                 : 'default'
+                additionalFileNameTag: "linuxXL",
+                configureArgs        : '--with-noncompressedrefs --disable-ccache --enable-dtrace'
+        ],
 
         aarch64Linux    : [
                 os                  : 'linux',
@@ -115,6 +161,15 @@ class Config16 {
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
                 ],
                 configureArgs       : '--enable-dtrace'
+        ],
+        
+        aarch64LinuxXL    : [
+                os                   : 'linux',
+                dockerImage          : 'adoptopenjdk/centos7_build_image',
+                arch                 : 'aarch64',
+                test                 : 'default'
+                additionalFileNameTag: "linuxXL",
+                configureArgs        : '--with-noncompressedrefs --enable-dtrace'
         ],
 
         arm32Linux    : [


### PR DESCRIPTION
XL builds were included in the jdk15 pipeline, but were not
included in the jdk16 pipeline.

As per build issue 2174, the OpenJ9 team has confirmed that XL
builds should be included here.

Signed-off-by: Adam Farley <adfarley@redhat.com>