### PR TITLE
buildArgs: allow args that aren't VM specific

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -169,7 +169,7 @@ class Builder implements Serializable {
                     return buildArgs.get(variant)
                 }
             } else {
-                context.error("Incorrect buildArgs type")
+                return configuration.buildArgs
             }
         }
 

--- a/pipelines/build/common/config_regeneration.groovy
+++ b/pipelines/build/common/config_regeneration.groovy
@@ -199,7 +199,7 @@ class Regeneration implements Serializable {
                     return buildArgs.get(variant)
                 }
             } else {
-                context.error("Incorrect buildArgs type")
+                return configuration.buildArgs
             }
         }
 


### PR DESCRIPTION
This fixes the current windows aarch64 build failure 