### PR TITLE
lock jdk11 dragonwell to alibaba build machines (for now)

### DIFF
--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -42,8 +42,9 @@ class Config11 {
                 os                  : 'windows',
                 arch                : 'x64',
                 additionalNodeLabels: [
-                        hotspot: 'win2012',
-                        openj9:  'win2012&&vs2017'
+                        hotspot:    'win2012',
+                        openj9:     'win2012&&vs2017'
+                        dragonwell: 'win2012&&dragonwell'
                 ],
                 buildArgs : [
                         hotspot : '--jvm-variant client,server'

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -43,7 +43,7 @@ class Config11 {
                 arch                : 'x64',
                 additionalNodeLabels: [
                         hotspot:    'win2012',
-                        openj9:     'win2012&&vs2017'
+                        openj9:     'win2012&&vs2017',
                         dragonwell: 'win2012&&dragonwell'
                 ],
                 buildArgs : [


### PR DESCRIPTION
Not sure why, but at the moment the vendor version string doesn't work properly when on a non-alibaba build machine. It's something we need to understand (so this should NOT close issue https://github.com/AdoptOpenJDK/openjdk-build/issues/2329#issuecomment-750916933) but this will stabilise the builds and allow us to resolve any follow-on problems for now.

Signed-off-by: Stewart X Addison <sxa@redhat.com>