### PR TITLE
macos: Use JDK8 for bootstrapping JDK8

### DIFF
--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -66,6 +66,7 @@ fi
 
 sudo xcode-select --switch "${XCODE_SWITCH_PATH}"
 
+# Adopt does not have builds of OpenJDK 7, OpenJDK 8 can boot itself just fine.
 if [ "${JAVA_FEATURE_VERSION" = "8" ]; then
   BOOT_JDK_VERSION="${JAVA_FEATURE_VERSION}"
 else

--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -66,7 +66,11 @@ fi
 
 sudo xcode-select --switch "${XCODE_SWITCH_PATH}"
 
-BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION-1))"
+if [ "${JAVA_FEATURE_VERSION" = "8" ]; then
+  BOOT_JDK_VERSION="${JAVA_FEATURE_VERSION}"
+else
+  BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION-1))"
+fi
 BOOT_JDK_VARIABLE="JDK$(echo $BOOT_JDK_VERSION)_BOOT_DIR"
 if [ ! -d "$(eval echo "\$$BOOT_JDK_VARIABLE")" ]; then
   bootDir="$PWD/jdk-$BOOT_JDK_VERSION"


### PR DESCRIPTION
We do not have a macos JDK7 to use as a bootstrap for JDK8

Problem introduced by a recent autodetect PR (Apparently macos systems didn't have a JDK7_BOOT_DIR pointing to this in their jenkins definition)

Fixes #1959

Signed-off-by: Stewart X Addison <sxa@redhat.com>