### PR TITLE
Increase node checkout step timeout

### DIFF
--- a/pipelines/build/common/create_job_from_template.groovy
+++ b/pipelines/build/common/create_job_from_template.groovy
@@ -28,6 +28,7 @@ folder(buildFolder) {
     description 'Automatically generated build jobs.'
 }
 
+int GIT_TIMEOUT = 20
 pipelineJob("$buildFolder/$JOB_NAME") {
     description('<h1>THIS IS AN AUTOMATICALLY GENERATED JOB DO NOT MODIFY, IT WILL BE OVERWRITTEN.</h1><p>This job is defined in create_job_from_template.groovy in the openjdk-build repo, if you wish to change it modify that</p>')
     definition {
@@ -42,6 +43,12 @@ pipelineJob("$buildFolder/$JOB_NAME") {
                     extensions {
                         cleanBeforeCheckout()
                         pruneStaleBranch()
+                        cloneTimeout(GIT_TIMEOUT)
+                        configure { node ->
+                            node / 'extensions' << 'hudson.plugins.git.extensions.impl.CheckoutOption' {
+                                timeout GIT_TIMEOUT
+                            }
+                        }
                     }
                 }
             }

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -65,7 +65,6 @@ class Build {
         API_REQUEST_TIMEOUT : 1,
         NODE_CLEAN_TIMEOUT : 1,
         NODE_CHECKOUT_TIMEOUT : 1,
-        NODE_CHECKOUT_SCM_STAGE : 20, // Mins as Jenkins checkout timeouts are in mins
         BUILD_JDK_TIMEOUT : 8,
         BUILD_ARCHIVE_TIMEOUT : 3,
         AIX_CLEAN_TIMEOUT : 1,
@@ -909,17 +908,7 @@ class Build {
 
             try {
                 context.timeout(time: buildTimeouts.NODE_CHECKOUT_TIMEOUT, unit: "HOURS") {
-                    context.checkout([
-                        $class: 'GitSCM',
-                        userRemoteConfigs: [
-                            [ url: "https://github.com/AdoptOpenJDK/openjdk-build" ]
-                        ],
-                        extensions: [
-                            [ $class: 'CheckoutOption', timeout: buildTimeouts.NODE_CHECKOUT_SCM_STAGE ],
-                            [ $class: 'CloneOption', timeout: buildTimeouts.NODE_CHECKOUT_SCM_STAGE ],
-                            [ $class: 'SubmoduleOption', timeout: buildTimeouts.NODE_CHECKOUT_SCM_STAGE ]
-                        ]
-                    ])
+                    context.checkout context.scm
                 }
             } catch (FlowInterruptedException e) {
                 context.println "[ERROR] Node checkout workspace timeout (${buildTimeouts.NODE_CHECKOUT_TIMEOUT} HOURS) has been reached. Exiting..."

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -61,10 +61,11 @@ class Build {
     Map variantVersion = [:]
 
     // Declare timeouts for each critical stage (unit is HOURS)
-    Map buildTimeouts = [
+    static Map buildTimeouts = [
         API_REQUEST_TIMEOUT : 1,
         NODE_CLEAN_TIMEOUT : 1,
         NODE_CHECKOUT_TIMEOUT : 1,
+        NODE_CHECKOUT_SCM_STAGE : 20, // Mins as Jenkins checkout timeouts are in mins
         BUILD_JDK_TIMEOUT : 8,
         BUILD_ARCHIVE_TIMEOUT : 3,
         AIX_CLEAN_TIMEOUT : 1,
@@ -908,7 +909,17 @@ class Build {
 
             try {
                 context.timeout(time: buildTimeouts.NODE_CHECKOUT_TIMEOUT, unit: "HOURS") {
-                    context.checkout context.scm
+                    context.checkout([
+                        $class: 'GitSCM',
+                        userRemoteConfigs: [
+                            [ url: "https://github.com/AdoptOpenJDK/openjdk-build" ]
+                        ],
+                        extensions: [
+                            [ $class: 'CheckoutOption', timeout: buildTimeouts.NODE_CHECKOUT_SCM_STAGE ],
+                            [ $class: 'CloneOption', timeout: buildTimeouts.NODE_CHECKOUT_SCM_STAGE ],
+                            [ $class: 'SubmoduleOption', timeout: buildTimeouts.NODE_CHECKOUT_SCM_STAGE ]
+                        ]
+                    ])
                 }
             } catch (FlowInterruptedException e) {
                 context.println "[ERROR] Node checkout workspace timeout (${buildTimeouts.NODE_CHECKOUT_TIMEOUT} HOURS) has been reached. Exiting..."


### PR DESCRIPTION
* Timeout of each step is 20mins, timeout of the whole checkout is 1hr

Fixes: https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1553
Signed-off-by: Morgan Davies <morgandavies2020@gmail.com>