### PR TITLE
build.sh: Add eyecatcher timestamps to check build performance

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -892,11 +892,6 @@ createOpenJDKTarArchive() {
   createArchive "${jdkTargetPath}" "${BUILD_CONFIG[TARGET_FILE_NAME]}"
 }
 
-# Echo success
-showCompletionMessage() {
-  echo "All done!"
-}
-
 copyFreeFontForMacOS() {
   local jdkTargetPath=$(getJdkArchivePath)
   local jreTargetPath=$(getJreArchivePath)
@@ -1114,17 +1109,23 @@ if [[ "${BUILD_CONFIG[ASSEMBLE_EXPLODED_IMAGE]}" == "true" ]]; then
   exit 0
 fi
 
+echo "build.sh : $(date +%T) : Building shared library with gradle ..."
 buildSharedLibs
 
+echo "build.sh : $(date +%T) : Clearing out target dir ..."
 wipeOutOldTargetDir
 createTargetDir
 
+echo "build.sh : $(date +%T) : Configuring workspace inc. clone and cacerts generation ..."
 configureWorkspace
 
+echo "build.sh : $(date +%T) : Initiating build ..."
 getOpenJDKUpdateAndBuildVersion
 configureCommandParameters
 buildTemplatedFile
 executeTemplatedFile
+
+echo "build.sh : $(date +%T) : Build complete ..."
 
 if [[ "${BUILD_CONFIG[MAKE_EXPLODED]}" != "true" ]]; then
   printJavaVersionString
@@ -1135,7 +1136,7 @@ if [[ "${BUILD_CONFIG[MAKE_EXPLODED]}" != "true" ]]; then
   createOpenJDKTarArchive
 fi
 
-showCompletionMessage
+echo "build.sh : $(date +%T) : All done!"
 
 # ccache is not detected properly TODO
 # change grep to something like $GREP -e '^1.*' -e '^2.*' -e '^3\.0.*' -e '^3\.1\.[0123]$'`]

--- a/sbin/common/common.sh
+++ b/sbin/common/common.sh
@@ -147,9 +147,9 @@ createOpenJDKArchive()
   else
       # Create archive with UID/GID 0 for root if using GNU tar
       if tar --version 2>&1 | grep GNU > /dev/null; then
-          tar -cf - --owner=root --group=root "${repoDir}"/ | GZIP=-9 $COMPRESS -c > $fileName.tar.gz
+          time tar -cf - --owner=root --group=root "${repoDir}"/ | GZIP=-9 $COMPRESS -c > $fileName.tar.gz
       else
-          tar -cf - "${repoDir}"/ | GZIP=-9 $COMPRESS -c > $fileName.tar.gz
+          time tar -cf - "${repoDir}"/ | GZIP=-9 $COMPRESS -c > $fileName.tar.gz
       fi
   fi
 }

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -526,7 +526,7 @@ prepareCacerts() {
     echo "Generating cacerts from Mozilla's bundle"
 
     cd "$SCRIPT_DIR/../security"
-    ./mk-cacerts.sh --keytool "${BUILD_CONFIG[JDK_BOOT_DIR]}/bin/keytool"
+    time ./mk-cacerts.sh --keytool "${BUILD_CONFIG[JDK_BOOT_DIR]}/bin/keytool"
 }
 
 # Download all of the dependencies for OpenJDK (Alsa, FreeType, etc.)


### PR DESCRIPTION
Found this useful while running multiple builds in succession so I feel it could be beneficial here if we want to see which sections are fast/slow in different environments (also highlights [CaCerts](https://github.com/AdoptOpenJDK/openjdk-build/pull/2113) and [gradle timings](https://github.com/AdoptOpenJDK/openjdk-build/issues/2139))

This may be useful in optimising for third-party users of our build scripts

(If anyone feels particularly strongly about the removal of `showCompletionMessage()` let me know but it seems to be extra complexity wrapping a function around an echo statement :-) )

Signed-off-by: Stewart X Addison <sxa@redhat.com>