### PR TITLE
Rename BUILD_CONFIG CROSS_COMPILE to CROSSCOMPILE to avoid OpenSSL make conflict

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -540,7 +540,7 @@ printJavaVersionString() {
 
        echo "Error 'java' does not exist in '$PRODUCT_HOME'."
        exit -1
-     elif [ "${BUILD_CONFIG[CROSS_COMPILE]}" == "true" ]; then
+     elif [ "${BUILD_CONFIG[CROSSCOMPILE]}" == "true" ]; then
        # job is cross compiled, so we cannot run it on the build system
        # So we leave it for now and retrive the version from a downstream job after the build
        echo "Warning: java version can't be run on cross compiled build system. Faking version for now..."

--- a/sbin/common/config_init.sh
+++ b/sbin/common/config_init.sh
@@ -48,7 +48,7 @@ COPY_MACOSX_FREE_FONT_LIB_FOR_JRE_FLAG
 COPY_TO_HOST
 CREATE_DEBUG_SYMBOLS_PACKAGE
 CUSTOM_CACERTS
-CROSS_COMPILE
+CROSSCOMPILE
 DEBUG_DOCKER
 DEBUG_IMAGE_PATH
 DISABLE_ADOPT_BRANCH_SAFETY
@@ -271,7 +271,7 @@ function parseConfigurationArguments() {
         BUILD_CONFIG[JDK_BOOT_DIR]="$1";shift;;
 
         "--cross-compile" )
-        BUILD_CONFIG[CROSS_COMPILE]=true;;
+        BUILD_CONFIG[CROSSCOMPILE]=true;;
 
         "--keep" | "-k" )
         BUILD_CONFIG[KEEP_CONTAINER]=true;;
@@ -504,7 +504,7 @@ function configDefaults() {
 
   BUILD_CONFIG[RELEASE]=false
 
-  BUILD_CONFIG[CROSS_COMPILE]=false
+  BUILD_CONFIG[CROSSCOMPILE]=false
 
   # By default assume we have adopt patches applied to the repo
   BUILD_CONFIG[ADOPT_PATCHES]=true


### PR DESCRIPTION
CROSS_COMPILE is an environment variable relevant to OpenSSL make, the Adopt property is unrelated and for a different purpose

Signed-off-by: Andrew Leonard <anleonar@redhat.com>