### PR TITLE
Add ADDITIONAL_TEST_LABEL to allow targeting variant test jobs appropriately

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -99,6 +99,8 @@ class Builder implements Serializable {
 
         def additionalNodeLabels = formAdditionalBuildNodeLabels(platformConfig, variant)
 
+        def additionalTestLabels = formAdditionalTestLabels(platformConfig, variant)
+
         def archLabel = getArchLabel(platformConfig, variant)
 
         def dockerImage = getDockerImage(platformConfig, variant)
@@ -130,6 +132,7 @@ class Builder implements Serializable {
                 SCM_REF: scmReference,
                 BUILD_ARGS: buildArgs,
                 NODE_LABEL: "${additionalNodeLabels}&&${platformConfig.os}&&${archLabel}",
+                ADDITIONAL_TEST_LABEL: "${additionalTestLabels}",
                 ACTIVE_NODE_TIMEOUT: activeNodeTimeout,
                 CODEBUILD: platformConfig.codebuild as Boolean,
                 DOCKER_IMAGE: dockerImage,
@@ -328,6 +331,32 @@ class Builder implements Serializable {
 
             if (additionalNodeLabels != null) {
                 labels = "${additionalNodeLabels}&&${labels}"
+            }
+        }
+
+        return labels
+    }
+
+    /**
+    * Builds up additional test labels
+    * @param configuration
+    * @param variant
+    * @return
+    */
+    def formAdditionalTestLabels(Map<String, ?> configuration, String variant) {
+        def labels = ""
+
+        if (configuration.containsKey("additionalTestLabels")) {
+            def additionalTestLabels
+
+            if (isMap(configuration.additionalTestLabels)) {
+                additionalTestLabels = (configuration.additionalTestLabels as Map<String, ?>).get(variant)
+            } else {
+                additionalTestLabels = configuration.additionalTestLabels
+            }
+
+            if (additionalTestLabels != null) {
+                labels = "${additionalTestLabels}"
             }
         }
 

--- a/pipelines/build/common/config_regeneration.groovy
+++ b/pipelines/build/common/config_regeneration.groovy
@@ -186,6 +186,32 @@ class Regeneration implements Serializable {
         return labels
     }
 
+    /**
+    * Builds up additional test labels
+    * @param configuration
+    * @param variant
+    * @return
+    */
+    def formAdditionalTestLabels(Map<String, ?> configuration, String variant) {
+        def labels = ""
+
+        if (configuration.containsKey("additionalTestLabels")) {
+            def additionalTestLabels
+
+            if (isMap(configuration.additionalTestLabels)) {
+                additionalTestLabels = (configuration.additionalTestLabels as Map<String, ?>).get(variant)
+            } else {
+                additionalTestLabels = configuration.additionalTestLabels
+            }
+
+            if (additionalTestLabels != null) {
+                labels = "${additionalTestLabels}"
+            }
+        }
+
+        return labels
+    }
+
     /*
     * Get build args from jdk*_pipeline_config.groovy. Used when creating the IndividualBuildConfig.
     * @param configuration
@@ -268,6 +294,8 @@ class Regeneration implements Serializable {
             }
 
             def additionalNodeLabels = formAdditionalBuildNodeLabels(platformConfig, variant)
+ 
+            def additionalTestLabels = formAdditionalTestLabels(platformConfig, variant)
 
             def archLabel = getArchLabel(platformConfig, variant)
 
@@ -290,6 +318,7 @@ class Regeneration implements Serializable {
                 SCM_REF: "",
                 BUILD_ARGS: buildArgs,
                 NODE_LABEL: "${additionalNodeLabels}&&${platformConfig.os}&&${archLabel}",
+                ADDITIONAL_TEST_LABEL: "${additionalTestLabels}",
                 ACTIVE_NODE_TIMEOUT: "",
                 CODEBUILD: platformConfig.codebuild as Boolean,
                 DOCKER_IMAGE: dockerImage,

--- a/pipelines/build/common/create_job_from_template.groovy
+++ b/pipelines/build/common/create_job_from_template.groovy
@@ -72,6 +72,7 @@ pipelineJob("$buildFolder/$JOB_NAME") {
                 <dt><strong>SCM_REF</strong></dt><dd>Source code ref to build, i.e branch, tag, commit id</dd>
                 <dt><strong>BUILD_ARGS</strong></dt><dd>args to pass to makejdk-any-platform.sh</dd>
                 <dt><strong>NODE_LABEL</strong></dt><dd>Labels of node to build on</dd>
+                <dt><strong>ADDITIONAL_TEST_LABEL</strong></dt><dd>Additional label for test jobs</dd>
                 <dt><strong>ACTIVE_NODE_TIMEOUT</strong></dt><dd>Number of minutes we will wait for a label-matching node to become active.</dd>
                 <dt><strong>CODEBUILD</strong></dt><dd>Use a dynamic codebuild machine if no other machine is available</dd>
                 <dt><strong>DOCKER_IMAGE</strong></dt><dd>Use a docker build environment</dd>

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -219,6 +219,8 @@ class Build {
         def jdkRepo = getJDKRepo()
         def openj9Branch = (buildConfig.SCM_REF && buildConfig.VARIANT == "openj9") ? buildConfig.SCM_REF : "master"
 
+        def additionalTestLabel = buildConfig.ADDITIONAL_TEST_LABEL
+
         if (buildConfig.VARIANT == "corretto") {
             testList = buildConfig.TEST_LIST.minus(['sanity.external'])
         } else {
@@ -250,6 +252,7 @@ class Build {
 												context.string(name: 'JDK_REPO', value: jdkRepo),
 												context.string(name: 'JDK_BRANCH', value: jdkBranch),
 												context.string(name: 'OPENJ9_BRANCH', value: openj9Branch),
+												context.string(name: 'LABEL_ADDITION', value: additionalTestLabel),
 												context.string(name: 'ACTIVE_NODE_TIMEOUT', value: "${buildConfig.ACTIVE_NODE_TIMEOUT}")]
 							}
 						} else {

--- a/pipelines/jobs/configurations/jdk15u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk15u_pipeline_config.groovy
@@ -28,6 +28,9 @@ class Config15 {
                         openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],
                 test                : 'default',
+                additionalTestLabels: [
+                        openj9      : '!(centos6||rhel6)'
+                ],
                 configureArgs       : [
                         "openj9"      : '--enable-dtrace --enable-jitserver',
                         "hotspot"     : '--enable-dtrace'
@@ -42,6 +45,9 @@ class Config15 {
                         openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],
                 test                : 'default',
+                additionalTestLabels: [
+                        openj9      : '!(centos6||rhel6)'
+                ],
                 additionalFileNameTag: "linuxXL",
                 configureArgs       : '--with-noncompressedrefs --enable-dtrace --enable-jitserver'
         ],

--- a/pipelines/jobs/configurations/jdk16_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk16_pipeline_config.groovy
@@ -28,6 +28,9 @@ class Config16 {
                         openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],
                 test                : 'default',
+                additionalTestLabels: [
+                        openj9      : '!(centos6||rhel6)'
+                ],
                 configureArgs       : [
                         "openj9"      : '--enable-dtrace --enable-jitserver',
                         "hotspot"     : '--enable-dtrace'
@@ -42,6 +45,9 @@ class Config16 {
                         openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],
                 test                 : 'default',
+                additionalTestLabels: [
+                        openj9      : '!(centos6||rhel6)'
+                ],
                 additionalFileNameTag: "linuxXL",
                 configureArgs        : '--with-noncompressedrefs --enable-dtrace --enable-jitserver'
         ],

--- a/pipelines/jobs/configurations/jdk17_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17_pipeline_config.groovy
@@ -34,6 +34,9 @@ class Config17 {
                         nightly: [],
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external', 'special.functional']
                 ],
+                additionalTestLabels: [
+                        openj9      : '!(centos6||rhel6)'
+                ],
                 configureArgs       : [
                         "openj9"      : '--enable-dtrace --enable-jitserver',
                         "hotspot"     : '--enable-dtrace'
@@ -48,6 +51,9 @@ class Config17 {
                         openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],
                 test                 : 'default',
+                additionalTestLabels: [
+                        openj9      : '!(centos6||rhel6)'
+                ],
                 additionalFileNameTag: "linuxXL",
                 configureArgs        : '--with-noncompressedrefs --enable-dtrace --enable-jitserver'
         ],

--- a/pipelines/library/src/common/IndividualBuildConfig.groovy
+++ b/pipelines/library/src/common/IndividualBuildConfig.groovy
@@ -12,6 +12,7 @@ class IndividualBuildConfig implements Serializable {
     final String SCM_REF
     final String BUILD_ARGS
     final String NODE_LABEL
+    final String ADDITIONAL_TEST_LABEL
     final String ACTIVE_NODE_TIMEOUT
     final boolean CODEBUILD
     final String DOCKER_IMAGE
@@ -50,6 +51,7 @@ class IndividualBuildConfig implements Serializable {
         SCM_REF = map.get("SCM_REF")
         BUILD_ARGS = map.get("BUILD_ARGS")
         NODE_LABEL = map.get("NODE_LABEL")
+        ADDITIONAL_TEST_LABEL = map.get("ADDITIONAL_TEST_LABEL")
         ACTIVE_NODE_TIMEOUT = map.get("ACTIVE_NODE_TIMEOUT")
         CODEBUILD = map.get("CODEBUILD")
         DOCKER_IMAGE = map.get("DOCKER_IMAGE")
@@ -93,6 +95,7 @@ class IndividualBuildConfig implements Serializable {
                 SCM_REF                   : SCM_REF,
                 BUILD_ARGS                : BUILD_ARGS,
                 NODE_LABEL                : NODE_LABEL,
+                ADDITIONAL_TEST_LABEL     : ADDITIONAL_TEST_LABEL,
                 ACTIVE_NODE_TIMEOUT       : ACTIVE_NODE_TIMEOUT,
                 CODEBUILD                 : CODEBUILD,
                 DOCKER_IMAGE              : DOCKER_IMAGE,

--- a/pipelines/src/test/groovy/IndividualBuildConfigTest.groovy
+++ b/pipelines/src/test/groovy/IndividualBuildConfigTest.groovy
@@ -16,6 +16,7 @@ class IndividualBuildConfigTest {
                  SCM_REF                   : "f",
                  BUILD_ARGS                : "g",
                  NODE_LABEL                : "h",
+                 ADDITIONAL_TEST_LABEL     : "t",
                  ACTIVE_NODE_TIMEOUT       : "r",
                  CODEBUILD                 : false,
                  DOCKER_IMAGE              : "o",


### PR DESCRIPTION
Allow additional test labels, for example jdk15+ openj9 cannot run on centos6 or rhel6.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>