### PR TITLE
Correct "HEAP_SIZE" release file value for x86 OpenJ9 builds

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -962,7 +962,8 @@ addInfoToReleaseFile() {
 
 addHeapSize() { # Adds an identifier for heap size on OpenJ9 builds
   local heapSize=""
-  if [[ $($JAVA_LOC -version 2>&1 | grep 'Compressed References') ]]; then
+  local architecture=$($JAVA_LOC -XshowSettings:properties -version 2>&1 | grep 'os.arch' | sed 's/^.*= //' | tr -d '\r') # Heap size must be standard for x86 builds (openjdk-build/2412)
+  if [[ $($JAVA_LOC -version 2>&1 | grep 'Compressed References') ]] || [[ "$architecture" == "x86" ]]; then
     heapSize="Standard"
   else
     heapSize="Large"


### PR DESCRIPTION
Fixes: https://github.com/AdoptOpenJDK/openjdk-build/issues/2412

Currently the `HEAP_SIZE` value in the `release` file is incorrect and states "Large" while x86 OpenJ9 binaries are only produced with standard heap size. This PR adds a check for the architecture being built on and factors this in when setting the `HEAP_SIZE` value.

Old `release` file for x86:
```
JAVA_VERSION="1.8.0_282"
OS_NAME="Windows"
OS_VERSION="5.1"
OS_ARCH="i586"
SOURCE="OpenJDK:ab07c6a8fd OpenJ9:345e1b09e OMR:741e94ea8"
IMPLEMENTOR="AdoptOpenJDK"
BUILD_SOURCE="git:10223734"
FULL_VERSION="1.8.0_282-b08"
SEMANTIC_VERSION="8.0.282+8"
BUILD_INFO="OS: Windows Server 2012 R2 Version: 6.3"
JVM_VARIANT="Openj9"
JVM_VERSION="openj9-0.24.0"
HEAP_SIZE="Large"
IMAGE_TYPE="JDK"
```

New `release` file for x86:
```

```

Signed-off-by: Austin Bailey <Austin.Bailey@ibm.com>