### PR TITLE
De-duplicate RISCV cross compile code and allow native builds too

### DIFF
--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -155,23 +155,17 @@ if which ccache 2> /dev/null; then
   export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --enable-ccache"
 fi
 
-if [ "${ARCHITECTURE}" == "riscv64" -a "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]; then
-  echo RISCV cross-compilation ... Downloading latest nightly OpenJ9/x64 as build JDK
-  export BUILDJDK=$WORKSPACE/buildjdk
-  rm -rf "$BUILDJDK"
-  mkdir "$BUILDJDK"
-  wget -O - "https://api.adoptopenjdk.net/v3/binary/latest/${JAVA_FEATURE_VERSION}/ea/linux/x64/jdk/openj9/normal/adoptopenjdk" | tar xpzf - --strip-components=1 -C "$BUILDJDK"
-  "$BUILDJDK/bin/java" -version 2>&1 | sed 's/^/CROSSBUILD JDK > /g'
-  export RISCV64=/opt/riscv_toolchain_linux
-  export LD_LIBRARY_PATH=$RISCV64/lib64
-  export PATH="$RISCV64/bin:$PATH"
-  # riscv has to use a cross compiler
-  export CC=$RISCV64/bin/riscv64-unknown-linux-gnu-gcc
-  export CXX=$RISCV64/bin/riscv64-unknown-linux-gnu-g++
-  CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --disable-ddr --openjdk-target=riscv64-unknown-linux-gnu --with-sysroot=/opt/fedora28_riscv_root --with-boot-jdk=$JDK_BOOT_DIR --with-build-jdk=$BUILDJDK"
-  BUILD_ARGS="${BUILD_ARGS} -F"
-elif [ "${ARCHITECTURE}" == "riscv64" -a "${VARIANT}" == "${BUILD_VARIANT_BISHENG}" ]; then
-  echo Bisheng RISCV cross-compilation ... 
+# If we are in a cross compilation environment for RISC-V
+if [ "${ARCHITECTURE}" == "riscv64" -a "`uname -a`" == "x86_x64" ]; then
+  if [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]; then
+    echo RISCV cross-compilation ... Downloading latest nightly OpenJ9/x64 as build JDK
+    export BUILDJDK=$WORKSPACE/buildjdk
+    rm -rf "$BUILDJDK"
+    mkdir "$BUILDJDK"
+    wget -O - "https://api.adoptopenjdk.net/v3/binary/latest/${JAVA_FEATURE_VERSION}/ea/linux/x64/jdk/openj9/normal/adoptopenjdk" | tar xpzf - --strip-components=1 -C "$BUILDJDK"
+    "$BUILDJDK/bin/java" -version 2>&1 | sed 's/^/CROSSBUILD JDK > /g'
+  fi
+  echo RISC-V cross-compilation ... 
   export RISCV64=/opt/riscv_toolchain_linux
   export LD_LIBRARY_PATH=$RISCV64/lib64
   export PATH="$RISCV64/bin:$PATH"
@@ -180,5 +174,6 @@ elif [ "${ARCHITECTURE}" == "riscv64" -a "${VARIANT}" == "${BUILD_VARIANT_BISHEN
   export CXX=$RISCV64/bin/riscv64-unknown-linux-gnu-g++
   CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --openjdk-target=riscv64-unknown-linux-gnu --with-sysroot=/opt/fedora28_riscv_root --with-boot-jdk=$JDK_BOOT_DIR"
   BUILD_ARGS="${BUILD_ARGS} -F"
+  [ ! -x "$CXX" ] && echo "RISC-V cross compiler $CXX does not exist on this system - cannot continue" && exit 1
 fi
 


### PR DESCRIPTION
Currently the builds scripts are hard coded to build using a cross-compiler on RISC-V.

While this is fine for OpenJ9, this is not curently testd for Bisheng (https://github.com/AdoptOpenJDK/openjdk-build/issues/2420) therefore this PR will detect if we are building for a RISC-V target on an x86_64 host and if not it will disable the cross compiler options.

Alternative options: Use "if not riscv64" instead of "if x86_64" although I doubt anyone's going to try and cross compile elsewhere, and if they do then the message will be the same as it is if they try the same trick elsewhere :-)

Signed-off-by: Stewart X Addison <sxa@redhat.com>