### PR TITLE
JDK16: Temporarily stop JDK16/J9/XL/s390x builds due to capacity issues

### DIFF
--- a/pipelines/jobs/configurations/jdk16.groovy
+++ b/pipelines/jobs/configurations/jdk16.groovy
@@ -41,9 +41,6 @@ targetConfigurations = [
                 "hotspot",
                 "openj9"
         ],
-        "s390xLinuxXL": [
-                "openj9"
-        ],
         "aarch64Linux": [
                 "hotspot",
                 "openj9"


### PR DESCRIPTION
Partially reverts https://github.com/AdoptOpenJDK/openjdk-build/pull/2251/files (@M-Davies I'm assume the pipeline configuration files don't need to have backed out here too)
Mitigation for https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1652

FYI @pshipton @aahlenst

Signed-off-by: Stewart X Addison <sxa@redhat.com>