### PR TITLE
Add default nightly testing on JDK16

### DIFF
--- a/build-farm/platform-specific-configurations/windows.sh
+++ b/build-farm/platform-specific-configurations/windows.sh
@@ -152,7 +152,7 @@ then
       export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-freemarker-jar=/cygdrive/c/openjdk/freemarker.jar"
     elif [ "${JAVA_TO_BUILD}" == "${JDK11_VERSION}" ]
     then
-      TOOLCHAIN_VERSION="2019"
+      TOOLCHAIN_VERSION="2017"
       export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-freemarker-jar=/cygdrive/c/openjdk/freemarker.jar --with-openssl=/cygdrive/c/openjdk/OpenSSL-${OPENSSL_VERSION}-x86_64-VS2017 --enable-openssl-bundling"
     elif [ "$JAVA_FEATURE_VERSION" -gt 11 ]
     then

--- a/pipelines/jobs/configurations/jdk16_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk16_pipeline_config.groovy
@@ -62,7 +62,7 @@ class Config16 {
                 os                  : 'windows',
                 arch                : 'x64',
                 additionalNodeLabels: 'win2012&&vs2017',
-                test                : 'default',
+                test                : 'default'
         ],
         
         x64WindowsXL: [

--- a/pipelines/jobs/configurations/jdk16_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk16_pipeline_config.groovy
@@ -4,10 +4,7 @@ class Config16 {
                 os                  : 'mac',
                 arch                : 'x64',
                 additionalNodeLabels: 'macos10.14',
-                test                : [
-                        nightly: [],
-                        weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
-                ],
+                test                : 'default',
                 configureArgs       : '--enable-dtrace'
         ],
         
@@ -30,10 +27,7 @@ class Config16 {
                 dockerFile: [
                         openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],
-                test                : [
-                        nightly: [],
-                        weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external', 'special.functional']
-                ],
+                test                : 'default',
                 configureArgs       : [
                         "openj9"      : '--enable-dtrace --enable-jitserver',
                         "hotspot"     : '--enable-dtrace'
@@ -68,10 +62,7 @@ class Config16 {
                 os                  : 'windows',
                 arch                : 'x64',
                 additionalNodeLabels: 'win2012&&vs2017',
-                test                : [
-                        nightly: [],
-                        weekly : ['sanity.openjdk', 'sanity.perf', 'sanity.system', 'extended.system']
-                ]
+                test                : 'default',
         ],
         
         x64WindowsXL: [
@@ -103,10 +94,7 @@ class Config16 {
                 buildArgs : [
                         hotspot : '--jvm-variant client,server'
                 ],
-                test                : [
-                        nightly: [],
-                        weekly : ['sanity.openjdk', 'sanity.perf', 'sanity.system', 'extended.system']
-                ]
+                test                : 'default'
         ],
 
         ppc64Aix    : [
@@ -116,20 +104,14 @@ class Config16 {
                         hotspot: 'xlc16&&aix710',
                         openj9:  'xlc16&&aix715'
                 ],
-                test                : [
-                        nightly: [],
-                        weekly : ['sanity.openjdk', 'sanity.system', 'extended.system']
-                ]
+                test                : 'default'
         ],
 
 
         s390xLinux    : [
                 os                  : 'linux',
                 arch                : 's390x',
-                test                : [
-                        nightly: [],
-                        weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
-                ],
+                test                : 'default',
                 configureArgs       : '--enable-dtrace'
         ],
         
@@ -144,10 +126,7 @@ class Config16 {
         ppc64leLinux    : [
                 os                  : 'linux',
                 arch                : 'ppc64le',
-                test                : [
-                        nightly: [],
-                        weekly: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
-                ],
+                test                : 'default',
                 configureArgs       : [
                         "hotspot"     : '--enable-dtrace',
                         "openj9"      : '--enable-dtrace --enable-jitserver'
@@ -167,10 +146,7 @@ class Config16 {
                 os                  : 'linux',
                 arch                : 'aarch64',
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
-                test                : [
-                        nightly: [],
-                        weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
-                ],
+                test                : 'default',
                 configureArgs       : '--enable-dtrace'
         ],
         
@@ -186,10 +162,7 @@ class Config16 {
         arm32Linux    : [
                 os                  : 'linux',
                 arch                : 'arm',
-                test                : [
-                        nightly: ['sanity.openjdk'],
-                        weekly : []
-                ],
+                test                : 'default',
                 configureArgs       : '--enable-dtrace'
         ]
   ]


### PR DESCRIPTION
Fixes https://github.com/AdoptOpenJDK/openjdk-build/issues/2337

NOTE: I can't do the same for JDK17 for now as the jobs haven't been created, but doing this one step at a time to check machine capacity is a good thing. We could also wait until JDK15 is no longer needed before enabling JDK17 fully

Notes to reviewers:
1. PLEASE be certain I haven't made any typos in the syntax
2. PLEASE leave it for me to merge so I can do it at a time I'm paying attention to the pipelines when it first gooes through