### PR TITLE
Copy MacOS dSYM folder contents

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -688,8 +688,8 @@ removingUnnecessaryFiles() {
       debugSymbols=$(find "${jdkTargetPath}" -type f -name "*.pdb" -o -name "*.map")
       ;;
     darwin)
-      # on MacOSX, we want to take .dSYM folders
-      debugSymbols=$(find "${jdkTargetPath}" -type d -name "*.dSYM")
+      # on MacOSX, we want to take the files within the .dSYM folders
+      debugSymbols=$(find "${jdkTargetPath}" -type d -name "*.dSYM" | xargs -I {} find "{}" -type f)
       ;;
     *)
       # on other platforms, we want to take .debuginfo files


### PR DESCRIPTION
The previous Mac debug symbol copy change was copying the directory but not its contents! this fixes that.

Signed-off-by: Andrew Leonard <anleonar@redhat.com>