### PR TITLE
Revert "windows: switch aarch64 builds to use correct boot jdk version"

### DIFF
--- a/build-farm/platform-specific-configurations/windows.sh
+++ b/build-farm/platform-specific-configurations/windows.sh
@@ -27,8 +27,8 @@ export OPENSSL_VERSION=1.1.1j
 
 TOOLCHAIN_VERSION=""
 
-if [ "$ARCHITECTURE" == "aarch64" ] && [ "$JAVA_FEATURE_VERSION" == 16 ]; then
-  # Windows aarch64 jdk16 cross compiles requires same version boot jdk
+if [ "$ARCHITECTURE" == "aarch64" ]; then
+  # Windows aarch64 cross compiles requires same version boot jdk
   BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION))"
 else
   BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION-1))"


### PR DESCRIPTION
Reverts AdoptOpenJDK/openjdk-build#2494

Partially fixes https://github.com/AdoptOpenJDK/openjdk-build/issues/2511