### PR TITLE
Fix RISC-V cross-compilation environment detection

### DIFF
--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -156,7 +156,7 @@ if which ccache 2> /dev/null; then
 fi
 
 # If we are in a cross compilation environment for RISC-V
-if [ "${ARCHITECTURE}" == "riscv64" -a "`uname -a`" == "x86_x64" ]; then
+if [ "${ARCHITECTURE}" == "riscv64" -a "`uname -m`" == "x86_64" ]; then
   if [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]; then
     echo RISCV cross-compilation ... Downloading latest nightly OpenJ9/x64 as build JDK
     export BUILDJDK=$WORKSPACE/buildjdk


### PR DESCRIPTION
Blatant error that didn't get picked up in reviews of https://github.com/AdoptOpenJDK/openjdk-build/pull/2509 ;-)

Luckily there wasn't a JDK11 build last night as this would have broken RISC-V since it was merged in the evening (something that #2504 would likely have helped with :-P )