### PR TITLE
use VS2019 on OpenJ9 JDK15+ builds

### DIFF
--- a/build-farm/platform-specific-configurations/windows.sh
+++ b/build-farm/platform-specific-configurations/windows.sh
@@ -152,7 +152,7 @@ then
       export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-freemarker-jar=/cygdrive/c/openjdk/freemarker.jar"
     elif [ "$JAVA_FEATURE_VERSION" -ge 11 ]
     then
-      TOOLCHAIN_VERSION="2017"
+      TOOLCHAIN_VERSION="2019"
       export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-freemarker-jar=/cygdrive/c/openjdk/freemarker.jar --with-openssl=/cygdrive/c/openjdk/OpenSSL-${OPENSSL_VERSION}-x86_64-VS2017 --enable-openssl-bundling"
     fi
 


### PR DESCRIPTION
Fixes https://github.com/AdoptOpenJDK/openjdk-build/issues/2147 (OpenJ9 request)

Validating at https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/OS=Win2012,label=vagrant/978/

Signed-off-by: Stewart X Addison <sxa@redhat.com>