### PR TITLE
Disable nightly testing during January 2021 release cycle

### DIFF
--- a/pipelines/build/common/config_regeneration.groovy
+++ b/pipelines/build/common/config_regeneration.groovy
@@ -331,7 +331,7 @@ class Regeneration implements Serializable {
                 RELEASE: false,
                 PUBLISH_NAME: "",
                 ADOPT_BUILD_NUMBER: "",
-                ENABLE_TESTS: true,
+                ENABLE_TESTS: false,
                 ENABLE_INSTALLERS: true,
                 ENABLE_SIGNER: true,
                 CLEAN_WORKSPACE: true

--- a/pipelines/jobs/pipeline_job_template.groovy
+++ b/pipelines/jobs/pipeline_job_template.groovy
@@ -6,7 +6,7 @@ if(!binding.hasVariable('triggerSchedule')) {
 
 gitRefSpec = ""
 propagateFailures = false
-runTests = true
+runTests = false
 runInstaller = true
 runSigner = true
 


### PR DESCRIPTION
Disabled as per the instructions now in https://github.com/AdoptOpenJDK/openjdk-build/blob/master/RELEASING.md

@andrew-m-leonard  I assume none of your recent scheduling changes will invalidate this way of disabling the tests

Signed-off-by: Stewart X Addison <sxa@redhat.com>