### PR TITLE
Unify debug-image and debug-symbols creation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ temporary_speech_mark_placeholder in the place of any speech marks.
 --clean-git-repo
 clean out any 'bad' local git repo you already have.
 
---create-debug-symbols-package
-create a debug-symbols only archive (if debug symbols were generated).
+--create-debug-image
+create a debug-image archive with the debug symbols.
 
 -d, --destination <path>
 specify the location for the built binary, e.g. /path/.

--- a/sbin/common/config_init.sh
+++ b/sbin/common/config_init.sh
@@ -228,7 +228,7 @@ function parseConfigurationArguments() {
         "--clean-libs" )
         BUILD_CONFIG[CLEAN_LIBS]=true;;
 
-        "--create-debug-symbols-package" )
+        "--create-debug-image" )
         BUILD_CONFIG[CREATE_DEBUG_IMAGE]="true";;
 
         "--disable-adopt-branch-safety" )

--- a/sbin/common/config_init.sh
+++ b/sbin/common/config_init.sh
@@ -46,7 +46,7 @@ CONTAINER_NAME
 COPY_MACOSX_FREE_FONT_LIB_FOR_JDK_FLAG
 COPY_MACOSX_FREE_FONT_LIB_FOR_JRE_FLAG
 COPY_TO_HOST
-CREATE_DEBUG_SYMBOLS_PACKAGE
+CREATE_DEBUG_IMAGE
 CUSTOM_CACERTS
 CROSSCOMPILE
 DEBUG_DOCKER
@@ -229,7 +229,7 @@ function parseConfigurationArguments() {
         BUILD_CONFIG[CLEAN_LIBS]=true;;
 
         "--create-debug-symbols-package" )
-        BUILD_CONFIG[CREATE_DEBUG_SYMBOLS_PACKAGE]="true";;
+        BUILD_CONFIG[CREATE_DEBUG_IMAGE]="true";;
 
         "--disable-adopt-branch-safety" )
         BUILD_CONFIG[DISABLE_ADOPT_BRANCH_SAFETY]=true;;
@@ -408,7 +408,7 @@ function configDefaults() {
   esac
 
   # The default behavior of whether we want to create a separate debug symbols archive
-  BUILD_CONFIG[CREATE_DEBUG_SYMBOLS_PACKAGE]="false"
+  BUILD_CONFIG[CREATE_DEBUG_IMAGE]="false"
 
   BUILD_CONFIG[SIGN]="false"
   BUILD_CONFIG[JDK_BOOT_DIR]=""


### PR DESCRIPTION
debug-image and debug-symbols archives were the same. I'm removing the debug-symbols folder and archive creation and instead redirect that logic to create a debug-image archive.

By default, for OpenJ9 the debug-image will be created (as it was already working), for other platforms, we must add the `--create-debug-image` option.