### PR TITLE
fix sleep command syntax in prepareWorkspace.sh

### DIFF
--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -66,7 +66,7 @@ checkoutAndCloneOpenJDKGitRepo() {
     if [ "${isValidGitRepo}" == "0" ]; then
       cd "${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}" || return
       echo "Resetting the git openjdk source repository at $PWD in 10 seconds..."
-      sleep 10s
+      sleep 10
       echo "Pulling latest changes from git openjdk source repository"
     elif [ "${BUILD_CONFIG[CLEAN_GIT_REPO]}" == "true" ]; then
       echo "Removing current git repo as it is the wrong type"


### PR DESCRIPTION
This needs to go in today to prevent a build break. Solaris `sleep` doesn't support the `s` parameter. I suspect it's a pathway that is now being run as a result of https://github.com/AdoptOpenJDK/openjdk-buil/pull/2275 being merged.

Problem description from the build log:
```
14:10:57  Resetting the git openjdk source repository at /export/home/jenkins/workspace/build-scripts/jobs/jdk8u/jdk8u-solaris-x64-hotspot/workspace/build/src in 10 seconds...
14:10:57  sleep: bad character in argument
```

Signed-off-by: Stewart X Addison <sxa@redhat.com>