### PR TITLE
Add scmReference config for weekly release builds

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -259,6 +259,10 @@ When the repo has been created, a few changes to the codebase will be necessary 
 
   - https://github.com/AdoptOpenJDK/openjdk-build/search?q=jdkxx
 
+### Post Release Tasks
+Once all the release binaries have been published the following tasks should be completed:
+1. Reset the "weekly_release_scmReferences" (change to "") for the weekend release test build so it is using HEAD streams: https://github.com/AdoptOpenJDK/openjdk-build/tree/master/pipelines/jobs/configurations
+
 ## Summary on point releases
 
 Occasionally we may have to do an out-of-band release that does not align with a quarterly release from the upstream OpenJDK project. This may occur if there has been a problem with our build process that we missed at GA time, to fix a critical issue, or when a project outside OpenJDK (e.g. OpenJ9) needs to do an interim release. In order to do such a release, follow the steps included in the process above which I'll repeat here for clarity:

--- a/pipelines/build/regeneration/build_pipeline_generator.groovy
+++ b/pipelines/build/regeneration/build_pipeline_generator.groovy
@@ -60,6 +60,7 @@ node('master') {
     config.JOB_NAME = "weekly-openjdk${javaVersion}-pipeline"
     config.SCRIPT   = "pipelines/build/common/weekly_release_pipeline.groovy"
     config.PIPELINE = "openjdk${javaVersion}-pipeline"
+    config.weekly_release_scmReferences = target.weekly_release_scmReferences
 
     if (Boolean.parseBoolean(enablePipelineSchedule) == true) {
       try {

--- a/pipelines/jobs/configurations/jdk11u.groovy
+++ b/pipelines/jobs/configurations/jdk11u.groovy
@@ -64,4 +64,12 @@ triggerSchedule_nightly="TZ=UTC\n05 18 * * 2,4"
 // 17:05 Sat
 triggerSchedule_weekly="TZ=UTC\n05 17 * * 6"
 
+// scmReferences to use for weekly release build
+weekly_release_scmReferences=[
+        "hotspot"        : "jdk-11.0.10+8_adopt",
+        "openj9"         : "v0.24.0-release",
+        "corretto"       : "",
+        "dragonwell"     : ""
+]
+
 return this

--- a/pipelines/jobs/configurations/jdk15u.groovy
+++ b/pipelines/jobs/configurations/jdk15u.groovy
@@ -58,4 +58,12 @@ triggerSchedule_nightly="TZ=UTC\n30 23 * * 2,4"
 // 23:30 Sat
 triggerSchedule_weekly="TZ=UTC\n30 23 * * 6"
 
+// scmReferences to use for weekly release build
+weekly_release_scmReferences=[
+        "hotspot"        : "jdk-15.0.1+9_adopt",
+        "openj9"         : "v0.24.0-release",
+        "corretto"       : "",
+        "dragonwell"     : ""
+]
+
 return this

--- a/pipelines/jobs/configurations/jdk16.groovy
+++ b/pipelines/jobs/configurations/jdk16.groovy
@@ -61,4 +61,12 @@ triggerSchedule_nightly="TZ=UTC\n30 23 * * 1,3,5"
 // 04:30 Sun
 triggerSchedule_weekly="TZ=UTC\n30 04 * * 7"
 
+// scmReferences to use for weekly release build
+weekly_release_scmReferences=[
+        "hotspot"        : "",
+        "openj9"         : "",
+        "corretto"       : "",
+        "dragonwell"     : ""
+]
+
 return this

--- a/pipelines/jobs/configurations/jdk17.groovy
+++ b/pipelines/jobs/configurations/jdk17.groovy
@@ -61,4 +61,12 @@ triggerSchedule_nightly="TZ=UTC\n30 03 * * 3,5"
 // 12:05 Sun
 triggerSchedule_weekly="TZ=UTC\n05 12 * * 7"
 
+// scmReferences to use for weekly release build
+weekly_release_scmReferences=[
+        "hotspot"        : "",
+        "openj9"         : "",
+        "corretto"       : "",
+        "dragonwell"     : ""
+]
+
 return this

--- a/pipelines/jobs/configurations/jdk8u.groovy
+++ b/pipelines/jobs/configurations/jdk8u.groovy
@@ -65,4 +65,12 @@ triggerSchedule_nightly="TZ=UTC\n05 18 * * 1,3,5"
 // 12:05 Sat
 triggerSchedule_weekly="TZ=UTC\n05 12 * * 6"
 
+// scmReferences to use for weekly release build
+weekly_release_scmReferences=[
+        "hotspot"        : "jdk8u282-b07",
+        "openj9"         : "v0.24.0-release",
+        "corretto"       : "",
+        "dragonwell"     : ""
+]
+
 return this

--- a/pipelines/jobs/weekly_release_pipeline_job_template.groovy
+++ b/pipelines/jobs/weekly_release_pipeline_job_template.groovy
@@ -1,3 +1,4 @@
+import groovy.json.JsonOutput
 
 folder("${BUILD_FOLDER}")
 
@@ -27,5 +28,7 @@ pipelineJob("${BUILD_FOLDER}/${JOB_NAME}") {
 
     parameters {
         stringParam('buildPipeline', "${BUILD_FOLDER}/${PIPELINE}", 'The build pipeline to invoke.')
+        textParam('scmReferences', JsonOutput.prettyPrint(JsonOutput.toJson(weekly_release_scmReferences)), 'The map of scmReferences for each variant.')
+        textParam('targetConfigurations', JsonOutput.prettyPrint(JsonOutput.toJson(targetConfigurations)), 'The map of platforms and variants to build.')
     }
 }


### PR DESCRIPTION
Add into the pipeline jdk job config weekly release build scmReference configuration, allowing the weekend weekly build to actually build the release tags/branches.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>