### PR TITLE
Update weekend release test pipelines so they do not lock Jenkins logs

### DIFF
--- a/pipelines/build/common/build_base_file.groovy
+++ b/pipelines/build/common/build_base_file.groovy
@@ -53,6 +53,7 @@ class Builder implements Serializable {
     boolean cleanWorkspaceBeforeBuild
     boolean propagateFailures
     boolean keepTestReportDir
+    boolean keepReleaseLogs
 
     def env
     def scmVars
@@ -547,8 +548,8 @@ class Builder implements Serializable {
 
             if (release) {
                 if (publishName) {
-                    // Only keep release logs for real releases, not the weekend weekly release test builds that are not published
-                    currentBuild.setKeepLog(true)
+                    // Keep Jenkins release logs for real releases
+                    currentBuild.setKeepLog(keepReleaseLogs)
                     currentBuild.setDisplayName(publishName)
                 }
             }
@@ -564,6 +565,7 @@ class Builder implements Serializable {
             context.echo "Release: ${release}"
             context.echo "Tag/Branch name: ${scmReference}"
             context.echo "Keep test reportdir: ${keepTestReportDir}"
+            context.echo "Keey release logs: ${keepReleaseLogs}"
 
             jobConfigurations.each { configuration ->
                 jobs[configuration.key] = {
@@ -684,6 +686,7 @@ return {
     String adoptBuildNumber,
     String propagateFailures,
     String keepTestReportDir,
+    String keepReleaseLogs,
     def currentBuild,
     def context,
     def env ->
@@ -734,6 +737,7 @@ return {
             adoptBuildNumber: adoptBuildNumber,
             propagateFailures: Boolean.parseBoolean(propagateFailures),
             keepTestReportDir: Boolean.parseBoolean(keepTestReportDir),
+            keepReleaseLogs: Boolean.parseBoolean(keepReleaseLogs),
             currentBuild: currentBuild,
             context: context,
             env: env

--- a/pipelines/build/common/weekly_release_pipeline.groovy
+++ b/pipelines/build/common/weekly_release_pipeline.groovy
@@ -43,7 +43,8 @@ stage("Submit Release Pipelines") {
                       parameters: [
                           string(name: 'releaseType',        value: 'Release'),
                           string(name: 'scmReference',       value: scmRef),
-                          text(name: 'targetConfigurations', value: JsonOutput.prettyPrint(JsonOutput.toJson(targetConfig)))
+                          text(name: 'targetConfigurations', value: JsonOutput.prettyPrint(JsonOutput.toJson(targetConfig))),
+                          ['$class': 'BooleanParameterValue', name: 'keepReleaseLogs', value: false]
                       ]
                 }
             }

--- a/pipelines/build/openjdk10_pipeline.groovy
+++ b/pipelines/build/openjdk10_pipeline.groovy
@@ -46,6 +46,7 @@ if (scmVars != null && configureBuild != null && buildConfigurations != null) {
         adoptBuildNumber,
         propagateFailures,
         keepTestReportDir,
+        keepReleaseLogs,
         currentBuild,
         this,
         env

--- a/pipelines/build/openjdk11_pipeline.groovy
+++ b/pipelines/build/openjdk11_pipeline.groovy
@@ -46,6 +46,7 @@ if (scmVars != null && configureBuild != null && buildConfigurations != null) {
         adoptBuildNumber,
         propagateFailures,
         keepTestReportDir,
+        keepReleaseLogs,
         currentBuild,
         this,
         env

--- a/pipelines/build/openjdk12_pipeline.groovy
+++ b/pipelines/build/openjdk12_pipeline.groovy
@@ -46,6 +46,7 @@ if (scmVars != null && configureBuild != null && buildConfigurations != null) {
         adoptBuildNumber,
         propagateFailures,
         keepTestReportDir,
+        keepReleaseLogs,
         currentBuild,
         this,
         env

--- a/pipelines/build/openjdk13_pipeline.groovy
+++ b/pipelines/build/openjdk13_pipeline.groovy
@@ -46,6 +46,7 @@ if (scmVars != null && configureBuild != null && buildConfigurations != null) {
         adoptBuildNumber,
         propagateFailures,
         keepTestReportDir,
+        keepReleaseLogs,
         currentBuild,
         this,
         env

--- a/pipelines/build/openjdk14_pipeline.groovy
+++ b/pipelines/build/openjdk14_pipeline.groovy
@@ -46,6 +46,7 @@ if (scmVars != null && configureBuild != null && buildConfigurations != null) {
         adoptBuildNumber,
         propagateFailures,
         keepTestReportDir,
+        keepReleaseLogs,
         currentBuild,
         this,
         env

--- a/pipelines/build/openjdk15_pipeline.groovy
+++ b/pipelines/build/openjdk15_pipeline.groovy
@@ -46,6 +46,7 @@ if (scmVars != null && configureBuild != null && buildConfigurations != null) {
         adoptBuildNumber,
         propagateFailures,
         keepTestReportDir,
+        keepReleaseLogs,
         currentBuild,
         this,
         env

--- a/pipelines/build/openjdk16_pipeline.groovy
+++ b/pipelines/build/openjdk16_pipeline.groovy
@@ -46,6 +46,7 @@ if (scmVars != null && configureBuild != null && buildConfigurations != null) {
         adoptBuildNumber,
         propagateFailures,
         keepTestReportDir,
+        keepReleaseLogs,
         currentBuild,
         this,
         env

--- a/pipelines/build/openjdk17_pipeline.groovy
+++ b/pipelines/build/openjdk17_pipeline.groovy
@@ -46,6 +46,7 @@ if (scmVars != null && configureBuild != null && buildConfigurations != null) {
         adoptBuildNumber,
         propagateFailures,
         keepTestReportDir,
+        keepReleaseLogs,
         currentBuild,
         this,
         env

--- a/pipelines/build/openjdk8_pipeline.groovy
+++ b/pipelines/build/openjdk8_pipeline.groovy
@@ -46,6 +46,7 @@ if (scmVars != null && configureBuild != null && buildConfigurations != null) {
         adoptBuildNumber,
         propagateFailures,
         keepTestReportDir,
+        keepReleaseLogs,
         currentBuild,
         this,
         env

--- a/pipelines/build/openjdk9_pipeline.groovy
+++ b/pipelines/build/openjdk9_pipeline.groovy
@@ -46,6 +46,7 @@ if (scmVars != null && configureBuild != null && buildConfigurations != null) {
         adoptBuildNumber,
         propagateFailures,
         keepTestReportDir,
+        keepReleaseLogs,
         currentBuild,
         this,
         env

--- a/pipelines/jobs/pipeline_job_template.groovy
+++ b/pipelines/jobs/pipeline_job_template.groovy
@@ -74,6 +74,7 @@ pipelineJob("${BUILD_FOLDER}/${JOB_NAME}") {
         booleanParam('cleanWorkspaceBeforeBuild', false, "Clean out the workspace before the build")
         booleanParam('propagateFailures', propagateFailures, "If true, a failure of <b>ANY</b> downstream build (but <b>NOT</b> test) will cause the whole build to fail")
         booleanParam('keepTestReportDir', false, 'If true, test report dir (including core files where generated) will be kept even when the testcase passes, failed testcases always keep the report dir. Does not apply to JUnit jobs which are always kept, eg.openjdk.')
+        booleanParam('keepReleaseLogs', true, 'If true, "Release" type pipeline Jenkins logs will be marked as "Keep this build forever".')
         stringParam('adoptBuildNumber', "", "Empty by default. If you ever need to re-release then bump this number. Currently this is only added to the build metadata file.")
     }
 }


### PR DESCRIPTION
Add a new build pipeline param keepReleaseLogs which defaults to true, but weekend test builds set to false.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>