### PR TITLE
Perform openjdk-build git clean after scm checkout

### DIFF
--- a/pipelines/build/common/create_job_from_template.groovy
+++ b/pipelines/build/common/create_job_from_template.groovy
@@ -40,7 +40,8 @@ pipelineJob("$buildFolder/$JOB_NAME") {
                     }
                     branch("${GIT_BRANCH}")
                     extensions {
-                        cleanBeforeCheckout()
+                        //repo clean is performed after scm checkout in pipelines/build/common/openjdk_build_pipeline.groovy
+
                         pruneStaleBranch()
                     }
                 }

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -909,6 +909,10 @@ class Build {
             try {
                 context.timeout(time: buildTimeouts.NODE_CHECKOUT_TIMEOUT, unit: "HOURS") {
                     context.checkout context.scm
+
+                    // Perform a git clean outside of checkout to avoid the Jenkins enforced 10 minute timeout
+                    // https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1553
+                    context.sh(script: "git clean -fdx")
                 }
             } catch (FlowInterruptedException e) {
                 context.println "[ERROR] Node checkout workspace timeout (${buildTimeouts.NODE_CHECKOUT_TIMEOUT} HOURS) has been reached. Exiting..."
@@ -1083,6 +1087,10 @@ class Build {
                                 try {
                                     context.timeout(time: buildTimeouts.DOCKER_CHECKOUT_TIMEOUT, unit: "HOURS") {
                                         context.checkout context.scm
+
+                                        // Perform a git clean outside of checkout to avoid the Jenkins enforced 10 minute timeout
+                                        // https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1553
+                                        context.sh(script: "git clean -fdx")
                                     }
                                 } catch (FlowInterruptedException e) {
                                     context.println "[ERROR] Master docker file scm checkout timeout (${buildTimeouts.DOCKER_CHECKOUT_TIMEOUT} HOURS) has been reached. Exiting..."


### PR DESCRIPTION
Nightly builds do not cleanWorkspace, thus the "workspace" folder can contain 1000s of files which on some machines can take many minutes, sometimes exceeding the Jenkins enforced 10minute timeout for git clean -fdx
This PR disables the git clean on the SCM checkout and explicitly performs the clean afterwards.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>