### PR TITLE
Fix syntax error in sbin/prepareWorkspace.sh

### DIFF
--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -56,7 +56,7 @@ checkoutAndCloneOpenJDKGitRepo() {
     # eg. origin git@github.com:adoptopenjdk/openjdk-jdk.git (fetch)
     # eg. origin https://github.com/alibaba/dragonwell8.git (fetch)
     # eg. origin https://github.com/feilongjiang/bishengjdk-11-mirror.git (fetch)
-    if [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_DRAGONWELL}" || "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_BISHENG}" ]; then
+    if [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_DRAGONWELL}" -o "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_BISHENG}" ]; then
       git --git-dir "${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/.git" remote -v | grep "origin.*fetch" | egrep "${BUILD_CONFIG[REPOSITORY]}.git|${BUILD_CONFIG[REPOSITORY]}\s"
     else
       git --git-dir "${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/.git" remote -v | grep "origin.*fetch" | grep "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" | egrep "${BUILD_CONFIG[REPOSITORY]}.git|${BUILD_CONFIG[REPOSITORY]}\s"


### PR DESCRIPTION
Probably introduced as part of https://github.com/AdoptOpenJDK/openjdk-build/pull/2485/files

I've seen this a couple of times today:

```
/home/sxa/dw/openjdk-build/sbin/prepareWorkspace.sh: line 59: [: missing `]'
/home/sxa/dw/openjdk-build/sbin/prepareWorkspace.sh: line 59: dragonwell: command not found
```

Signed-off-by: Stewart X Addison <sxa@redhat.com>