### PR TITLE
Remove java 11 boot JDK restriction (Reverts PR 1416 and then some!)

### DIFF
--- a/build-farm/platform-specific-configurations/aix.sh
+++ b/build-farm/platform-specific-configurations/aix.sh
@@ -46,56 +46,52 @@ if [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]; then
 fi
 echo LDR_CNTRL=$LDR_CNTRL
 
-# Any version above 8 (11 for now due to openjdk-build#1409
-if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then 
-  BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION-1))"
-  BOOT_JDK_VARIABLE="JDK$(echo $BOOT_JDK_VERSION)_BOOT_DIR"
-  if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then
-    bootDir="$PWD/jdk-$BOOT_JDK_VERSION"
-    # Note we export $BOOT_JDK_VARIABLE (i.e. JDKXX_BOOT_DIR) here
-    # instead of BOOT_JDK_VARIABLE (no '$').
-    export ${BOOT_JDK_VARIABLE}="${bootDir}"
-    if [ ! -x "$bootDir/bin/javac" ]; then
-      # Set to a default location as linked in the ansible playbooks
-      if [ -x /usr/java${BOOT_JDK_VERSION}_64/bin/javac ]; then
-        echo Could not use ${BOOT_JDK_VARIABLE} - using /usr/java${BOOT_JDK_VERSION}_64
-        export ${BOOT_JDK_VARIABLE}="/usr/java${BOOT_JDK_VERSION}_64"
-      else
-        mkdir -p "${bootDir}"
-        echo "Downloading GA release of boot JDK version ${BOOT_JDK_VERSION}..."
-        releaseType="ga"
-        apiUrlTemplate="https://api.adoptopenjdk.net/v3/binary/latest/\${BOOT_JDK_VERSION}/\${releaseType}/aix/\${ARCHITECTURE}/jdk/openj9/normal/adoptopenjdk"
+BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION-1))"
+BOOT_JDK_VARIABLE="JDK$(echo $BOOT_JDK_VERSION)_BOOT_DIR"
+if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then
+  bootDir="$PWD/jdk-$BOOT_JDK_VERSION"
+  # Note we export $BOOT_JDK_VARIABLE (i.e. JDKXX_BOOT_DIR) here
+  # instead of BOOT_JDK_VARIABLE (no '$').
+  export ${BOOT_JDK_VARIABLE}="${bootDir}"
+  if [ ! -x "$bootDir/bin/javac" ]; then
+    # Set to a default location as linked in the ansible playbooks
+    if [ -x /usr/java${BOOT_JDK_VERSION}_64/bin/javac ]; then
+      echo Could not use ${BOOT_JDK_VARIABLE} - using /usr/java${BOOT_JDK_VERSION}_64
+      export ${BOOT_JDK_VARIABLE}="/usr/java${BOOT_JDK_VERSION}_64"
+    elif [ "$BOOT_JDK_VERSION" -ge 8 ]; then # Adopt has no build pre-8
+      mkdir -p "${bootDir}"
+      releaseType="ga"
+      apiUrlTemplate="https://api.adoptopenjdk.net/v3/binary/latest/\${BOOT_JDK_VERSION}/\${releaseType}/aix/\${ARCHITECTURE}/jdk/openj9/normal/adoptopenjdk"
+      apiURL=$(eval echo ${apiUrlTemplate})
+      echo "Downloading GA release of boot JDK version ${BOOT_JDK_VERSION} from ${apiURL}"
+      # make-adopt-build-farm.sh has 'set -e'. We need to disable that for
+      # the fallback mechanism, as downloading of the GA binary might fail.
+      set +e
+      wget -q -O - "${apiURL}" | tar xpzf - --strip-components=1 -C "$bootDir"
+      retVal=$?
+      set -e
+      if [ $retVal -ne 0 ]; then
+        # We must be a JDK HEAD build for which no boot JDK exists other than
+        # nightlies?
+        echo "Downloading GA release of boot JDK version ${BOOT_JDK_VERSION} failed."
+        # shellcheck disable=SC2034
+        releaseType="ea"
         apiURL=$(eval echo ${apiUrlTemplate})
-        # make-adopt-build-farm.sh has 'set -e'. We need to disable that
-        # for the fallback mechanism, as downloading of the GA binary might
-        # fail.
-        set +e
+        echo "Attempting to download EA release of boot JDK version ${BOOT_JDK_VERSION} from ${apiURL}"
         wget -q -O - "${apiURL}" | tar xpzf - --strip-components=1 -C "$bootDir"
-        retVal=$?
-        set -e
-        if [ $retVal -ne 0 ]; then
-          # We must be a JDK HEAD build for which no boot JDK exists other than
-          # nightlies?
-          echo "Downloading GA release of boot JDK version ${BOOT_JDK_VERSION} failed."
-          echo "Attempting to download EA release of boot JDK version ${BOOT_JDK_VERSION} ..."
-          # shellcheck disable=SC2034
-          releaseType="ea"
-          apiURL=$(eval echo ${apiUrlTemplate})
-          wget -q -O - "${apiURL}" | tar xpzf - --strip-components=1 -C "$bootDir"
-        fi
       fi
     fi
   fi
-  export JDK_BOOT_DIR="$(eval echo "\$$BOOT_JDK_VARIABLE")"
-  "$JDK_BOOT_DIR/bin/java" -version
-  executedJavaVersion=$?
-  if [ $executedJavaVersion -ne 0 ]; then
-      echo "Failed to obtain or find a valid boot jdk"
-      exit 1
-  fi
-    "$JDK_BOOT_DIR/bin/java" -version 2>&1 | sed 's/^/BOOT JDK: /'
 fi
 
+export JDK_BOOT_DIR="$(eval echo "\$$BOOT_JDK_VARIABLE")"
+"$JDK_BOOT_DIR/bin/java" -version 2>&1 | sed 's/^/BOOT JDK: /'
+"$JDK_BOOT_DIR/bin/java" -version > /dev/null 2>&1
+executedJavaVersion=$?
+if [ $executedJavaVersion -ne 0 ]; then
+    echo "Failed to obtain or find a valid boot jdk"
+    exit 1
+fi
 
 if [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]; then
   if [ "$JAVA_FEATURE_VERSION" -ge 11 ]; then

--- a/build-farm/platform-specific-configurations/alpine-linux.sh
+++ b/build-farm/platform-specific-configurations/alpine-linux.sh
@@ -21,46 +21,43 @@ source "$SCRIPT_DIR/../../sbin/common/constants.sh"
 # ccache seems flaky on alpine
 export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-ccache"
 
-# Any version above 8 (11 for now due to openjdk-build#1409
-if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
-    BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION-1))"
-    BOOT_JDK_VARIABLE="JDK$(echo $BOOT_JDK_VERSION)_BOOT_DIR"
-    if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then
-      bootDir="$PWD/jdk-$BOOT_JDK_VERSION"
-      # Note we export $BOOT_JDK_VARIABLE (i.e. JDKXX_BOOT_DIR) here
-      # instead of BOOT_JDK_VARIABLE (no '$').
-      export ${BOOT_JDK_VARIABLE}="$bootDir"
-      if [ ! -d "$bootDir/bin" ]; then
-        mkdir -p "$bootDir"
-        echo "Downloading GA release of boot JDK version ${BOOT_JDK_VERSION}..."
-        releaseType="ga"
-        apiUrlTemplate="https://api.adoptopenjdk.net/v3/binary/latest/\${BOOT_JDK_VERSION}/\${releaseType}/alpine-linux/\${ARCHITECTURE}/jdk/\${VARIANT}/normal/adoptopenjdk"
-        apiURL=$(eval echo ${apiUrlTemplate})
-        # make-adopt-build-farm.sh has 'set -e'. We need to disable that
-        # for the fallback mechanism, as downloading of the GA binary might
-        # fail.
-        set +e
-        wget -q -O - "${apiURL}" | tar xpzf - --strip-components=1 -C "$bootDir"
-        retVal=$?
-        set -e
-        if [ $retVal -ne 0 ]; then
-          # We must be a JDK HEAD build for which no boot JDK exists other than
-          # nightlies?
-          echo "Downloading GA release of boot JDK version ${BOOT_JDK_VERSION} failed."
-          echo "Attempting to download EA release of boot JDK version ${BOOT_JDK_VERSION} ..."
-          # shellcheck disable=SC2034
-          releaseType="ea"
-          apiURL=$(eval echo ${apiUrlTemplate})
-          wget -q -O - "${apiURL}" | tar xpzf - --strip-components=1 -C "$bootDir"
-        fi
-      fi
+BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION-1))"
+BOOT_JDK_VARIABLE="JDK$(echo $BOOT_JDK_VERSION)_BOOT_DIR"
+if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then
+  bootDir="$PWD/jdk-$BOOT_JDK_VERSION"
+  # Note we export $BOOT_JDK_VARIABLE (i.e. JDKXX_BOOT_DIR) here
+  # instead of BOOT_JDK_VARIABLE (no '$').
+  export ${BOOT_JDK_VARIABLE}="$bootDir"
+  if [ ! -d "$bootDir/bin" ]; then
+    mkdir -p "$bootDir"
+    releaseType="ga"
+    apiUrlTemplate="https://api.adoptopenjdk.net/v3/binary/latest/\${BOOT_JDK_VERSION}/\${releaseType}/alpine-linux/\${ARCHITECTURE}/jdk/\${VARIANT}/normal/adoptopenjdk"
+    apiURL=$(eval echo ${apiUrlTemplate})
+    echo "Downloading GA release of boot JDK version ${BOOT_JDK_VERSION} from ${apiURL}"
+    # make-adopt-build-farm.sh has 'set -e'. We need to disable that for
+    # the fallback mechanism, as downloading of the GA binary might fail.
+    set +e
+    wget -q -O - "${apiURL}" | tar xpzf - --strip-components=1 -C "$bootDir"
+    retVal=$?
+    set -e
+    if [ $retVal -ne 0 ]; then
+      # We must be a JDK HEAD build for which no boot JDK exists other than
+      # nightlies?
+      echo "Downloading GA release of boot JDK version ${BOOT_JDK_VERSION} failed."
+      # shellcheck disable=SC2034
+      releaseType="ea"
+      apiURL=$(eval echo ${apiUrlTemplate})
+      echo "Attempting to download EA release of boot JDK version ${BOOT_JDK_VERSION} from ${apiURL}"
+      wget -q -O - "${apiURL}" | tar xpzf - --strip-components=1 -C "$bootDir"
     fi
-    export JDK_BOOT_DIR="$(eval echo "\$$BOOT_JDK_VARIABLE")"
-    "$JDK_BOOT_DIR/bin/java" -version
-    executedJavaVersion=$?
-    if [ $executedJavaVersion -ne 0 ]; then
-        echo "Failed to obtain or find a valid boot jdk"
-        exit 1
-    fi
-    "$JDK_BOOT_DIR/bin/java" -version 2>&1 | sed 's/^/BOOT JDK: /'
+  fi
+fi
+
+export JDK_BOOT_DIR="$(eval echo "\$$BOOT_JDK_VARIABLE")"
+"$JDK_BOOT_DIR/bin/java" -version 2>&1 | sed 's/^/BOOT JDK: /'
+"$JDK_BOOT_DIR/bin/java" -version > /dev/null 2>&1
+executedJavaVersion=$?
+if [ $executedJavaVersion -ne 0 ]; then
+    echo "Failed to obtain or find a valid boot jdk"
+    exit 1
 fi

--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -90,54 +90,51 @@ then
   fi
 fi
 
-# Any version above 8 (11 for now due to openjdk-build#1409
-if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then 
-  BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION-1))"
-  BOOT_JDK_VARIABLE="JDK$(echo $BOOT_JDK_VERSION)_BOOT_DIR"
-  if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then
-    bootDir="$PWD/jdk-$BOOT_JDK_VERSION"
-    # Note we export $BOOT_JDK_VARIABLE (i.e. JDKXX_BOOT_DIR) here
-    # instead of BOOT_JDK_VARIABLE (no '$').
-    export ${BOOT_JDK_VARIABLE}="$bootDir"
-    if [ ! -x "$bootDir/bin/javac" ]; then
-      # Set to a default location as linked in the ansible playbooks
-      if [ -x /usr/lib/jvm/jdk-${BOOT_JDK_VERSION}/bin/javac ]; then
-        echo Could not use ${BOOT_JDK_VARIABLE} - using /usr/lib/jvm/jdk-${BOOT_JDK_VERSION}
-        export ${BOOT_JDK_VARIABLE}="/usr/lib/jvm/jdk-${BOOT_JDK_VERSION}"
-      else
-        mkdir -p "$bootDir"
-        echo "Downloading GA release of boot JDK version ${BOOT_JDK_VERSION}..."
-        releaseType="ga"
-        apiUrlTemplate="https://api.adoptopenjdk.net/v3/binary/latest/\${BOOT_JDK_VERSION}/\${releaseType}/linux/\${ARCHITECTURE}/jdk/\${VARIANT}/normal/adoptopenjdk"
+BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION-1))"
+BOOT_JDK_VARIABLE="JDK$(echo $BOOT_JDK_VERSION)_BOOT_DIR"
+if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then
+  bootDir="$PWD/jdk-$BOOT_JDK_VERSION"
+  # Note we export $BOOT_JDK_VARIABLE (i.e. JDKXX_BOOT_DIR) here
+  # instead of BOOT_JDK_VARIABLE (no '$').
+  export ${BOOT_JDK_VARIABLE}="$bootDir"
+  if [ ! -x "$bootDir/bin/javac" ]; then
+    # Set to a default location as linked in the ansible playbooks
+    if [ -x /usr/lib/jvm/jdk-${BOOT_JDK_VERSION}/bin/javac ]; then
+      echo Could not use ${BOOT_JDK_VARIABLE} - using /usr/lib/jvm/jdk-${BOOT_JDK_VERSION}
+      export ${BOOT_JDK_VARIABLE}="/usr/lib/jvm/jdk-${BOOT_JDK_VERSION}"
+    elif [ "$BOOT_JDK_VERSION" -ge 8 ]; then # Adopt has no build pre-8
+      mkdir -p "$bootDir"
+      releaseType="ga"
+      apiUrlTemplate="https://api.adoptopenjdk.net/v3/binary/latest/\${BOOT_JDK_VERSION}/\${releaseType}/linux/\${ARCHITECTURE}/jdk/\${VARIANT}/normal/adoptopenjdk"
+      apiURL=$(eval echo ${apiUrlTemplate})
+      echo "Downloading GA release of boot JDK version ${BOOT_JDK_VERSION} from ${apiURL}"
+      # make-adopt-build-farm.sh has 'set -e'. We need to disable that for
+      # the fallback mechanism, as downloading of the GA binary might fail.
+      set +e
+      wget -q -O - "${apiURL}" | tar xpzf - --strip-components=1 -C "$bootDir"
+      retVal=$?
+      set -e
+      if [ $retVal -ne 0 ]; then
+        # We must be a JDK HEAD build for which no boot JDK exists other than
+        # nightlies?
+        echo "Downloading GA release of boot JDK version ${BOOT_JDK_VERSION} failed."
+        # shellcheck disable=SC2034
+        releaseType="ea"
         apiURL=$(eval echo ${apiUrlTemplate})
-        # make-adopt-build-farm.sh has 'set -e'. We need to disable that
-        # for the fallback mechanism, as downloading of the GA binary might
-        # fail.
-        set +e
+        echo "Attempting to download EA release of boot JDK version ${BOOT_JDK_VERSION} from ${apiURL}"
         wget -q -O - "${apiURL}" | tar xpzf - --strip-components=1 -C "$bootDir"
-        retVal=$?
-        set -e
-        if [ $retVal -ne 0 ]; then
-          # We must be a JDK HEAD build for which no boot JDK exists other than
-          # nightlies?
-          echo "Downloading GA release of boot JDK version ${BOOT_JDK_VERSION} failed."
-          echo "Attempting to download EA release of boot JDK version ${BOOT_JDK_VERSION} ..."
-          # shellcheck disable=SC2034
-          releaseType="ea"
-          apiURL=$(eval echo ${apiUrlTemplate})
-          wget -q -O - "${apiURL}" | tar xpzf - --strip-components=1 -C "$bootDir"
-        fi
       fi
     fi
   fi
-  export JDK_BOOT_DIR="$(eval echo "\$$BOOT_JDK_VARIABLE")"
-  "$JDK_BOOT_DIR/bin/java" -version
-  executedJavaVersion=$?
-  if [ $executedJavaVersion -ne 0 ]; then
-      echo "Failed to obtain or find a valid boot jdk"
-      exit 1
-  fi
-  "$JDK_BOOT_DIR/bin/java" -version 2>&1 | sed 's/^/BOOT JDK: /'
+fi
+
+export JDK_BOOT_DIR="$(eval echo "\$$BOOT_JDK_VARIABLE")"
+"$JDK_BOOT_DIR/bin/java" -version 2>&1 | sed 's/^/BOOT JDK: /'
+"$JDK_BOOT_DIR/bin/java" -version >/dev/null 2>&1
+executedJavaVersion=$?
+if [ $executedJavaVersion -ne 0 ]; then
+    echo "Failed to obtain or find a valid boot jdk"
+    exit 1
 fi
 
 if [ "${VARIANT}" == "${BUILD_VARIANT_DRAGONWELL}" ] && [ "$JAVA_FEATURE_VERSION" -eq 11 ] && [ -r /usr/local/gcc9/ ]; then

--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -66,53 +66,50 @@ fi
 
 sudo xcode-select --switch "${XCODE_SWITCH_PATH}"
 
-# Any version above 8 (11 for now due to openjdk-build#1409
-if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then 
-  BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION-1))"
-  BOOT_JDK_VARIABLE="JDK$(echo $BOOT_JDK_VERSION)_BOOT_DIR"
-  if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then
-    bootDir="$PWD/jdk-$BOOT_JDK_VERSION"
-    # Note we export $BOOT_JDK_VARIABLE (i.e. JDKXX_BOOT_DIR) here
-    # instead of BOOT_JDK_VARIABLE (no '$').
-    export ${BOOT_JDK_VARIABLE}="$bootDir/Contents/Home"
-    if [ ! -x "$bootDir/Contents/Home/bin/javac" ]; then
-      if [ -x /Library/Java/JavaVirtualMachines/adoptopenjdk-${BOOT_JDK_VERSION}/Contents/Home/bin/javac ]; then
-        echo Could not use ${BOOT_JDK_VARIABLE} - using /Library/Java/JavaVirtualMachines/adoptopenjdk-${BOOT_JDK_VERSION}/Contents/Home
-        export ${BOOT_JDK_VARIABLE}="/Library/Java/JavaVirtualMachines/adoptopenjdk-${BOOT_JDK_VERSION}/Contents/Home"
-      else
-        mkdir -p "$bootDir"
-        echo "Downloading GA release of boot JDK version ${BOOT_JDK_VERSION}..."
-        releaseType="ga"
-        apiUrlTemplate="https://api.adoptopenjdk.net/v3/binary/latest/\${BOOT_JDK_VERSION}/\${releaseType}/mac/\${ARCHITECTURE}/jdk/\${VARIANT}/normal/adoptopenjdk"
+BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION-1))"
+BOOT_JDK_VARIABLE="JDK$(echo $BOOT_JDK_VERSION)_BOOT_DIR"
+if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then
+  bootDir="$PWD/jdk-$BOOT_JDK_VERSION"
+  # Note we export $BOOT_JDK_VARIABLE (i.e. JDKXX_BOOT_DIR) here
+  # instead of BOOT_JDK_VARIABLE (no '$').
+  export ${BOOT_JDK_VARIABLE}="$bootDir/Contents/Home"
+  if [ ! -x "$bootDir/Contents/Home/bin/javac" ]; then
+    if [ -x /Library/Java/JavaVirtualMachines/adoptopenjdk-${BOOT_JDK_VERSION}/Contents/Home/bin/javac ]; then
+      echo Could not use ${BOOT_JDK_VARIABLE} - using /Library/Java/JavaVirtualMachines/adoptopenjdk-${BOOT_JDK_VERSION}/Contents/Home
+      export ${BOOT_JDK_VARIABLE}="/Library/Java/JavaVirtualMachines/adoptopenjdk-${BOOT_JDK_VERSION}/Contents/Home"
+    elif [ "$BOOT_JDK_VERSION" -ge 8 ]; then # Adopt has no build pre-8
+      mkdir -p "$bootDir"
+      releaseType="ga"
+      apiUrlTemplate="https://api.adoptopenjdk.net/v3/binary/latest/\${BOOT_JDK_VERSION}/\${releaseType}/mac/\${ARCHITECTURE}/jdk/\${VARIANT}/normal/adoptopenjdk"
+      apiURL=$(eval echo ${apiUrlTemplate})
+      echo "Downloading GA release of boot JDK version ${BOOT_JDK_VERSION} from ${apiURL}"
+      # make-adopt-build-farm.sh has 'set -e'. We need to disable that for
+      # the fallback mechanism, as downloading of the GA binary might fail.
+      set +e
+      wget -q -O "${BOOT_JDK_VERSION}.tgz" "${apiURL}" && tar xpzf "${BOOT_JDK_VERSION}.tgz" --strip-components=1 -C "$bootDir" && rm "${BOOT_JDK_VERSION}.tgz"
+      retVal=$?
+      set -e
+      if [ $retVal -ne 0 ]; then
+        # We must be a JDK HEAD build for which no boot JDK exists other than
+        # nightlies?
+        echo "Downloading GA release of boot JDK version ${BOOT_JDK_VERSION} failed."
+        # shellcheck disable=SC2034
+        releaseType="ea"
         apiURL=$(eval echo ${apiUrlTemplate})
-        # make-adopt-build-farm.sh has 'set -e'. We need to disable that
-        # for the fallback mechanism, as downloading of the GA binary might
-        # fail.
-        set +e
-        wget -q -O "${BOOT_JDK_VERSION}.tgz" "${apiURL}" && tar xpzf "${BOOT_JDK_VERSION}.tgz" --strip-components=1 -C "$bootDir" && rm "${BOOT_JDK_VERSION}.tgz"
-        retVal=$?
-        set -e
-        if [ $retVal -ne 0 ]; then
-          # We must be a JDK HEAD build for which no boot JDK exists other than
-          # nightlies?
-          echo "Downloading GA release of boot JDK version ${BOOT_JDK_VERSION} failed."
-          echo "Attempting to download EA release of boot JDK version ${BOOT_JDK_VERSION} ..."
-          # shellcheck disable=SC2034
-          releaseType="ea"
-          apiURL=$(eval echo ${apiUrlTemplate})
-          wget -q -O - "${apiURL}" | tar xpzf - --strip-components=1 -C "$bootDir"
-        fi
+        echo "Attempting to download EA release of boot JDK version ${BOOT_JDK_VERSION} from ${apiURL}"
+        wget -q -O - "${apiURL}" | tar xpzf - --strip-components=1 -C "$bootDir"
       fi
     fi
   fi
-  export JDK_BOOT_DIR="$(eval echo "\$$BOOT_JDK_VARIABLE")"
-  "$JDK_BOOT_DIR/bin/java" -version
-  executedJavaVersion=$?
-  if [ $executedJavaVersion -ne 0 ]; then
-      echo "Failed to obtain or find a valid boot jdk"
-      exit 1
-  fi
-  "$JDK_BOOT_DIR/bin/java" -version 2>&1 | sed 's/^/BOOT JDK: /'
+fi
+
+export JDK_BOOT_DIR="$(eval echo "\$$BOOT_JDK_VARIABLE")"
+"$JDK_BOOT_DIR/bin/java" -version 2>&1 | sed 's/^/BOOT JDK: /'
+"$JDK_BOOT_DIR/bin/java" -version > /dev/null 2>&1
+executedJavaVersion=$?
+if [ $executedJavaVersion -ne 0 ]; then
+  echo "Failed to obtain or find a valid boot jdk"
+  exit 1
 fi
 
 if [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]; then

--- a/build-farm/platform-specific-configurations/windows.sh
+++ b/build-farm/platform-specific-configurations/windows.sh
@@ -27,67 +27,65 @@ export OPENSSL_VERSION=1.1.1i
 
 TOOLCHAIN_VERSION=""
 
-# Any version above 8 (11 for now due to openjdk-build#1409
-if [ "$JAVA_FEATURE_VERSION" -gt 11 ]; then
-  if [ "$ARCHITECTURE" == "aarch64" ]; then
-    # Windows aarch64 cross compiles requires same version boot jdk
-    BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION))"
-  else
-    BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION-1))"
-  fi
-  BOOT_JDK_VARIABLE="JDK$(echo $BOOT_JDK_VERSION)_BOOT_DIR"
-  if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then
-    bootDir="$PWD/jdk-$BOOT_JDK_VERSION"
-    # Note we export $BOOT_JDK_VARIABLE (i.e. JDKXX_BOOT_DIR) here
-    # instead of BOOT_JDK_VARIABLE (no '$').
-    export ${BOOT_JDK_VARIABLE}="$bootDir"
-    if [ ! -x "$bootDir/bin/javac.exe" ]; then
-      # Set to a default location as linked in the ansible playbooks
-      if [ -x /cygdrive/c/openjdk/jdk-${BOOT_JDK_VERSION}/bin/javac ]; then
-        echo Could not use ${BOOT_JDK_VARIABLE} - using /cygdrive/c/openjdk/jdk-${BOOT_JDK_VERSION}
-        export ${BOOT_JDK_VARIABLE}="/usr/lib/jvm/jdk-${BOOT_JDK_VERSION}"
-      else
-        # This is needed to convert x86-32 to x32 which is what the API uses
-        case "$ARCHITECTURE" in
-           "x86-32") downloadArch="x32";;
-          "aarch64") downloadArch="x64";;
-                  *) downloadArch="$ARCHITECTURE";;
-        esac
-        echo "Downloading GA release of boot JDK version ${BOOT_JDK_VERSION}..."
-        releaseType="ga"
-        apiUrlTemplate="https://api.adoptopenjdk.net/v3/binary/latest/\${BOOT_JDK_VERSION}/\${releaseType}/windows/\${downloadArch}/jdk/\${VARIANT}/normal/adoptopenjdk"
+if [ "$ARCHITECTURE" == "aarch64" ]; then
+  # Windows aarch64 cross compiles requires same version boot jdk
+  BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION))"
+else
+  BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION-1))"
+fi
+BOOT_JDK_VARIABLE="JDK$(echo $BOOT_JDK_VERSION)_BOOT_DIR"
+if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then
+  bootDir="$PWD/jdk-$BOOT_JDK_VERSION"
+  # Note we export $BOOT_JDK_VARIABLE (i.e. JDKXX_BOOT_DIR) here
+  # instead of BOOT_JDK_VARIABLE (no '$').
+  export ${BOOT_JDK_VARIABLE}="$bootDir"
+  if [ ! -x "$bootDir/bin/javac.exe" ]; then
+    # Set to a default location as linked in the ansible playbooks
+    if [ -x /cygdrive/c/openjdk/jdk-${BOOT_JDK_VERSION}/bin/javac ]; then
+      echo Could not use ${BOOT_JDK_VARIABLE} - using /cygdrive/c/openjdk/jdk-${BOOT_JDK_VERSION}
+      export ${BOOT_JDK_VARIABLE}="/usr/lib/jvm/jdk-${BOOT_JDK_VERSION}"
+    elif [ "$BOOT_JDK_VERSION" -ge 8 ]; then # Adopt has no build pre-8
+      # This is needed to convert x86-32 to x32 which is what the API uses
+      case "$ARCHITECTURE" in
+         "x86-32") downloadArch="x32";;
+        "aarch64") downloadArch="x64";;
+                *) downloadArch="$ARCHITECTURE";;
+      esac
+      releaseType="ga"
+      apiUrlTemplate="https://api.adoptopenjdk.net/v3/binary/latest/\${BOOT_JDK_VERSION}/\${releaseType}/windows/\${downloadArch}/jdk/\${VARIANT}/normal/adoptopenjdk"
+      apiURL=$(eval echo ${apiUrlTemplate})
+      echo "Downloading GA release of boot JDK version ${BOOT_JDK_VERSION} from ${apiURL}"
+      # make-adopt-build-farm.sh has 'set -e'. We need to disable that for
+      # the fallback mechanism, as downloading of the GA binary might fail
+      set +e
+      wget -q "${apiURL}" -O openjdk.zip
+      retVal=$?
+      set -e
+      if [ $retVal -ne 0 ]; then
+        # We must be a JDK HEAD build for which no boot JDK exists other than
+        # nightlies?
+        echo "Downloading GA release of boot JDK version ${BOOT_JDK_VERSION} failed."
+        # shellcheck disable=SC2034
+        releaseType="ea"
         apiURL=$(eval echo ${apiUrlTemplate})
-        # make-adopt-build-farm.sh has 'set -e'. We need to disable that
-        # for the fallback mechanism, as downloading of the GA binary might
-        # fail.
-        set +e
+        echo "Attempting to download EA release of boot JDK version ${BOOT_JDK_VERSION} from ${apiURL}"
         wget -q "${apiURL}" -O openjdk.zip
-        retVal=$?
-        set -e
-        if [ $retVal -ne 0 ]; then
-          # We must be a JDK HEAD build for which no boot JDK exists other than
-          # nightlies?
-          echo "Downloading GA release of boot JDK version ${BOOT_JDK_VERSION} failed."
-          echo "Attempting to download EA release of boot JDK version ${BOOT_JDK_VERSION} ..."
-          # shellcheck disable=SC2034
-          releaseType="ea"
-          apiURL=$(eval echo ${apiUrlTemplate})
-          wget -q "${apiURL}" -O openjdk.zip
-        fi
-        unzip -q openjdk.zip
-        mv $(ls -d jdk-${BOOT_JDK_VERSION}*) "$bootDir"
       fi
+      unzip -q openjdk.zip
+      mv $(ls -d jdk-${BOOT_JDK_VERSION}*) "$bootDir"
     fi
   fi
-  export JDK_BOOT_DIR="$(eval echo "\$$BOOT_JDK_VARIABLE")"
-  "$JDK_BOOT_DIR/bin/java" -version
-  executedJavaVersion=$?
-  if [ $executedJavaVersion -ne 0 ]; then
-      echo "Failed to obtain or find a valid boot jdk"
-      exit 1
-  fi
-  "$JDK_BOOT_DIR/bin/java" -version 2>&1 | sed 's/^/BOOT JDK: /'
 fi
+
+export JDK_BOOT_DIR="$(eval echo "\$$BOOT_JDK_VARIABLE")"
+"$JDK_BOOT_DIR/bin/java" -version 2>&1 | sed 's/^/BOOT JDK: /'
+"$JDK_BOOT_DIR/bin/java" -version > /dev/null 2>&1
+executedJavaVersion=$?
+if [ $executedJavaVersion -ne 0 ]; then
+    echo "Failed to obtain or find a valid boot jdk"
+    exit 1
+fi
+"$JDK_BOOT_DIR/bin/java" -version 2>&1 | sed 's/^/BOOT JDK: /'
 
 if [ "${ARCHITECTURE}" == "x86-32" ]
 then


### PR DESCRIPTION
Reverts #1409 and allows a JDK10 boot JDK (For JDK11) to be auto-detected and downloaded, which https://github.com/AdoptOpenJDK/openjdk-build/pull/2167 was not able to do.

JDK7 (for JDK8) will still be detected if present, but will not be auto-downloaded (highly unlikely any machine would not have it set up anyway...)

Summary:
- Removes the conditional surrounding the detection/download
- Adjusts the "Downloading" message to print the API target we are downloading from (means moving that line to after `apiURL is set`)
- Changes indentation and the wrapping of one comment (which is why this looks more substantial than it is (Suggest reviewers do the review with whitespace ignored)
- Moves the printing of the `BOOT JDK` `java -version` output little earlier, and suppresses the printing on the `java -version` which checks that it works (moving the visible one earlier means that any "odd" errors won't get hidden from view now we're suppressing the second output

Testing at https://ci.adoptopenjdk.net/view/Tooling/job/VagrantPlaybookCheck/1053/

Signed-off-by: Stewart X Addison <sxa@redhat.com>