### PR TITLE
Add pipeline param for test KEEP_REPORTDIR

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -52,6 +52,7 @@ class Builder implements Serializable {
     boolean enableSigner
     boolean cleanWorkspaceBeforeBuild
     boolean propagateFailures
+    boolean keepTestReportDir
 
     def env
     def scmVars
@@ -133,6 +134,7 @@ class Builder implements Serializable {
                 BUILD_ARGS: buildArgs,
                 NODE_LABEL: "${additionalNodeLabels}&&${platformConfig.os}&&${archLabel}",
                 ADDITIONAL_TEST_LABEL: "${additionalTestLabels}",
+                KEEP_TEST_REPORTDIR: keepTestReportDir,
                 ACTIVE_NODE_TIMEOUT: activeNodeTimeout,
                 CODEBUILD: platformConfig.codebuild as Boolean,
                 DOCKER_IMAGE: dockerImage,
@@ -561,6 +563,7 @@ class Builder implements Serializable {
             context.echo "Publish: ${publish}"
             context.echo "Release: ${release}"
             context.echo "Tag/Branch name: ${scmReference}"
+            context.echo "Keep test reportdir: ${keepTestReportDir}"
 
             jobConfigurations.each { configuration ->
                 jobs[configuration.key] = {
@@ -680,6 +683,7 @@ return {
     String cleanWorkspaceBeforeBuild,
     String adoptBuildNumber,
     String propagateFailures,
+    String keepTestReportDir,
     def currentBuild,
     def context,
     def env ->
@@ -729,6 +733,7 @@ return {
             cleanWorkspaceBeforeBuild: Boolean.parseBoolean(cleanWorkspaceBeforeBuild),
             adoptBuildNumber: adoptBuildNumber,
             propagateFailures: Boolean.parseBoolean(propagateFailures),
+            keepTestReportDir: Boolean.parseBoolean(keepTestReportDir),
             currentBuild: currentBuild,
             context: context,
             env: env

--- a/pipelines/build/common/config_regeneration.groovy
+++ b/pipelines/build/common/config_regeneration.groovy
@@ -319,6 +319,7 @@ class Regeneration implements Serializable {
                 BUILD_ARGS: buildArgs,
                 NODE_LABEL: "${additionalNodeLabels}&&${platformConfig.os}&&${archLabel}",
                 ADDITIONAL_TEST_LABEL: "${additionalTestLabels}",
+                KEEP_TEST_REPORTDIR: false,
                 ACTIVE_NODE_TIMEOUT: "",
                 CODEBUILD: platformConfig.codebuild as Boolean,
                 DOCKER_IMAGE: dockerImage,

--- a/pipelines/build/common/create_job_from_template.groovy
+++ b/pipelines/build/common/create_job_from_template.groovy
@@ -73,7 +73,7 @@ pipelineJob("$buildFolder/$JOB_NAME") {
                 <dt><strong>BUILD_ARGS</strong></dt><dd>args to pass to makejdk-any-platform.sh</dd>
                 <dt><strong>NODE_LABEL</strong></dt><dd>Labels of node to build on</dd>
                 <dt><strong>ADDITIONAL_TEST_LABEL</strong></dt><dd>Additional label for test jobs</dd>
-                <dt><strong>KEEP_TEST_REPORTDIR</strong></dt><dd>If true, test report dir will be kept even when the testcase passes, failed testcases always keep the report dir. Does not apply to JUnit jobs which are always kept, eg.openjdk.</dd>
+                <dt><strong>KEEP_TEST_REPORTDIR</strong></dt><dd>If true, test report dir (including core files where generated) will be kept even when the testcase passes, failed testcases always keep the report dir. Does not apply to JUnit jobs which are always kept, eg.openjdk.</dd>
                 <dt><strong>ACTIVE_NODE_TIMEOUT</strong></dt><dd>Number of minutes we will wait for a label-matching node to become active.</dd>
                 <dt><strong>CODEBUILD</strong></dt><dd>Use a dynamic codebuild machine if no other machine is available</dd>
                 <dt><strong>DOCKER_IMAGE</strong></dt><dd>Use a docker build environment</dd>

--- a/pipelines/build/common/create_job_from_template.groovy
+++ b/pipelines/build/common/create_job_from_template.groovy
@@ -73,6 +73,7 @@ pipelineJob("$buildFolder/$JOB_NAME") {
                 <dt><strong>BUILD_ARGS</strong></dt><dd>args to pass to makejdk-any-platform.sh</dd>
                 <dt><strong>NODE_LABEL</strong></dt><dd>Labels of node to build on</dd>
                 <dt><strong>ADDITIONAL_TEST_LABEL</strong></dt><dd>Additional label for test jobs</dd>
+                <dt><strong>KEEP_TEST_REPORTDIR</strong></dt><dd>If true, test report dir will be kept even when the testcase passes, failed testcases always keep the report dir. Does not apply to JUnit jobs which are always kept, eg.openjdk.</dd>
                 <dt><strong>ACTIVE_NODE_TIMEOUT</strong></dt><dd>Number of minutes we will wait for a label-matching node to become active.</dd>
                 <dt><strong>CODEBUILD</strong></dt><dd>Use a dynamic codebuild machine if no other machine is available</dd>
                 <dt><strong>DOCKER_IMAGE</strong></dt><dd>Use a docker build environment</dd>

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -234,6 +234,11 @@ class Build {
 				context.println "Running test: ${testType}"
 				testStages["${testType}"] = {
 					context.stage("${testType}") {
+						def keep_test_reportdir = buildConfig.KEEP_TEST_REPORTDIR
+						if (("${testType}".contains("openjdk")) || ("${testType}".contains("jck"))) {
+							// Keep test reportdir always for JUnit targets
+							keep_test_reportdir = "true"
+						}
 
 						// example jobName: Test_openjdk11_hs_sanity.system_ppc64_aix
 						def jobName = determineTestJobName(testType)
@@ -253,6 +258,7 @@ class Build {
 												context.string(name: 'JDK_BRANCH', value: jdkBranch),
 												context.string(name: 'OPENJ9_BRANCH', value: openj9Branch),
 												context.string(name: 'LABEL_ADDITION', value: additionalTestLabel),
+												context.string(name: 'KEEP_REPORTDIR', value: "${keep_test_reportdir}"),
 												context.string(name: 'ACTIVE_NODE_TIMEOUT', value: "${buildConfig.ACTIVE_NODE_TIMEOUT}")]
 							}
 						} else {

--- a/pipelines/build/openjdk10_pipeline.groovy
+++ b/pipelines/build/openjdk10_pipeline.groovy
@@ -45,6 +45,7 @@ if (scmVars != null && configureBuild != null && buildConfigurations != null) {
         cleanWorkspaceBeforeBuild,
         adoptBuildNumber,
         propagateFailures,
+        keepTestReportDir,
         currentBuild,
         this,
         env

--- a/pipelines/build/openjdk11_pipeline.groovy
+++ b/pipelines/build/openjdk11_pipeline.groovy
@@ -45,6 +45,7 @@ if (scmVars != null && configureBuild != null && buildConfigurations != null) {
         cleanWorkspaceBeforeBuild,
         adoptBuildNumber,
         propagateFailures,
+        keepTestReportDir,
         currentBuild,
         this,
         env

--- a/pipelines/build/openjdk12_pipeline.groovy
+++ b/pipelines/build/openjdk12_pipeline.groovy
@@ -45,6 +45,7 @@ if (scmVars != null && configureBuild != null && buildConfigurations != null) {
         cleanWorkspaceBeforeBuild,
         adoptBuildNumber,
         propagateFailures,
+        keepTestReportDir,
         currentBuild,
         this,
         env

--- a/pipelines/build/openjdk13_pipeline.groovy
+++ b/pipelines/build/openjdk13_pipeline.groovy
@@ -45,6 +45,7 @@ if (scmVars != null && configureBuild != null && buildConfigurations != null) {
         cleanWorkspaceBeforeBuild,
         adoptBuildNumber,
         propagateFailures,
+        keepTestReportDir,
         currentBuild,
         this,
         env

--- a/pipelines/build/openjdk14_pipeline.groovy
+++ b/pipelines/build/openjdk14_pipeline.groovy
@@ -45,6 +45,7 @@ if (scmVars != null && configureBuild != null && buildConfigurations != null) {
         cleanWorkspaceBeforeBuild,
         adoptBuildNumber,
         propagateFailures,
+        keepTestReportDir,
         currentBuild,
         this,
         env

--- a/pipelines/build/openjdk15_pipeline.groovy
+++ b/pipelines/build/openjdk15_pipeline.groovy
@@ -45,6 +45,7 @@ if (scmVars != null && configureBuild != null && buildConfigurations != null) {
         cleanWorkspaceBeforeBuild,
         adoptBuildNumber,
         propagateFailures,
+        keepTestReportDir,
         currentBuild,
         this,
         env

--- a/pipelines/build/openjdk16_pipeline.groovy
+++ b/pipelines/build/openjdk16_pipeline.groovy
@@ -45,6 +45,7 @@ if (scmVars != null && configureBuild != null && buildConfigurations != null) {
         cleanWorkspaceBeforeBuild,
         adoptBuildNumber,
         propagateFailures,
+        keepTestReportDir,
         currentBuild,
         this,
         env

--- a/pipelines/build/openjdk17_pipeline.groovy
+++ b/pipelines/build/openjdk17_pipeline.groovy
@@ -45,6 +45,7 @@ if (scmVars != null && configureBuild != null && buildConfigurations != null) {
         cleanWorkspaceBeforeBuild,
         adoptBuildNumber,
         propagateFailures,
+        keepTestReportDir,
         currentBuild,
         this,
         env

--- a/pipelines/build/openjdk8_pipeline.groovy
+++ b/pipelines/build/openjdk8_pipeline.groovy
@@ -45,6 +45,7 @@ if (scmVars != null && configureBuild != null && buildConfigurations != null) {
         cleanWorkspaceBeforeBuild,
         adoptBuildNumber,
         propagateFailures,
+        keepTestReportDir,
         currentBuild,
         this,
         env

--- a/pipelines/build/openjdk9_pipeline.groovy
+++ b/pipelines/build/openjdk9_pipeline.groovy
@@ -45,6 +45,7 @@ if (scmVars != null && configureBuild != null && buildConfigurations != null) {
         cleanWorkspaceBeforeBuild,
         adoptBuildNumber,
         propagateFailures,
+        keepTestReportDir,
         currentBuild,
         this,
         env

--- a/pipelines/jobs/pipeline_job_template.groovy
+++ b/pipelines/jobs/pipeline_job_template.groovy
@@ -73,6 +73,7 @@ pipelineJob("${BUILD_FOLDER}/${JOB_NAME}") {
         stringParam('overrideFileNameVersion', "", "When forming the filename, ignore the part of the filename derived from the publishName or timestamp and override it.<br/>For instance if you set this to 'FOO' the final file name will be of the form: <code>OpenJDK8U-jre_ppc64le_linux_openj9_FOO.tar.gz</code>")
         booleanParam('cleanWorkspaceBeforeBuild', false, "Clean out the workspace before the build")
         booleanParam('propagateFailures', propagateFailures, "If true, a failure of <b>ANY</b> downstream build (but <b>NOT</b> test) will cause the whole build to fail")
+        booleanParam('keepTestReportDir', false, 'If true, test report dir will be kept even when the testcase passes, failed testcases always keep the report dir. Does not apply to JUnit jobs which are always kept, eg.openjdk.')
         stringParam('adoptBuildNumber', "", "Empty by default. If you ever need to re-release then bump this number. Currently this is only added to the build metadata file.")
     }
 }

--- a/pipelines/jobs/pipeline_job_template.groovy
+++ b/pipelines/jobs/pipeline_job_template.groovy
@@ -73,7 +73,7 @@ pipelineJob("${BUILD_FOLDER}/${JOB_NAME}") {
         stringParam('overrideFileNameVersion', "", "When forming the filename, ignore the part of the filename derived from the publishName or timestamp and override it.<br/>For instance if you set this to 'FOO' the final file name will be of the form: <code>OpenJDK8U-jre_ppc64le_linux_openj9_FOO.tar.gz</code>")
         booleanParam('cleanWorkspaceBeforeBuild', false, "Clean out the workspace before the build")
         booleanParam('propagateFailures', propagateFailures, "If true, a failure of <b>ANY</b> downstream build (but <b>NOT</b> test) will cause the whole build to fail")
-        booleanParam('keepTestReportDir', false, 'If true, test report dir will be kept even when the testcase passes, failed testcases always keep the report dir. Does not apply to JUnit jobs which are always kept, eg.openjdk.')
+        booleanParam('keepTestReportDir', false, 'If true, test report dir (including core files where generated) will be kept even when the testcase passes, failed testcases always keep the report dir. Does not apply to JUnit jobs which are always kept, eg.openjdk.')
         stringParam('adoptBuildNumber', "", "Empty by default. If you ever need to re-release then bump this number. Currently this is only added to the build metadata file.")
     }
 }

--- a/pipelines/library/src/common/IndividualBuildConfig.groovy
+++ b/pipelines/library/src/common/IndividualBuildConfig.groovy
@@ -13,6 +13,7 @@ class IndividualBuildConfig implements Serializable {
     final String BUILD_ARGS
     final String NODE_LABEL
     final String ADDITIONAL_TEST_LABEL
+    final boolean KEEP_TEST_REPORTDIR
     final String ACTIVE_NODE_TIMEOUT
     final boolean CODEBUILD
     final String DOCKER_IMAGE
@@ -52,6 +53,7 @@ class IndividualBuildConfig implements Serializable {
         BUILD_ARGS = map.get("BUILD_ARGS")
         NODE_LABEL = map.get("NODE_LABEL")
         ADDITIONAL_TEST_LABEL = map.get("ADDITIONAL_TEST_LABEL")
+        KEEP_TEST_REPORTDIR = map.get("KEEP_TEST_REPORTDIR")
         ACTIVE_NODE_TIMEOUT = map.get("ACTIVE_NODE_TIMEOUT")
         CODEBUILD = map.get("CODEBUILD")
         DOCKER_IMAGE = map.get("DOCKER_IMAGE")
@@ -96,6 +98,7 @@ class IndividualBuildConfig implements Serializable {
                 BUILD_ARGS                : BUILD_ARGS,
                 NODE_LABEL                : NODE_LABEL,
                 ADDITIONAL_TEST_LABEL     : ADDITIONAL_TEST_LABEL,
+                KEEP_TEST_REPORTDIR       : KEEP_TEST_REPORTDIR,
                 ACTIVE_NODE_TIMEOUT       : ACTIVE_NODE_TIMEOUT,
                 CODEBUILD                 : CODEBUILD,
                 DOCKER_IMAGE              : DOCKER_IMAGE,

--- a/pipelines/src/test/groovy/IndividualBuildConfigTest.groovy
+++ b/pipelines/src/test/groovy/IndividualBuildConfigTest.groovy
@@ -17,6 +17,7 @@ class IndividualBuildConfigTest {
                  BUILD_ARGS                : "g",
                  NODE_LABEL                : "h",
                  ADDITIONAL_TEST_LABEL     : "t",
+                 KEEP_TEST_REPORTDIR       : false,
                  ACTIVE_NODE_TIMEOUT       : "r",
                  CODEBUILD                 : false,
                  DOCKER_IMAGE              : "o",


### PR DESCRIPTION
Some AIX nodes at ci.AdoptOpenJDK only have about 35Gb of disk space, some j9 extended.functional testcases produce j9core.dmp files of the size 2-3Gb, a complete Test job may run this 10+ times using 20+Gb of disk space before the job completes and resulting in the machine runninf out of space and hanging...
This PR adds the following support for KEEP_REPORT_DIR which will delete the report dir containing the dumps after each successful testcase, thus the job will consujme far less space.

Add a new build pipeline param "keepTestReportDir" defaults to false
And corresponding BuildConfig: KEEP_TEST_REPORTDIR
Pass down to test job, but not for JUnit test jobs (eg.openjdk) which default to true.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>