### PR TITLE
Remove overrides to remove gradle and cacerts from Solaris/SPARC

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -1109,11 +1109,7 @@ if [[ "${BUILD_CONFIG[ASSEMBLE_EXPLODED_IMAGE]}" == "true" ]]; then
   exit 0
 fi
 
-# Our Solaris build environment has performance issues so disabling this for now
-# Refhttps://github.com/AdoptOpenJDK/openjdk-build/issues/2206
-if [ "${ARCHITECTURE}" != "sparcv9" ]; then
-  buildSharedLibs
-fi
+buildSharedLibs
 
 wipeOutOldTargetDir
 createTargetDir

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -516,21 +516,7 @@ prepareCacerts() {
     echo "Generating cacerts from Mozilla's bundle"
 
     cd "$SCRIPT_DIR/../security"
-    # Our Solaris/SPARC box exhibits slowness when running keytool
-    # Therefore pull the cacerts file from the latest Solaris/x64 build
-    if [ "$ARCHITECTURE" = "sparcv9" ]; then
-      mkdir tmp
-      cd tmp || exit 1
-      wget -q -O jdk8build.tgz "https://api.adoptopenjdk.net/v3/binary/latest/8/ea/solaris/sparcv9/jre/hotspot/normal/adoptopenjdk?project=jdk"
-      CACERTSFILE=`gzip -cd jdk8build.tgz | tar tf - | grep /cacerts$`
-      [ ! -z "$CACERTSFILE" ] && gzip -cd jdk8build.tgz | tar xf - "$CACERTSFILE"
-      cp "$CACERTSFILE" .. || exit 1
-      cd ..
-      rm -r tmp
-      echo Solaris/SPARC: Successfully extracted cacerts from x64 build: `ls -l cacerts`
-    else
-      ./mk-cacerts.sh --keytool "${BUILD_CONFIG[JDK_BOOT_DIR]}/bin/keytool"
-    fi
+    ./mk-cacerts.sh --keytool "${BUILD_CONFIG[JDK_BOOT_DIR]}/bin/keytool"
 }
 
 # Download all of the dependencies for OpenJDK (Alsa, FreeType, etc.)


### PR DESCRIPTION
Machines are now working at full speed after a reboot so these can be revoked ... Currently testing. We should however, consider if the Gradle step can be skipped everywhere since Solaris seems happy without it and it breaks more often than I'd like ([Ref this issue](https://github.com/AdoptOpenJDK/openjdk-build/issues/2139))

Reverts https://github.com/AdoptOpenJDK/openjdk-build/pull/2276 and https://github.com/AdoptOpenJDK/openjdk-build/pull/2228 and should maybe also revert https://github.com/AdoptOpenJDK/openjdk-build/pull/2225

Recommend taking care when this is merged as we may want ot keep the individual commits, or change the first line of the commit message