### PR TITLE
Revert "Ensure createOpenJDKTarArchive is in the working directory

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -851,8 +851,6 @@ createArchive() {
 
 # Create a Tar ball
 createOpenJDKTarArchive() {
-  stepIntoTheWorkingDirectory
-
   local jdkTargetPath=$(getJdkArchivePath)
   local jreTargetPath=$(getJreArchivePath)
   local testImageTargetPath=$(getTestImageArchivePath)


### PR DESCRIPTION
This reverts commit 1a60958cf7e51329ef3a0597e96d0130fe76d74f from https://github.com/AdoptOpenJDK/openjdk-build/pull/2252


Fixes https://github.com/AdoptOpenJDK/openjdk-build/issues/2255