### PR TITLE
Enable debug images for all platforms except AIX

### DIFF
--- a/build-farm/make-adopt-build-farm.sh
+++ b/build-farm/make-adopt-build-farm.sh
@@ -191,6 +191,11 @@ echo "Filename will be: $FILENAME"
 
 export BUILD_ARGS="${BUILD_ARGS} --use-jep319-certs"
 
+# Enable debug images for all platforms except AIX until upstream openjdk supports "external" native debug symbols
+if [ "${OPERATING_SYSTEM}" != "aix" ] ; then
+    export BUILD_ARGS="${BUILD_ARGS} --create-debug-image"
+fi
+
 echo "$PLATFORM_SCRIPT_DIR/../makejdk-any-platform.sh" --clean-git-repo --jdk-boot-dir "${JDK_BOOT_DIR}" --configure-args "${CONFIGURE_ARGS_FOR_ANY_PLATFORM}" --target-file-name "${FILENAME}" ${TAG_OPTION} ${OPTIONS} ${BUILD_ARGS} ${VARIANT_ARG} "${JAVA_TO_BUILD}"
 
 # Convert all speech marks in config args to make them safe to pass in.


### PR DESCRIPTION
Enable debug images for all platforms except AIX (upstream does not support external native debug symbols yet)

Signed-off-by: Andrew Leonard <anleonar@redhat.com>