### PR TITLE
Allow other sign tools via param SIGN_TOOL

### DIFF
--- a/build-farm/sign-releases.sh
+++ b/build-farm/sign-releases.sh
@@ -18,6 +18,7 @@
 BUILD_ARGS=${BUILD_ARGS:-""}
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+export SIGN_TOOL
 export OPERATING_SYSTEM
 
 if [ "${OPERATING_SYSTEM}" == "mac" ] ; then

--- a/sign.sh
+++ b/sign.sh
@@ -78,7 +78,13 @@ signRelease()
         for SERVER in $TIMESTAMPSERVERS; do
           if [ "$STAMPED" = "false" ]; then
             echo "Signing $f using $SERVER"
-            if "$signToolPath" sign /f "${SIGNING_CERTIFICATE}" /p "$SIGN_PASSWORD" /fd SHA256 /t "${SERVER}" "$f"; then
+            if [ "$SIGN_TOOL" = "ucl" ]; then
+              ucl sign-code --file "$f" -n WindowsSHA -t "${SERVER}" --hash SHA256
+            else
+              "$signToolPath" sign /f "${SIGNING_CERTIFICATE}" /p "$SIGN_PASSWORD" /fd SHA256 /t "${SERVER}" "$f"
+            fi
+            RC=$?
+            if [ $RC -eq 0 ]; then
               STAMPED=true
             else
               echo "RETRYWARNING: Failed to sign ${f} at $(date +%T): Possible timestamp server error at ${SERVER} - Trying new server in 5 seconds"


### PR DESCRIPTION
Add param SIGN_TOOL that will allow other signing
tools to be used.
Add case for Windows "ucl" sign tool.
Default to signtool.exe on Windows.

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>