### PR TITLE
Revert "Disable nightly testing during January 2021 release cycle (#2392)

### DIFF
--- a/pipelines/build/common/config_regeneration.groovy
+++ b/pipelines/build/common/config_regeneration.groovy
@@ -332,7 +332,7 @@ class Regeneration implements Serializable {
                 RELEASE: false,
                 PUBLISH_NAME: "",
                 ADOPT_BUILD_NUMBER: "",
-                ENABLE_TESTS: false,
+                ENABLE_TESTS: true,
                 ENABLE_INSTALLERS: true,
                 ENABLE_SIGNER: true,
                 CLEAN_WORKSPACE: true

--- a/pipelines/jobs/pipeline_job_template.groovy
+++ b/pipelines/jobs/pipeline_job_template.groovy
@@ -6,7 +6,7 @@ if(!binding.hasVariable('triggerSchedule')) {
 
 gitRefSpec = ""
 propagateFailures = false
-runTests = false
+runTests = true
 runInstaller = true
 runSigner = true
 


### PR DESCRIPTION
GAs are mostly out at the time of writing so we should be safe to re-enable.

This reverts commit ea53ac3d1623de5ecefdcd9aee3379a776be84b2.