### PR TITLE
Fixup RISC-V cross-compiler check so it doesn't fail with set -e

### DIFF
--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -174,6 +174,6 @@ if [ "${ARCHITECTURE}" == "riscv64" -a "`uname -m`" == "x86_64" ]; then
   export CXX=$RISCV64/bin/riscv64-unknown-linux-gnu-g++
   CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --openjdk-target=riscv64-unknown-linux-gnu --with-sysroot=/opt/fedora28_riscv_root --with-boot-jdk=$JDK_BOOT_DIR"
   BUILD_ARGS="${BUILD_ARGS} -F"
-  [ ! -x "$CXX" ] && echo "RISC-V cross compiler $CXX does not exist on this system - cannot continue" && exit 1
+  [ -x "$CXX" ] || echo "RISC-V cross compiler $CXX does not exist on this system - cannot continue" && exit 1
 fi
 


### PR DESCRIPTION
The original check of `[ ! -x "$CXX" ]` returns false when the location exists, so the `set -e` causes the script to fail at that point which is not the desired behaviour. This reverses the logic so it works as expected. I'm on a roll today ...

This needs to be put in before the nightly builds

Signed-off-by: Stewart X Addison <sxa@redhat.com>