### PR TITLE
Corretto jdk-11 does not have a src sub-folder any more

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -384,8 +384,8 @@ configureCommandParameters() {
 stepIntoTheWorkingDirectory() {
   cd "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}" || exit
 
-  # corretto nest their source under /src in their dir
-  if [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_CORRETTO}" ]; then
+  # corretto/corretto-8 (jdk-8 only) nest their source under /src in their dir
+  if [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_CORRETTO}" ] && [ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" == "8" ]; then
     cd "src"
   fi
 


### PR DESCRIPTION
Only corretto jdk-8 has an extra "src" sub-folder now
Signed-off-by: Andrew Leonard <anleonar@redhat.com>