### PR TITLE
AIX: LIBPATH to include /opt/freeware/lib/pthread/ppc64 at the front

### DIFF
--- a/build-farm/platform-specific-configurations/aix.sh
+++ b/build-farm/platform-specific-configurations/aix.sh
@@ -30,7 +30,7 @@ source "$SCRIPT_DIR/../../sbin/common/constants.sh"
 export PATH="/opt/freeware/bin:/usr/local/bin:/opt/IBM/xlC/13.1.3/bin:/opt/IBM/xlc/13.1.3/bin:$PATH"
 # Without this, java adds /usr/lib to the LIBPATH and it's own library
 # directories of anything it forks which breaks linkage
-export LIBPATH=/opt/freeware/lib:/usr/lib
+export LIBPATH=/opt/freeware/lib/pthread/ppc64:/opt/freeware/lib:/usr/lib
 export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-cups-include=/opt/freeware/include"
 
 # Any version below 11


### PR DESCRIPTION
ref https://github.com/eclipse/openj9/issues/12018 and https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/1952

Ive updated the LIBPATH variable for AIX so that it provides a path to the library /opt/freeware/lib/gcc/powerpc-ibm-aix7.1.0.0/8/pthread/libstdc++.a, which has a symlink in /opt/freeware/lib/pthread/ppc64.

This solves a cmake issue we seem to be getting, which causes the following error
```
13:56:15  Could not load program cmake:
13:56:15  Symbol resolution failed for cmake because:
13:56:15  	Symbol _ZTINSt6thread6_StateE (number 358) is not exported from dependent
13:56:15  	  module /opt/freeware/lib/libstdc++.a[libstdc++.so.6].
13:56:15  	Symbol _ZTVNSt6thread6_StateE (number 359) is not exported from dependent
13:56:15  	  module /opt/freeware/lib/libstdc++.a[libstdc++.so.6].
13:56:15  	Symbol _ZNSt6thread4joinEv (number 379) is not exported from dependent
13:56:15  	  module /opt/freeware/lib/libstdc++.a[libstdc++.so.6].
...
```