### PR TITLE
Use multiple backup timeservers for Windows signing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
+.vscode/
 shellcheck-stable
 workspace
 pipelines/.gradle

--- a/pipelines/jobs/configurations/jdk11u.groovy
+++ b/pipelines/jobs/configurations/jdk11u.groovy
@@ -1,62 +1,20 @@
 targetConfigurations = [
-        "x64Mac"      : [
-                "hotspot",
-                "openj9"
-        ],
-        "x64MacXL"    : [
-                "openj9"
-        ],
-        "x64Linux"    : [
-                "hotspot",
-                "openj9",
-                "corretto",
-                "dragonwell"
-        ],
-        "x64Windows"  : [
-                "hotspot",
-                "openj9",
-                "dragonwell"
-        ],
-        "x64WindowsXL"  : [
-                "openj9"
-        ],
-        "x32Windows"  : [
-                "hotspot"
-        ],
-        "ppc64Aix"    : [
-                "hotspot",
-                "openj9"
-        ],
-        "ppc64leLinux": [
-                "hotspot",
-                "openj9"
-        ],
-        "s390xLinux"  : [
-                "hotspot",
-                "openj9"
-        ],
-        "aarch64Linux": [
-                "hotspot",
-                "openj9"
-        ],
-        "arm32Linux"  : [
-                "hotspot"
-        ],
-        "x64LinuxXL"     : [
-                "openj9"
-        ],
-        "s390xLinuxXL"     : [
-                "openj9"
-        ],
-        "ppc64leLinuxXL"     : [
-                "openj9"
-        ],
-        "aarch64LinuxXL": [
-                "openj9"
-        ],
-        "riscv64Linux": [
-                "openj9"
-        ]
+        "x64Mac"      : [	"hotspot",	"openj9"					],
+        "x64MacXL"    : [			"openj9"					],
+        "x64Linux"    : [	"hotspot",	"openj9",	"dragonwell",	"corretto"	],
+        "x64Windows"  : [	"hotspot",	"openj9",	"dragonwell"			],
+        "x64WindowsXL": [			"openj9"					],
+        "x32Windows"  : [	"hotspot"							],
+        "ppc64Aix"    : [	"hotspot",	"openj9"					],
+        "ppc64leLinux": [	"hotspot",	"openj9"					],
+        "s390xLinux"  : [	"hotspot",	"openj9"					],
+        "aarch64Linux": [	"hotspot",	"openj9"					],
+        "arm32Linux"  : [	"hotspot"							],
+        "x64LinuxXL"  : [			"openj9"					],
+        "s390xLinuxXL": [			"openj9"					],
+        "ppc64leLinuxXL":[			"openj9"					],
+        "aarch64LinuxXL":[			"openj9"					],
+        "riscv64Linux": [			"openj9"					]
 ]
 
 // 18:05 Tue, Thur

--- a/pipelines/jobs/configurations/jdk11u.groovy
+++ b/pipelines/jobs/configurations/jdk11u.groovy
@@ -1,20 +1,62 @@
 targetConfigurations = [
-        "x64Mac"      : [	"hotspot",	"openj9"					],
-        "x64MacXL"    : [			"openj9"					],
-        "x64Linux"    : [	"hotspot",	"openj9",	"dragonwell",	"corretto"	],
-        "x64Windows"  : [	"hotspot",	"openj9",	"dragonwell"			],
-        "x64WindowsXL": [			"openj9"					],
-        "x32Windows"  : [	"hotspot"							],
-        "ppc64Aix"    : [	"hotspot",	"openj9"					],
-        "ppc64leLinux": [	"hotspot",	"openj9"					],
-        "s390xLinux"  : [	"hotspot",	"openj9"					],
-        "aarch64Linux": [	"hotspot",	"openj9"					],
-        "arm32Linux"  : [	"hotspot"							],
-        "x64LinuxXL"  : [			"openj9"					],
-        "s390xLinuxXL": [			"openj9"					],
-        "ppc64leLinuxXL":[			"openj9"					],
-        "aarch64LinuxXL":[			"openj9"					],
-        "riscv64Linux": [			"openj9"					]
+        "x64Mac"      : [
+                "hotspot",
+                "openj9"
+        ],
+        "x64MacXL"    : [
+                "openj9"
+        ],
+        "x64Linux"    : [
+                "hotspot",
+                "openj9",
+                "corretto",
+                "dragonwell"
+        ],
+        "x64Windows"  : [
+                "hotspot",
+                "openj9",
+                "dragonwell"
+        ],
+        "x64WindowsXL"  : [
+                "openj9"
+        ],
+        "x32Windows"  : [
+                "hotspot"
+        ],
+        "ppc64Aix"    : [
+                "hotspot",
+                "openj9"
+        ],
+        "ppc64leLinux": [
+                "hotspot",
+                "openj9"
+        ],
+        "s390xLinux"  : [
+                "hotspot",
+                "openj9"
+        ],
+        "aarch64Linux": [
+                "hotspot",
+                "openj9"
+        ],
+        "arm32Linux"  : [
+                "hotspot"
+        ],
+        "x64LinuxXL"     : [
+                "openj9"
+        ],
+        "s390xLinuxXL"     : [
+                "openj9"
+        ],
+        "ppc64leLinuxXL"     : [
+                "openj9"
+        ],
+        "aarch64LinuxXL": [
+                "openj9"
+        ],
+        "riscv64Linux": [
+                "openj9"
+        ]
 ]
 
 // 18:05 Tue, Thur

--- a/serverTimestamp.properties
+++ b/serverTimestamp.properties
@@ -1,0 +1,7 @@
+comodaca=http://timestamp.comodoca.com/authenticode
+globalsign=http://timestamp.globalsign.com/scripts/timstamp.dll
+isectigo=http://timestamp.sectigo.com
+comodocarfc3161=http://timestamp.comodoca.com/rfc3161
+startssl=http://tsa.startssl.com/rfc3161
+starfieldtech=http://tsa.starfieldtech.com
+digicert=http://timestamp.digicert.com

--- a/sign.sh
+++ b/sign.sh
@@ -33,6 +33,16 @@ WORKSPACE=$(pwd)
 TMP_DIR_NAME="tmp"
 TMP_DIR="${WORKSPACE}/${TMP_DIR_NAME}/"
 
+# List of valid timestamp servers:
+# http://timestamp.comodoca.com/authenticode -> OK 02/08/2030 -> Sectigo RSA Time Stamping Signer #1
+# http://timestamp.sectigo.com -> OK 02/08/2030 -> Sectigo RSA Time Stamping Signer #1 .. same as previous but with another url
+# http://timestamp.comodoca.com/rfc3161 -> OK 02/08/2030 -> Sectigo RSA Time Stamping Signer #1 .. same as previous but with another url
+# http://tsa.startssl.com/rfc3161 -> OK 15/08/2028 -> WoSign Time Stamping Signer ( buyed by WoTrus )
+# http://tsa.starfieldtech.com -> OK 17/09/2027 -> Starfield Timestamp Authority - G2
+# http://timestamp.globalsign.com/scripts/timstamp.dll -> OK 24/06/2027 -> GlobalSign TSA for MS Authenticode - G2
+# http://timestamp.digicert.com -> OK 22/10/2024 -> DigiCert Timestamp Responder
+TIMESTAMP_SERVER_CONFIG="./serverTimestamp.properties"
+
 checkSignConfiguration() {
   if [[ "${OPERATING_SYSTEM}" == "windows" ]] ; then
     if [ ! -f "${SIGNING_CERTIFICATE}" ]
@@ -52,35 +62,37 @@ checkSignConfiguration() {
 # Sign the built binary
 signRelease()
 {
+  TIMESTAMPSERVERS=`cut -d= -f2 < $WORKSPACE/$TIMESTAMP_SERVER_CONFIG | tr -d \\\\r`
+
   case "$OPERATING_SYSTEM" in
     "windows")
       echo "Signing Windows release"
       signToolPath=${signToolPath:-"/cygdrive/c/Program Files (x86)/Windows Kits/10/bin/10.0.17763.0/x64/signtool.exe"}
 
       # Sign .exe files
-      FILES=$(find . -type f -name '*.exe')
+      FILES=$(find . -type f -name '*.exe' -o -name '*.dll')
       echo "$FILES" | while read -r f;
       do
         echo "Signing ${f}"
-        if ! "$signToolPath" sign /f "${SIGNING_CERTIFICATE}" /p "$SIGN_PASSWORD" /fd SHA256 /t http://timestamp.globalsign.com/scripts/timestamp.dll "$f"; then
-          echo "RETRYWARNING: Failed to sign ${f} at $(date +%T): Possible timestamp server error - RC $? ... Retrying in 10 seconds"
-          sleep 10s
-          "$signToolPath" sign /f "${SIGNING_CERTIFICATE}" /p "$SIGN_PASSWORD" /fd SHA256 /t http://timestamp.globalsign.com/scripts/timestamp.dll "$f"
-        fi        
-      done
-
-      # Sign .dll files
-      FILES=$(find . -type f -name '*.dll')
-      echo "$FILES" | while read -r f;
-      do
-        echo "Signing ${f}"
-        if ! "$signToolPath" sign /f "${SIGNING_CERTIFICATE}" /p "$SIGN_PASSWORD" /fd SHA256 /t http://timestamp.globalsign.com/scripts/timestamp.dll "$f"; then
-          echo "RETRYWARNING: Failed to sign ${f} at $(date +%T): Possible timestamp server error - RC $? ... Retrying in 10 seconds"
-          sleep 10s
-          "$signToolPath" sign /f "${SIGNING_CERTIFICATE}" /p "$SIGN_PASSWORD" /fd SHA256 /t http://timestamp.globalsign.com/scripts/timestamp.dll "$f"
+        STAMPED=false
+        for SERVER in $TIMESTAMPSERVERS; do
+          if [ "$STAMPED" = "false" ]; then
+            echo Signing $f using $SERVER
+            if "$signToolPath" sign /f "${SIGNING_CERTIFICATE}" /p "$SIGN_PASSWORD" /fd SHA256 /t "${SERVER}" "$f"; then
+              STAMPED=true
+            else
+              echo "RETRYWARNING: Failed to sign ${f} at $(date +%T): Possible timestamp server error at ${SERVER} - Trying new server in 5 seconds"
+              sleep 5
+            fi
+          fi
+        done
+        if [ "$STAMPED" = "false" ]; then
+          echo Failed to sign ${f} using any time server - aborting
+          exit 1
         fi
       done
-      ;;
+    ;;
+
     "mac"*)
       # TODO: Remove this completly once https://github.com/AdoptOpenJDK/openjdk-jdk11u/commit/b3250adefed0c1778f38a7e221109ae12e7c421e has been backported to JDK8u
       echo "Signing OSX release"
@@ -117,7 +129,7 @@ function extractArchive {
   rm -rf "${TMP_DIR}" || true
   mkdir "${TMP_DIR}"
   if [[ "${OPERATING_SYSTEM}" == "windows" ]]; then
-    unzip "${ARCHIVE}" -d "${TMP_DIR}"
+    unzip -q "${ARCHIVE}" -d "${TMP_DIR}"
   elif [[ "${OPERATING_SYSTEM}" == "mac" ]]; then
     gunzip -dc "${ARCHIVE}" | tar xf - -C "${TMP_DIR}"
   else
@@ -135,8 +147,8 @@ configDefaults
 parseArguments "$@"
 extractArchive
 
-# shellcheck disable=SC2012
-jdkDir=$(find "${TMP_DIR}" ! -path "${TMP_DIR}" -type d -exec basename {} \; | head -n1)
+# Set jdkDir to the top level directory from the tarball/zipball
+jdkDir=$(ls -1d $TMP_DIR/* | head -1 | xargs basename)
 
 cd "${TMP_DIR}/${jdkDir}" || exit 1
 signRelease


### PR DESCRIPTION
This does the following:

- Implements timestamp server fallback as originally attempted in https://github.com/AdoptOpenJDK/openjdk-build/pull/2405 and https://github.com/AdoptOpenJDK/openjdk-build/pull/2374 - this supercedes both
- Adjusts the ordering so that the "known good" server is first in the list, reducing the likelihood of failure (globalsign is no longer working today)
- Unifies the `exe` and `dll` parts in a single `find`
- Adjusts the way the JDK directory is detected, thus removing the `find: 'basename' terminated by signal 13` that have been polluting the logs
- Uses `-q` on the `unzip` command in order to avoid filling the log with a list of all files in the JDK

The latest runs of [sign_build](https://ci.adoptopenjdk.net/job/build-scripts/job/release/job/sign_build) have been from this branch

I am somewhat worried that none of the timestamp servers we have are reliable though...