### PR TITLE
Enable Dragonwell JDK11 builds for Linux/aarch64

### DIFF
--- a/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk11u_pipeline_config.groovy
@@ -127,7 +127,7 @@ class Config11 {
                         "openj9" : '--enable-dtrace=auto',
                         "corretto" : '--enable-dtrace=auto',
                         "dragonwell" : "--enable-dtrace=auto --with-extra-cflags=\"-march=armv8.2-a+crypto\" --with-extra-cxxflags=\"-march=armv8.2-a+crypto\""
-                ]
+                ],
         ],
 
         x64LinuxXL    : [


### PR DESCRIPTION
Partially fixes #2367 (Not using GCC9 yet as requested in https://github.com/AdoptOpenJDK/openjdk-infrastructure/pull/1706 although I have tested with it - that change is awaiting deployment of https://github.com/AdoptOpenJDK/openjdk-infrastructure/pull/1706 once it is approved and merged)

Signed-off-by: Stewart X Addison <sxa@redhat.com>