### PR TITLE
Use the correct openj9 extensions repo name to runTests

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -189,7 +189,12 @@ class Build {
         if (buildConfig.VARIANT == "corretto") {
             suffix="corretto/corretto-${javaNumber}"
         } else if (buildConfig.VARIANT == "openj9") {
-            suffix = "ibmruntimes/openj9-openjdk-jdk${javaNumber}"
+            def openj9JavaToBuild = buildConfig.JAVA_TO_BUILD
+            if (openj9JavaToBuild.endsWith("u")) {
+                // OpenJ9 extensions repo does not use the "u" suffix
+                openj9JavaToBuild = openj9JavaToBuild.substring(0, openj9JavaToBuild.length() - 1)
+            }
+            suffix = "ibmruntimes/openj9-openjdk-${openj9JavaToBuild}"
         } else if (buildConfig.VARIANT == "hotspot") {
             suffix = "adoptopenjdk/openjdk-${buildConfig.JAVA_TO_BUILD}"
         } else if (buildConfig.VARIANT == "dragonwell") {


### PR DESCRIPTION
The openj9 extensions repo to runTests against was being determined incorrectly for the jdk(head) scenario.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>