### PR TITLE
Dragonwell Windows everywhere

### DIFF
--- a/build-farm/platform-specific-configurations/windows.sh
+++ b/build-farm/platform-specific-configurations/windows.sh
@@ -152,7 +152,7 @@ then
       export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-freemarker-jar=/cygdrive/c/openjdk/freemarker.jar"
     elif [ "${JAVA_TO_BUILD}" == "${JDK11_VERSION}" ]
     then
-      TOOLCHAIN_VERSION="2019"
+      TOOLCHAIN_VERSION="2017"
       export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-freemarker-jar=/cygdrive/c/openjdk/freemarker.jar --with-openssl=/cygdrive/c/openjdk/OpenSSL-${OPENSSL_VERSION}-x86_64-VS2017 --enable-openssl-bundling"
     elif [ "$JAVA_FEATURE_VERSION" -gt 11 ]
     then

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -43,7 +43,7 @@ class Config11 {
                 additionalNodeLabels: [
                         hotspot:    'win2012',
                         openj9:     'win2012&&vs2017',
-                        dragonwell: 'win2012&&dragonwell'
+                        dragonwell: 'win2012'
                 ],
                 buildArgs : [
                         hotspot : '--jvm-variant client,server'

--- a/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
@@ -42,7 +42,7 @@ class Config8 {
                         hotspot : 'win2012',
                         corretto: 'win2012',
                         openj9  : 'win2012&&mingw-cygwin',
-                        dragonwell: 'win2012&&dragonwell'
+                        dragonwell: 'win2012'
                 ],
                 test                 : 'default'
         ],


### PR DESCRIPTION
As per https://github.com/AdoptOpenJDK/openjdk-build/pull/2354#pullrequestreview-561238497 we need to have redundancy in our infrastructure to ensure things are not tied to single systems with customer configurations. Installing the Dragonwell boot JDK8 as per the playbooks means we can build Dragonwell on all systems.

Based on the comment at https://github.com/AdoptOpenJDK/openjdk-build/issues/2329#issuecomment-751429058 it is possible that https://github.com/AdoptOpenJDK/openjdk-build/pull/2352 resolves the JDK11 issue, so this reverts both #2341 and #2354

- [x] [JDK8 test](https://ci.adoptopenjdk.net/view/work-in-progress/job/SXA-dragonwell8/21/console)
- [x] [JDK11 test](https://ci.adoptopenjdk.net/job/build-scripts/job/jobs/job/jdk11u/job/jdk11u-windows-x64-dragonwell/33/console)

Merging this will give us additional time to diagnose the alibaba current alibaba build system issues, there this hopefully fixes #2329 and https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1832