### PR TITLE
fix downstream SCM_REF in tests for aarch64 and arm32

### DIFF
--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -170,7 +170,12 @@ class Build {
         def jdkBranch
 
         if (buildConfig.SCM_REF) {
-            jdkBranch = buildConfig.SCM_REF
+            // We need to override the SCM ref on jdk8 arm builds
+            if (buildConfig.JAVA_TO_BUILD == "jdk8u" &&  buildConfig.VARIANT == "hotspot" && (buildConfig.ARCHITECTURE == "aarch64" || (buildConfig.ARCHITECTURE == "arm") {
+                jdkBranch = buildConfig.OVERRIDE_FILE_NAME_VERSION
+            } else {
+                jdkBranch = buildConfig.SCM_REF
+            }
         } else {
             if (buildConfig.VARIANT == "corretto") {
                 jdkBranch = 'develop'

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -171,7 +171,7 @@ class Build {
 
         if (buildConfig.SCM_REF) {
             // We need to override the SCM ref on jdk8 arm builds
-            if (buildConfig.JAVA_TO_BUILD == "jdk8u" &&  buildConfig.VARIANT == "hotspot" && (buildConfig.ARCHITECTURE == "aarch64" || (buildConfig.ARCHITECTURE == "arm") {
+            if (buildConfig.JAVA_TO_BUILD == "jdk8u" &&  buildConfig.VARIANT == "hotspot" && (buildConfig.ARCHITECTURE == "aarch64" || (buildConfig.ARCHITECTURE == "arm")) {
                 jdkBranch = buildConfig.OVERRIDE_FILE_NAME_VERSION
             } else {
                 jdkBranch = buildConfig.SCM_REF

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -170,7 +170,7 @@ class Build {
         def jdkBranch
 
         if (buildConfig.SCM_REF) {
-            // We need to override the SCM ref on jdk8 arm builds
+            // We need to override the SCM ref on jdk8 arm builds change aarch64-shenandoah-jdk8u282-b08 to jdk8u282-b08
             if (buildConfig.JAVA_TO_BUILD == "jdk8u" &&  buildConfig.VARIANT == "hotspot" && (buildConfig.ARCHITECTURE == "aarch64" || buildConfig.ARCHITECTURE == "arm")) {
                 jdkBranch = buildConfig.OVERRIDE_FILE_NAME_VERSION
             } else {

--- a/pipelines/build/common/openjdk_build_pipeline.groovy
+++ b/pipelines/build/common/openjdk_build_pipeline.groovy
@@ -171,7 +171,7 @@ class Build {
 
         if (buildConfig.SCM_REF) {
             // We need to override the SCM ref on jdk8 arm builds
-            if (buildConfig.JAVA_TO_BUILD == "jdk8u" &&  buildConfig.VARIANT == "hotspot" && (buildConfig.ARCHITECTURE == "aarch64" || (buildConfig.ARCHITECTURE == "arm")) {
+            if (buildConfig.JAVA_TO_BUILD == "jdk8u" &&  buildConfig.VARIANT == "hotspot" && (buildConfig.ARCHITECTURE == "aarch64" || buildConfig.ARCHITECTURE == "arm")) {
                 jdkBranch = buildConfig.OVERRIDE_FILE_NAME_VERSION
             } else {
                 jdkBranch = buildConfig.SCM_REF


### PR DESCRIPTION
currently, we are passing the incorrect SCM ref to the test repo for aarch64 and arm32.

Example: 

jdk8u aarch64 SCM_REF is set to `aarch64-shenandoah-jdk8u282-b08`.

This tag doesn't exist in the jdk8 source because it comes from a different repo. By using the `OVERRIDE_FILE_NAME_VERSION` variable we are able to select the correct tag