### PR TITLE
autodetect as much as possible in make-adopt-build-farm.sh

### DIFF
--- a/build-farm/make-adopt-build-farm.sh
+++ b/build-farm/make-adopt-build-farm.sh
@@ -35,7 +35,6 @@ fi
 
 ## AdoptOpenJDK uses "windows" instead of "cygwin" for the OS name on Windows
 ## so needs to be special cased - on everthing else "uname" is valid
-
 if [ -z "$TARGET_OS" ]; then
   TARGET_OS=`uname`
   if [ "$OSTYPE" = "cygwin" ]; then TARGET_OS=windows ; fi
@@ -46,7 +45,6 @@ fi
 
 ## Allow JAVA_TO_BUILD to be supplied as a parameter to the script
 ## and if not there or definied in environment, use latest LTS (jdk11u)
-
 if [ -z "$JAVA_TO_BUILD" ]; then
   if [ "$1" != "${1##jdk}" ]; then
     echo Setting JAVA_TO_BUILD to "$1" from the parameter supplied
@@ -62,7 +60,6 @@ fi
 [ -z "$FILENAME"      ] && echo FILENAME not defined - assuming "${JAVA_TO_BUILD}-${VARIANT}.tar.gz" && export FILENAME="${JAVA_TO_BUILD}-${VARIANT}.tar.gz"
 
 ## Very very build farm specific configuration
-
 export OPERATING_SYSTEM
 OPERATING_SYSTEM=$(echo "${TARGET_OS}" | tr '[:upper:]' '[:lower:]')
 


### PR DESCRIPTION
Follow on from https://github.com/AdoptOpenJDK/openjdk-build/commit/238ad36cb85d19ce443f6f0a16ea2153ff4c10ce - autodetect default values (but tell user what is being defaulted so they can override easily if required ...

Testing with [VPC](https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/1058/) and [QPC](https://ci.adoptopenjdk.net/view/Tooling/job/QEMUPlaybookCheck/203/)

Signed-off-by: Stewart X Addison <sxa@redhat.com>