### PR TITLE
Add cleanWorkspaceAfterBuild and cleanWorkspaceBuildOutputAfterBuild

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -126,3 +126,9 @@ For more information, see the [PR testing documentation](./pipelines/build/prTes
 The operating systems/distributions which we build or are documented in the
 [openjdk-build wiki](https://github.com/AdoptOpenJDK/openjdk-build/wiki/%5BWIP%5D-Minimum-OS-levels).
 Runtime platforms are in our [supported platforms page](https://adoptopenjdk.net/supported_platforms.html).
+
+## How to add a new build pipeline param and associated job configuration?
+
+The following PR: https://github.com/AdoptOpenJDK/openjdk-build/pull/2416
+demonstrates changes required to add a new build pipeline param, and also associated version/platform job configurations for setting the value when needed.
+

--- a/pipelines/build/common/config_regeneration.groovy
+++ b/pipelines/build/common/config_regeneration.groovy
@@ -335,7 +335,9 @@ class Regeneration implements Serializable {
                 ENABLE_TESTS: true,
                 ENABLE_INSTALLERS: true,
                 ENABLE_SIGNER: true,
-                CLEAN_WORKSPACE: true
+                CLEAN_WORKSPACE: true,
+                CLEAN_WORKSPACE_AFTER: true,
+                CLEAN_WORKSPACE_BUILD_OUTPUT_ONLY_AFTER: false
             )
         } catch (Exception e) {
             // Catch invalid configurations

--- a/pipelines/build/common/create_job_from_template.groovy
+++ b/pipelines/build/common/create_job_from_template.groovy
@@ -87,6 +87,8 @@ pipelineJob("$buildFolder/$JOB_NAME") {
                 <dt><strong>ENABLE_INSTALLERS</strong></dt><dd>Run installers</dd>
                 <dt><strong>ENABLE_SIGNER</strong></dt><dd>Run signer</dd>
                 <dt><strong>CLEAN_WORKSPACE</strong></dt><dd>Wipe out workspace before build</dd>
+                <dt><strong>CLEAN_WORKSPACE_AFTER</strong></dt><dd>Wipe out workspace after build</dd>
+                <dt><strong>CLEAN_WORKSPACE_BUILD_OUTPUT_ONLY_AFTER</strong></dt><dd>Wipe out workspace build output only, after build</dd>
             </dl>
         """)
     }

--- a/pipelines/build/openjdk10_pipeline.groovy
+++ b/pipelines/build/openjdk10_pipeline.groovy
@@ -43,6 +43,8 @@ if (scmVars != null && configureBuild != null && buildConfigurations != null) {
         additionalBuildArgs,
         overrideFileNameVersion,
         cleanWorkspaceBeforeBuild,
+        cleanWorkspaceAfterBuild,
+        cleanWorkspaceBuildOutputAfterBuild,
         adoptBuildNumber,
         propagateFailures,
         keepTestReportDir,

--- a/pipelines/build/openjdk11_pipeline.groovy
+++ b/pipelines/build/openjdk11_pipeline.groovy
@@ -43,6 +43,8 @@ if (scmVars != null && configureBuild != null && buildConfigurations != null) {
         additionalBuildArgs,
         overrideFileNameVersion,
         cleanWorkspaceBeforeBuild,
+        cleanWorkspaceAfterBuild,
+        cleanWorkspaceBuildOutputAfterBuild,
         adoptBuildNumber,
         propagateFailures,
         keepTestReportDir,

--- a/pipelines/build/openjdk12_pipeline.groovy
+++ b/pipelines/build/openjdk12_pipeline.groovy
@@ -43,6 +43,8 @@ if (scmVars != null && configureBuild != null && buildConfigurations != null) {
         additionalBuildArgs,
         overrideFileNameVersion,
         cleanWorkspaceBeforeBuild,
+        cleanWorkspaceAfterBuild,
+        cleanWorkspaceBuildOutputAfterBuild,
         adoptBuildNumber,
         propagateFailures,
         keepTestReportDir,

--- a/pipelines/build/openjdk13_pipeline.groovy
+++ b/pipelines/build/openjdk13_pipeline.groovy
@@ -43,6 +43,8 @@ if (scmVars != null && configureBuild != null && buildConfigurations != null) {
         additionalBuildArgs,
         overrideFileNameVersion,
         cleanWorkspaceBeforeBuild,
+        cleanWorkspaceAfterBuild,
+        cleanWorkspaceBuildOutputAfterBuild,
         adoptBuildNumber,
         propagateFailures,
         keepTestReportDir,

--- a/pipelines/build/openjdk14_pipeline.groovy
+++ b/pipelines/build/openjdk14_pipeline.groovy
@@ -43,6 +43,8 @@ if (scmVars != null && configureBuild != null && buildConfigurations != null) {
         additionalBuildArgs,
         overrideFileNameVersion,
         cleanWorkspaceBeforeBuild,
+        cleanWorkspaceAfterBuild,
+        cleanWorkspaceBuildOutputAfterBuild,
         adoptBuildNumber,
         propagateFailures,
         keepTestReportDir,

--- a/pipelines/build/openjdk15_pipeline.groovy
+++ b/pipelines/build/openjdk15_pipeline.groovy
@@ -43,6 +43,8 @@ if (scmVars != null && configureBuild != null && buildConfigurations != null) {
         additionalBuildArgs,
         overrideFileNameVersion,
         cleanWorkspaceBeforeBuild,
+        cleanWorkspaceAfterBuild,
+        cleanWorkspaceBuildOutputAfterBuild,
         adoptBuildNumber,
         propagateFailures,
         keepTestReportDir,

--- a/pipelines/build/openjdk16_pipeline.groovy
+++ b/pipelines/build/openjdk16_pipeline.groovy
@@ -43,6 +43,8 @@ if (scmVars != null && configureBuild != null && buildConfigurations != null) {
         additionalBuildArgs,
         overrideFileNameVersion,
         cleanWorkspaceBeforeBuild,
+        cleanWorkspaceAfterBuild,
+        cleanWorkspaceBuildOutputAfterBuild,
         adoptBuildNumber,
         propagateFailures,
         keepTestReportDir,

--- a/pipelines/build/openjdk17_pipeline.groovy
+++ b/pipelines/build/openjdk17_pipeline.groovy
@@ -43,6 +43,8 @@ if (scmVars != null && configureBuild != null && buildConfigurations != null) {
         additionalBuildArgs,
         overrideFileNameVersion,
         cleanWorkspaceBeforeBuild,
+        cleanWorkspaceAfterBuild,
+        cleanWorkspaceBuildOutputAfterBuild,
         adoptBuildNumber,
         propagateFailures,
         keepTestReportDir,

--- a/pipelines/build/openjdk8_pipeline.groovy
+++ b/pipelines/build/openjdk8_pipeline.groovy
@@ -43,6 +43,8 @@ if (scmVars != null && configureBuild != null && buildConfigurations != null) {
         additionalBuildArgs,
         overrideFileNameVersion,
         cleanWorkspaceBeforeBuild,
+        cleanWorkspaceAfterBuild,
+        cleanWorkspaceBuildOutputAfterBuild,
         adoptBuildNumber,
         propagateFailures,
         keepTestReportDir,

--- a/pipelines/build/openjdk9_pipeline.groovy
+++ b/pipelines/build/openjdk9_pipeline.groovy
@@ -43,6 +43,8 @@ if (scmVars != null && configureBuild != null && buildConfigurations != null) {
         additionalBuildArgs,
         overrideFileNameVersion,
         cleanWorkspaceBeforeBuild,
+        cleanWorkspaceAfterBuild,
+        cleanWorkspaceBuildOutputAfterBuild,
         adoptBuildNumber,
         propagateFailures,
         keepTestReportDir,

--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -80,7 +80,8 @@ class Config11 {
                         hotspot: 'xlc13&&aix710',
                         openj9:  'xlc13&&aix715'
                 ],
-                test                : 'default'
+                test                : 'default',
+                cleanWorkspaceAfterBuild: true
         ],
 
         s390xLinux    : [

--- a/pipelines/jobs/configurations/jdk16_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk16_pipeline_config.groovy
@@ -110,7 +110,8 @@ class Config16 {
                         hotspot: 'xlc16&&aix710',
                         openj9:  'xlc16&&aix715'
                 ],
-                test                : 'default'
+                test                : 'default',
+                cleanWorkspaceAfterBuild: true
         ],
 
 

--- a/pipelines/jobs/configurations/jdk17_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17_pipeline_config.groovy
@@ -122,7 +122,8 @@ class Config17 {
                 test                : [
                         nightly: [],
                         weekly : ['sanity.openjdk', 'sanity.system', 'extended.system']
-                ]
+                ],
+                cleanWorkspaceAfterBuild: true
         ],
 
 

--- a/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk8u_pipeline_config.groovy
@@ -77,7 +77,8 @@ class Config8 {
                         hotspot: 'xlc13&&aix710',
                         openj9:  'xlc13&&aix715'
                 ],
-                test                 : 'default'
+                test                 : 'default',
+                cleanWorkspaceAfterBuild: true
         ],
 
         s390xLinux    : [

--- a/pipelines/jobs/pipeline_job_template.groovy
+++ b/pipelines/jobs/pipeline_job_template.groovy
@@ -9,6 +9,7 @@ propagateFailures = false
 runTests = true
 runInstaller = true
 runSigner = true
+cleanWsBuildOutput = true
 
 // if true means this is running in the pr builder pipeline
 if (binding.hasVariable('PR_BUILDER')) {
@@ -72,6 +73,8 @@ pipelineJob("${BUILD_FOLDER}/${JOB_NAME}") {
         stringParam('additionalBuildArgs', "", "Additional arguments to be passed to <code>makejdk-any-platform.sh</code>")
         stringParam('overrideFileNameVersion', "", "When forming the filename, ignore the part of the filename derived from the publishName or timestamp and override it.<br/>For instance if you set this to 'FOO' the final file name will be of the form: <code>OpenJDK8U-jre_ppc64le_linux_openj9_FOO.tar.gz</code>")
         booleanParam('cleanWorkspaceBeforeBuild', false, "Clean out the workspace before the build")
+        booleanParam('cleanWorkspaceAfterBuild', false, "Clean out the workspace after the build")
+        booleanParam('cleanWorkspaceBuildOutputAfterBuild', cleanWsBuildOutput, "Clean out the workspace/build/src/build and workspace/target output only, after the build")
         booleanParam('propagateFailures', propagateFailures, "If true, a failure of <b>ANY</b> downstream build (but <b>NOT</b> test) will cause the whole build to fail")
         booleanParam('keepTestReportDir', false, 'If true, test report dir (including core files where generated) will be kept even when the testcase passes, failed testcases always keep the report dir. Does not apply to JUnit jobs which are always kept, eg.openjdk.')
         booleanParam('keepReleaseLogs', true, 'If true, "Release" type pipeline Jenkins logs will be marked as "Keep this build forever".')

--- a/pipelines/library/src/common/IndividualBuildConfig.groovy
+++ b/pipelines/library/src/common/IndividualBuildConfig.groovy
@@ -30,6 +30,8 @@ class IndividualBuildConfig implements Serializable {
     final boolean ENABLE_INSTALLERS
     final boolean ENABLE_SIGNER
     final boolean CLEAN_WORKSPACE
+    final boolean CLEAN_WORKSPACE_AFTER
+    final boolean CLEAN_WORKSPACE_BUILD_OUTPUT_ONLY_AFTER
 
     IndividualBuildConfig(String json) {
         this(new JsonSlurper().parseText(json) as Map)
@@ -70,6 +72,8 @@ class IndividualBuildConfig implements Serializable {
         ENABLE_INSTALLERS = map.get("ENABLE_INSTALLERS")
         ENABLE_SIGNER = map.get("ENABLE_SIGNER")
         CLEAN_WORKSPACE = map.get("CLEAN_WORKSPACE")
+        CLEAN_WORKSPACE_AFTER = map.get("CLEAN_WORKSPACE_AFTER")
+        CLEAN_WORKSPACE_BUILD_OUTPUT_ONLY_AFTER = map.get("CLEAN_WORKSPACE_BUILD_OUTPUT_ONLY_AFTER")
     }
 
     Map<String, ?> toMap() {
@@ -114,7 +118,9 @@ class IndividualBuildConfig implements Serializable {
                 ENABLE_TESTS              : ENABLE_TESTS,
                 ENABLE_INSTALLERS         : ENABLE_INSTALLERS,
                 ENABLE_SIGNER             : ENABLE_SIGNER,
-                CLEAN_WORKSPACE           : CLEAN_WORKSPACE
+                CLEAN_WORKSPACE           : CLEAN_WORKSPACE,
+                CLEAN_WORKSPACE_AFTER     : CLEAN_WORKSPACE_AFTER,
+                CLEAN_WORKSPACE_BUILD_OUTPUT_ONLY_AFTER : CLEAN_WORKSPACE_BUILD_OUTPUT_ONLY_AFTER
         ]
     }
 

--- a/pipelines/src/test/groovy/IndividualBuildConfigTest.groovy
+++ b/pipelines/src/test/groovy/IndividualBuildConfigTest.groovy
@@ -33,7 +33,9 @@ class IndividualBuildConfigTest {
                  ENABLE_TESTS              : true,
                  ENABLE_INSTALLERS         : true,
                  ENABLE_SIGNER             : true,
-                 CLEAN_WORKSPACE           : false]
+                 CLEAN_WORKSPACE           : false,
+                 CLEAN_WORKSPACE_AFTER     : false,
+                 CLEAN_WORKSPACE_BUILD_OUTPUT_ONLY_AFTER : false]
         )
 
         def json = config.toJson()


### PR DESCRIPTION
Add the facility to clean the build workspace or just the workspace/build/src/build and workspace/target binary output at the end of the build. This provides a large saving of disk space, up to 30Gb for Build Output alone and an additional 6Gb for the whole workspace. The default settings for generated pipelines are:
- cleanWorkspaceAfterBuild : false
- cleanWorkspaceBuildOutputAfterBuild : true
Additionally, cleanWorkspaceAfterBuild can be specified in the jdk platform configuration if a specific platform requires cleaning only.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>