### PR TITLE
Allow speech marks in configure args

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,8 @@ removes the existing docker container and persistent volume before starting
 a new docker based build.
 
 -C, --configure-args <args>
-specify any custom user configuration arguments.
+specify any custom user configuration arguments, using 
+temporary_speech_mark_placeholder in the place of any speech marks.
 
 --clean-git-repo
 clean out any 'bad' local git repo you already have.

--- a/build-farm/make-adopt-build-farm.sh
+++ b/build-farm/make-adopt-build-farm.sh
@@ -152,5 +152,9 @@ export BUILD_ARGS="${BUILD_ARGS} --use-jep319-certs"
 
 echo "$PLATFORM_SCRIPT_DIR/../makejdk-any-platform.sh" --clean-git-repo --jdk-boot-dir "${JDK_BOOT_DIR}" --configure-args "${CONFIGURE_ARGS_FOR_ANY_PLATFORM}" --target-file-name "${FILENAME}" ${TAG_OPTION} ${OPTIONS} ${BUILD_ARGS} ${VARIANT_ARG} "${JAVA_TO_BUILD}"
 
+# Convert all speech marks in config args to make them safe to pass in.
+# These will be converted back into speech marks shortly before we use them, in build.sh.
+CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM//\"/temporary_speech_mark_placeholder}"
+
 # shellcheck disable=SC2086
 bash -c "$PLATFORM_SCRIPT_DIR/../makejdk-any-platform.sh --clean-git-repo --jdk-boot-dir ${JDK_BOOT_DIR} --configure-args \"${CONFIGURE_ARGS_FOR_ANY_PLATFORM}\" --target-file-name ${FILENAME} ${TAG_OPTION} ${OPTIONS} ${BUILD_ARGS} ${VARIANT_ARG} ${JAVA_TO_BUILD}"

--- a/pipelines/build/common/create_job_from_template.groovy
+++ b/pipelines/build/common/create_job_from_template.groovy
@@ -75,7 +75,7 @@ pipelineJob("$buildFolder/$JOB_NAME") {
                 <dt><strong>CODEBUILD</strong></dt><dd>Use a dynamic codebuild machine if no other machine is available</dd>
                 <dt><strong>DOCKER_IMAGE</strong></dt><dd>Use a docker build environment</dd>
                 <dt><strong>DOCKER_FILE</strong></dt><dd>Relative path to a dockerfile to be built and used on top of the DOCKER_IMAGE</dd>
-                <dt><strong>CONFIGURE_ARGS</strong></dt><dd>Arguments for ./configure</dd>
+                <dt><strong>CONFIGURE_ARGS</strong></dt><dd>Arguments for ./configure. Escape all speech marks used within this parameter.</dd>
                 <dt><strong>OVERRIDE_FILE_NAME_VERSION</strong></dt><dd>Set the version string on the file name</dd>
                 <dt><strong>RELEASE</strong></dt><dd>Is this build a release</dd>
                 <dt><strong>PUBLISH_NAME</strong></dt><dd>Set name of publish</dd>

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -374,7 +374,9 @@ configureCommandParameters() {
 
   # Finally, we add any configure arguments the user has specified on the command line.
   # This is done last, to ensure the user can override any args they need to.
-  CONFIGURE_ARGS="${CONFIGURE_ARGS} ${BUILD_CONFIG[USER_SUPPLIED_CONFIGURE_ARGS]}"
+  # The substitution allows the user to pass in speech marks without having to guess
+  # at the number of escapes needed to ensure that they persist up to this point.
+  CONFIGURE_ARGS="${CONFIGURE_ARGS} ${BUILD_CONFIG[USER_SUPPLIED_CONFIGURE_ARGS]//temporary_speech_mark_placeholder/\"}"
 
   configureFreetypeLocation
 


### PR DESCRIPTION
Currently, we lose these speech marks when they get passed from
make-adopt-build-farm.sh to makejdk-any-platform.sh

This change prevents that.

Signed-off-by: Adam Farley <adfarley@redhat.com>