### PR TITLE
Ensure jdk15/16/17 build ppcle on centos7 nodes

### DIFF
--- a/pipelines/jobs/configurations/jdk15u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk15u_pipeline_config.groovy
@@ -100,6 +100,7 @@ class Config15 {
         ppc64leLinux    : [
                 os                  : 'linux',
                 arch                : 'ppc64le',
+                additionalNodeLabels: 'centos7',
                 test                : 'default',
                 configureArgs       : [
                         "hotspot"     : '--enable-dtrace',
@@ -110,6 +111,7 @@ class Config15 {
         ppc64leLinuxXL    : [
                 os                   : 'linux',
                 arch                 : 'ppc64le',
+                additionalNodeLabels : 'centos7',
                 test                 : 'default',
                 additionalFileNameTag: "linuxXL",
                 configureArgs        : '--with-noncompressedrefs --disable-ccache --enable-dtrace'

--- a/pipelines/jobs/configurations/jdk16_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk16_pipeline_config.groovy
@@ -126,6 +126,7 @@ class Config16 {
         ppc64leLinux    : [
                 os                  : 'linux',
                 arch                : 'ppc64le',
+                additionalNodeLabels: 'centos7',
                 test                : 'default',
                 configureArgs       : [
                         "hotspot"     : '--enable-dtrace',
@@ -137,6 +138,7 @@ class Config16 {
         ppc64leLinuxXL    : [
                 os                   : 'linux',
                 arch                 : 'ppc64le',
+                additionalNodeLabels : 'centos7',
                 test                 : 'default',
                 additionalFileNameTag: "linuxXL",
                 configureArgs        : '--with-noncompressedrefs --disable-ccache --enable-dtrace'

--- a/pipelines/jobs/configurations/jdk17_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17_pipeline_config.groovy
@@ -141,6 +141,7 @@ class Config17 {
         ppc64leLinux    : [
                 os                  : 'linux',
                 arch                : 'ppc64le',
+                additionalNodeLabels: 'centos7',
                 test                : [
                         nightly: [],
                         weekly: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
@@ -155,6 +156,7 @@ class Config17 {
         ppc64leLinuxXL    : [
                 os                   : 'linux',
                 arch                 : 'ppc64le',
+                additionalNodeLabels : 'centos7',
                 test                 : 'default',
                 additionalFileNameTag: "linuxXL",
                 configureArgs        : '--with-noncompressedrefs --disable-ccache --enable-dtrace'


### PR DESCRIPTION
Without centos7 the builds can also target the OSUSL pple Cloud which is currently not operational

Signed-off-by: Andrew Leonard <anleonar@redhat.com>