### PR TITLE
Fix docker-build.sh with SELinux

### DIFF
--- a/docker-build.sh
+++ b/docker-build.sh
@@ -181,7 +181,7 @@ buildOpenJDKViaDocker()
          "--cpuset-cpus=${cpuSet}" 
          -v "${BUILD_CONFIG[DOCKER_SOURCE_VOLUME_NAME]}:/openjdk/build"
          -v "${hostDir}"/workspace/target:/"${BUILD_CONFIG[WORKSPACE_DIR]}"/"${BUILD_CONFIG[TARGET_DIR]}":Z 
-         -v "${hostDir}"/pipelines:/openjdk/pipelines 
+         -v "${hostDir}"/pipelines:/openjdk/pipelines:Z
          -e "DEBUG_DOCKER_FLAG=${BUILD_CONFIG[DEBUG_DOCKER]}" 
          -e "BUILD_VARIANT=${BUILD_CONFIG[BUILD_VARIANT]}"
           "${dockerEntrypoint[@]:+${dockerEntrypoint[@]}}")


### PR DESCRIPTION
Similar to https://github.com/AdoptOpenJDK/openjdk-build/pull/672.

`${BUILD_CONFIG[DOCKER_SOURCE_VOLUME_NAME]}` is a Docker volume, and according to the code, it's not shared so a `Z` is not required since it's implicit.