### PR TITLE
Remove x64Solaris from nightly until a working build machine is available

### DIFF
--- a/pipelines/jobs/configurations/jdk8u.groovy
+++ b/pipelines/jobs/configurations/jdk8u.groovy
@@ -43,9 +43,6 @@ targetConfigurations = [
         "sparcv9Solaris": [
                 "hotspot"
         ],
-        "x64Solaris": [
-                "hotspot"
-        ],
         "x64LinuxXL"       : [
                 "openj9"
         ],


### PR DESCRIPTION
Until we have working Solaris x64 machines, we shall remove this from the nightly as it hangs the whole build pipeline.
See:
https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1871
https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1865

Signed-off-by: Andrew Leonard <anleonar@redhat.com>