### PR TITLE
Update defaultJavaVersions in prTester to 8,11,16,17

### DIFF
--- a/pipelines/build/prTester/pr_test_pipeline.groovy
+++ b/pipelines/build/prTester/pr_test_pipeline.groovy
@@ -153,7 +153,7 @@ Map<String, ?> defaultTestConfigurations = [
     ]
 ]
 
-List<Integer> defaultJavaVersions = [8, 11, 15, 16]
+List<Integer> defaultJavaVersions = [8, 11, 16, 17]
 
 defaultGitRepo = "https://github.com/AdoptOpenJDK/openjdk-build"
 


### PR DESCRIPTION
Remove retired 15 and add 17.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>