### PR TITLE
Add warning if AIX ulimit -n is too low

### DIFF
--- a/build-farm/platform-specific-configurations/aix.sh
+++ b/build-farm/platform-specific-configurations/aix.sh
@@ -20,6 +20,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # AIX default ulimit is frequently less than we need to clone the LTS JDK repositories
 FILESIZELIMIT=$(ulimit)
 if [ "$FILESIZELIMIT" != "unlimited" ]; then
+  # Set to ~2GB as this works for the AIX hosts we have as of April 2021
   if [ "$FILESIZELIMIT" -lt 2097150 ]; then
     echo "WARNING: MAXIMUM USER FILE SIZE (ulimit -n) IS $FILESIZELIMIT (<2097150) - GIT MAY HAVE PROBLEMS CLONING"
     sleep 5

--- a/build-farm/platform-specific-configurations/aix.sh
+++ b/build-farm/platform-specific-configurations/aix.sh
@@ -16,6 +16,16 @@
 
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# AIX default ulimit is frequently less than we need to clone the LTS JDK repositories
+FILESIZELIMIT=$(ulimit)
+if [ "$FILESIZELIMIT" != "unlimited" ]; then
+  if [ "$FILESIZELIMIT" -lt 2097150 ]; then
+    echo "WARNING: MAXIMUM USER FILE SIZE (ulimit -n) IS $FILESIZELIMIT (<2097150) - GIT MAY HAVE PROBLEMS CLONING"
+    sleep 5
+  fi
+fi
+
 # Send temporary build files to the ramdisk for performance
 if [ -r /ramdisk0/build/tmp ]; then
   echo Using /ramdisk0/build/tmp for temporary files \(Clearing it out first...\)


### PR DESCRIPTION
Warn user if AIX ulimit is too low to perform the git checkout operations.
For all but JDK11, the default AIX limit of `1048575` should (only just for JDK8 - it needs 860Mb at the time of writing) work. Our jenkins users have this limit larger by defualt, but for anyone running our scripts themselves, this will warn them and pause to try and encourage to read the message otherwise they are likely to end up with things like this:
```
Cloning into 'openjdk-jdk11u'...
fatal: write error: A file cannot be larger than the value set by ulimit.
fatal: index-pack failed
```