### PR TITLE
Unbreak RISC-V OpenJ9 build

### DIFF
--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -173,7 +173,7 @@ if [ "${ARCHITECTURE}" == "riscv64" -a "`uname -m`" == "x86_64" ]; then
   export CC=$RISCV64/bin/riscv64-unknown-linux-gnu-gcc
   export CXX=$RISCV64/bin/riscv64-unknown-linux-gnu-g++
   CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --openjdk-target=riscv64-unknown-linux-gnu --with-sysroot=/opt/fedora28_riscv_root --with-boot-jdk=$JDK_BOOT_DIR"
-  BUILD_ARGS="${BUILD_ARGS} -F"
+  BUILD_ARGS="${BUILD_ARGS} --cross-compile -F"
   if [ ! -x "$CXX" ]; then
     echo "RISC-V cross compiler CXX=$CXX does not exist on this system - cannot continue"
     exit 1

--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -158,25 +158,24 @@ fi
 # If we are in a cross compilation environment for RISC-V
 if [ "${ARCHITECTURE}" == "riscv64" -a "`uname -m`" == "x86_64" ]; then
   if [ "${VARIANT}" == "${BUILD_VARIANT_OPENJ9}" ]; then
-    echo RISCV cross-compilation ... Downloading latest nightly OpenJ9/x64 as build JDK
-    export BUILDJDK=$WORKSPACE/buildjdk
+    export BUILDJDK=${WORKSPACE:-$PWD}/buildjdk
+    echo RISCV cross-compilation for OpenJ9 ... Downloading required nightly OpenJ9/x64 as build JDK to $BUILDJDK
     rm -rf "$BUILDJDK"
     mkdir "$BUILDJDK"
     wget -O - "https://api.adoptopenjdk.net/v3/binary/latest/${JAVA_FEATURE_VERSION}/ea/linux/x64/jdk/openj9/normal/adoptopenjdk" | tar xpzf - --strip-components=1 -C "$BUILDJDK"
     "$BUILDJDK/bin/java" -version 2>&1 | sed 's/^/CROSSBUILD JDK > /g'
+    CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-build-jdk=$BUILDJDK --disable-ddr"
   fi
-  echo RISC-V cross-compilation ... 
+  echo RISC-V cross-compilation setup ...  Setting RISCV64, LD_LIBRARY_PATH, PATH, CC, CXX
   export RISCV64=/opt/riscv_toolchain_linux
   export LD_LIBRARY_PATH=$RISCV64/lib64
   export PATH="$RISCV64/bin:$PATH"
-  # riscv has to use a cross compiler
   export CC=$RISCV64/bin/riscv64-unknown-linux-gnu-gcc
   export CXX=$RISCV64/bin/riscv64-unknown-linux-gnu-g++
   CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --openjdk-target=riscv64-unknown-linux-gnu --with-sysroot=/opt/fedora28_riscv_root --with-boot-jdk=$JDK_BOOT_DIR"
   BUILD_ARGS="${BUILD_ARGS} -F"
   if [ ! -x "$CXX" ]; then
-    echo "RISC-V cross compiler $CXX does not exist on this system - cannot continue"
+    echo "RISC-V cross compiler CXX=$CXX does not exist on this system - cannot continue"
     exit 1
   fi
 fi
-

--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -162,7 +162,7 @@ if [ "${ARCHITECTURE}" == "riscv64" -a "`uname -m`" == "x86_64" ]; then
     echo RISCV cross-compilation for OpenJ9 ... Downloading required nightly OpenJ9/x64 as build JDK to $BUILDJDK
     rm -rf "$BUILDJDK"
     mkdir "$BUILDJDK"
-    wget -O - "https://api.adoptopenjdk.net/v3/binary/latest/${JAVA_FEATURE_VERSION}/ea/linux/x64/jdk/openj9/normal/adoptopenjdk" | tar xpzf - --strip-components=1 -C "$BUILDJDK"
+    wget -q -O - "https://api.adoptopenjdk.net/v3/binary/latest/${JAVA_FEATURE_VERSION}/ea/linux/x64/jdk/openj9/normal/adoptopenjdk" | tar xpzf - --strip-components=1 -C "$BUILDJDK"
     "$BUILDJDK/bin/java" -version 2>&1 | sed 's/^/CROSSBUILD JDK > /g'
     CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-build-jdk=$BUILDJDK --disable-ddr"
   fi


### PR DESCRIPTION
We lost the `--disable-ddr` and build JDK options required for OpenJ9 in https://github.com/AdoptOpenJDK/openjdk-build/pull/2509/files - this reinstates them to allow it to build properly again.

Running some tests to verify but I'm confident this will fix everything. Will also need https://github.com/AdoptOpenJDK/ci-jenkins-pipelines/pull/81 but I'm confident that this will end up with the simplest code that will build OpenJ9 and the Bisheng RISC-V builds in the desired tested environments and configurations.

Please leave me to merge this once after review to ensure I've completed testing.