### PR TITLE
Clean up redundant json and sha256 files from previous mac runs

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -517,7 +517,7 @@ class Build {
         context.node('master') {
             context.stage("installer") {
                 switch (buildConfig.TARGET_OS) {
-                    case "mac": context.sh 'rm -f workspace/target/*.pkg; done'; buildMacInstaller(versionData); break
+                    case "mac": context.sh 'rm -f workspace/target/*.pkg workspace/target/*.pkg.json workspace/target/*.pkg.sha256.txt; done'; buildMacInstaller(versionData); break
                     case "linux": buildLinuxInstaller(versionData); break
                     case "windows": buildWindowsInstaller(versionData); break
                     default: return; break


### PR DESCRIPTION
Mac runs leave these behind. We should preserve the ones from the
current run to aid debugging, and delete the rest to prevent the
buildup of plaque.

Signed-off-by: Adam Farley <adfarley@redhat.com>