### PR TITLE
Revert weekend test release pipeline builds to HEAD tags

### DIFF
--- a/pipelines/jobs/configurations/jdk11u.groovy
+++ b/pipelines/jobs/configurations/jdk11u.groovy
@@ -66,8 +66,8 @@ triggerSchedule_weekly="TZ=UTC\n05 17 * * 6"
 
 // scmReferences to use for weekly release build
 weekly_release_scmReferences=[
-        "hotspot"        : "jdk-11.0.10+8_adopt",
-        "openj9"         : "v0.24.0-release",
+        "hotspot"        : "",
+        "openj9"         : "",
         "corretto"       : "",
         "dragonwell"     : ""
 ]

--- a/pipelines/jobs/configurations/jdk15u.groovy
+++ b/pipelines/jobs/configurations/jdk15u.groovy
@@ -60,8 +60,8 @@ triggerSchedule_weekly="TZ=UTC\n30 23 * * 6"
 
 // scmReferences to use for weekly release build
 weekly_release_scmReferences=[
-        "hotspot"        : "jdk-15.0.1+9_adopt",
-        "openj9"         : "v0.24.0-release",
+        "hotspot"        : "",
+        "openj9"         : "",
         "corretto"       : "",
         "dragonwell"     : ""
 ]

--- a/pipelines/jobs/configurations/jdk8u.groovy
+++ b/pipelines/jobs/configurations/jdk8u.groovy
@@ -67,8 +67,8 @@ triggerSchedule_weekly="TZ=UTC\n05 12 * * 6"
 
 // scmReferences to use for weekly release build
 weekly_release_scmReferences=[
-        "hotspot"        : "jdk8u282-b07",
-        "openj9"         : "v0.24.0-release",
+        "hotspot"        : "",
+        "openj9"         : "",
         "corretto"       : "",
         "dragonwell"     : ""
 ]


### PR DESCRIPTION
Now the releases are out the way we can change the weekend release test build back to building the HEAD branches.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>