### PR TITLE
solaris: add /usr/sfw/bin to path so openssl is available

### DIFF
--- a/build-farm/platform-specific-configurations/solaris.sh
+++ b/build-farm/platform-specific-configurations/solaris.sh
@@ -30,7 +30,8 @@ elif [ "${ARCHITECTURE}" == "sparcv9" ]; then
 fi
 
 export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} ${CUPS} ${FREETYPE} --with-memory-size=${MEMORY}"
-export PATH=/opt/solarisstudio12.3/bin/:/opt/csw/bin/:/usr/ccs/bin:$PATH
+# /usr/sfw/bin required for OpenSSL (build#2265)
+export PATH=/opt/solarisstudio12.3/bin/:/opt/csw/bin/:/usr/ccs/bin:$PATH:/usr/sfw/bin
 
 export LC_ALL=C
 export HOTSPOT_DISABLE_DTRACE_PROBES=true


### PR DESCRIPTION
Hopefully fixes https://github.com/AdoptOpenJDK/openjdk-build/issues/2265 - or at least enables the build to get further

Signed-off-by: Stewart X Addison <sxa@redhat.com>