### PR TITLE
Clean problematic files on alibaba workspaces

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -917,6 +917,8 @@ class Build {
                                 context.sh(script: "rm -rf J:/jenkins/tmp/workspace/build/src/build/*/jdk/gensrc")
                                 // https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1662
                                 context.sh(script: "rm -rf E:/jenkins/tmp/workspace/build/src/build/*/jdk/gensrc")
+                                // https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1818
+                                context.sh(script: "rm -rf C:/Jenkins/temp/workspace/build/src/build/*/jdk/gensrc")
                                 context.cleanWs notFailBuild: true, disableDeferredWipeout: true, deleteDirs: true
                             } else {
                                 context.cleanWs notFailBuild: true


### PR DESCRIPTION
This is a temporary fix to clean workspaces on alibaba machines before builds. Currently both alibaba machines are facing this issue
```
18:10:26  ERROR: Failed to clean the workspace
18:10:26  jenkins.util.io.CompositeIOException: Unable to delete 'C:\Jenkins\temp'. Tried 3 times (of a maximum of 3) waiting 0.1 sec between attempts.
18:10:26  	at jenkins.util.io.PathRemover.forceRemoveDirectoryContents(PathRemover.java:90)
18:10:26  	at hudson.Util.deleteContentsRecursive(Util.java:262)
18:10:26  	at hudson.Util.deleteContentsRecursive(Util.java:251)
18:10:26  	at org.jenkinsci.plugins.gitclient.CliGitAPIImpl$2.execute(CliGitAPIImpl.java:743)
```
This issue has affected other windows boxes, hence the pr https://github.com/AdoptOpenJDK/openjdk-build/pull/1956, so I am putting a similar fix in for alibaba machines.

Most recent failure on build-alibaba-win2012r2-x64-1 https://ci.adoptopenjdk.net/job/build-scripts/job/jobs/job/jdk11u/job/jdk11u-windows-x64-dragonwell/58/console