### PR TITLE
Fix gcc-9.3 build error and limit gcc 9.3 on dragonwell aarch64

### DIFF
--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -137,10 +137,10 @@ if [ $executedJavaVersion -ne 0 ]; then
     exit 1
 fi
 
-if [ "${VARIANT}" == "${BUILD_VARIANT_DRAGONWELL}" ] && [ "$JAVA_FEATURE_VERSION" -eq 11 ] && [ -r /usr/local/gcc9/ ]; then
+if [ "${VARIANT}" == "${BUILD_VARIANT_DRAGONWELL}" ] && [ "$JAVA_FEATURE_VERSION" -eq 11 ] && [ -r /usr/local/gcc9/ ] && [ "${ARCHITECTURE}" == "aarch64" ]; then
   export PATH=/usr/local/gcc9/bin:$PATH
   export CC=/usr/local/gcc9/bin/gcc-9.3
-  export CC=/usr/local/gcc9/bin/g++-9.3
+  export CXX=/usr/local/gcc9/bin/g++-9.3
 elif [ -r /usr/local/gcc/bin/gcc-7.5 ]; then
   export PATH=/usr/local/gcc/bin:$PATH
   [ -r /usr/local/gcc/bin/gcc-7.5 ] && export CC=/usr/local/gcc/bin/gcc-7.5


### PR DESCRIPTION
Related issue: https://github.com/AdoptOpenJDK/openjdk-build/issues/2501
In https://ci.adoptopenjdk.net/view/Failing%20Builds/job/build-scripts/job/jobs/job/jdk11u/job/jdk11u-linux-x64-dragonwell/164/console , we should be using 
```
CC=/usr/local/gcc9/bin/gcc-9.3
```
Also, limit GCC only on  aarch64 platform