### PR TITLE
Enable default nightly testing for jdk-17

### DIFF
--- a/pipelines/jobs/configurations/jdk17_pipeline_config.groovy
+++ b/pipelines/jobs/configurations/jdk17_pipeline_config.groovy
@@ -4,10 +4,7 @@ class Config17 {
                 os                  : 'mac',
                 arch                : 'x64',
                 additionalNodeLabels: 'macos10.14',
-                test                : [
-                        nightly: [],
-                        weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
-                ],
+                test                : 'default',
                 configureArgs       : '--enable-dtrace'
         ],
         
@@ -30,10 +27,7 @@ class Config17 {
                 dockerFile: [
                         openj9  : 'pipelines/build/dockerFiles/cuda.dockerfile'
                 ],
-                test                : [
-                        nightly: [],
-                        weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf', 'sanity.external', 'special.functional']
-                ],
+                test                : 'default',
                 additionalTestLabels: [
                         openj9      : '!(centos6||rhel6)'
                 ],
@@ -74,10 +68,7 @@ class Config17 {
                 os                  : 'windows',
                 arch                : 'x64',
                 additionalNodeLabels: 'win2012&&vs2017',
-                test                : [
-                        nightly: [],
-                        weekly : ['sanity.openjdk', 'sanity.perf', 'sanity.system', 'extended.system']
-                ]
+                test                : 'default'
         ],
         
         x64WindowsXL: [
@@ -109,7 +100,7 @@ class Config17 {
                 buildArgs : [
                         hotspot : '--jvm-variant client,server'
                 ],
-                test                : ['sanity.openjdk']
+                test                : 'default'
         ],
 
         ppc64Aix    : [
@@ -119,10 +110,7 @@ class Config17 {
                         hotspot: 'xlc16&&aix710',
                         openj9:  'xlc16&&aix715'
                 ],
-                test                : [
-                        nightly: [],
-                        weekly : ['sanity.openjdk', 'sanity.system', 'extended.system']
-                ],
+                test                : 'default',
                 cleanWorkspaceAfterBuild: true
         ],
 
@@ -130,10 +118,7 @@ class Config17 {
         s390xLinux    : [
                 os                  : 'linux',
                 arch                : 's390x',
-                test                : [
-                        nightly: [],
-                        weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
-                ],
+                test                : 'default',
                 configureArgs       : '--enable-dtrace'
         ],
         
@@ -149,10 +134,7 @@ class Config17 {
                 os                  : 'linux',
                 arch                : 'ppc64le',
                 additionalNodeLabels: 'centos7',
-                test                : [
-                        nightly: [],
-                        weekly: ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
-                ],
+                test                : 'default',
                 configureArgs       : [
                         "hotspot"     : '--enable-dtrace',
                         "openj9"      : '--enable-dtrace --enable-jitserver'
@@ -173,10 +155,7 @@ class Config17 {
                 os                  : 'linux',
                 arch                : 'aarch64',
                 dockerImage         : 'adoptopenjdk/centos7_build_image',
-                test                : [
-                        nightly: [],
-                        weekly : ['sanity.openjdk', 'sanity.system', 'extended.system', 'sanity.perf']
-                ],
+                test                : 'default',
                 configureArgs       : '--enable-dtrace'
         ],
         
@@ -192,10 +171,7 @@ class Config17 {
         arm32Linux    : [
                 os                  : 'linux',
                 arch                : 'arm',
-                test                : [
-                        nightly: ['sanity.openjdk'],
-                        weekly : []
-                ],
+                test                : 'default',
                 configureArgs       : '--enable-dtrace'
         ]
   ]


### PR DESCRIPTION
We already run jdk-17 nightly testing for the j9 XL builds (by config misstake than anything else!).
Seems we should run the nightly tests for the whole of jdk-17.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>