### PR TITLE
add support for Bisheng JDK8 and 8/11 on non-RISCV platforms

### DIFF
--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -159,6 +159,11 @@ elif [ -r /usr/bin/gcc-7 ]; then
   [ -r /usr/bin/g++-7 ] && export CXX=/usr/bin/g++-7
 fi
 
+# Bisheng on aarch64 has a KAE option which requires openssl 1.1.1 to be used
+if [ "${VARIANT}" == "${BUILD_VARIANT_BISHENG}" ] && [ -x /usr/local/openssl-1.1.1/lib/libcrypto.so.1.1 ]; then
+  export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-extra-cflags=-I/usr/local/openssl-1.1.1/include  --with-extra-cxxflags=-I/usr/local/openssl-1.1.1/include --with-extra-ldflags=-L/usr/local/openssl-1.1.1/lib"
+fi
+
 if which ccache 2> /dev/null; then
   export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --enable-ccache"
 fi

--- a/configureBuild.sh
+++ b/configureBuild.sh
@@ -168,7 +168,7 @@ setRepository() {
   elif [[ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_DRAGONWELL}" ]]; then
     suffix="alibaba/dragonwell${BUILD_CONFIG[OPENJDK_CORE_VERSION]/jdk/}"
   elif [[ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_BISHENG}" ]]; then
-    suffix="openeuler-mirror/bishengjdk-${BUILD_CONFIG[OPENJDK_CORE_VERSION]:3}"
+    suffix="openeuler-mirror/bishengjdk-11"
   elif [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK8_CORE_VERSION}" ] && [ "${BUILD_CONFIG[OS_ARCHITECTURE]}" == "armv7l" ]; then
     suffix="adoptopenjdk/openjdk-aarch32-jdk8u";
   elif [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK8_CORE_VERSION}" ] && [ "${BUILD_CONFIG[OS_ARCHITECTURE]}" == "aarch64" ]; then

--- a/configureBuild.sh
+++ b/configureBuild.sh
@@ -168,7 +168,7 @@ setRepository() {
   elif [[ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_DRAGONWELL}" ]]; then
     suffix="alibaba/dragonwell${BUILD_CONFIG[OPENJDK_CORE_VERSION]/jdk/}"
   elif [[ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_BISHENG}" ]]; then
-    suffix="openeuler-mirror/bishengjdk-11"
+    suffix="openeuler-mirror/bishengjdk-${BUILD_CONFIG[OPENJDK_CORE_VERSION]:3}"
   elif [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK8_CORE_VERSION}" ] && [ "${BUILD_CONFIG[OS_ARCHITECTURE]}" == "armv7l" ]; then
     suffix="adoptopenjdk/openjdk-aarch32-jdk8u";
   elif [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK8_CORE_VERSION}" ] && [ "${BUILD_CONFIG[OS_ARCHITECTURE]}" == "aarch64" ]; then

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -888,8 +888,11 @@ getFirstTagFromOpenJDKGitRepo() {
     TAG_SEARCH="dragonwell-*_jdk*"
   fi
 
-  if [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_BISHENG}" ]; then
+  if [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_BISHENG}" -a "${BUILD_CONFIG[OS_ARCHITECTORE]}" = "riscv64" ]; then
     TAG_SEARCH="jdk-*+*bisheng_riscv"
+  elif [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_BISHENG}" -a "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" == "8" ]; then
+    # Bisheng's JDK8 tags follow the aarch64 convention
+    TAG_SEARCH="aarch64-shenandoah-jdk8u*-b*"
   fi
 
   # If openj9 and the closed/openjdk-tag.gmk file exists which specifies what level the openj9 jdk code is based upon...

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -171,8 +171,8 @@ getOpenJdkVersion() {
     local bishengVerFile=${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/version.txt
     if [ -r "${bishengVerFile}" ]; then
       if [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK8_CORE_VERSION}" ]; then
-        local updateNum="$(cut -d'.' -f 2 <${bishengVerFile})"
-        local buildNum="$(cut -d'.' -f 5 <${bishengVerFile})"
+        local updateNum="$(cut -d'.' -f 2 <"${bishengVerFile}")"
+        local buildNum="$(cut -d'.' -f 5 <"${bishengVerFile}")"
         version="jdk8u${updateNum}-b${buildNum}"
       else
       local minorNum="$(cut -d'.' -f 2 <"${bishengVerFile}")"

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -170,10 +170,16 @@ getOpenJdkVersion() {
   elif [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_BISHENG}" ]; then
     local bishengVerFile=${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}/version.txt
     if [ -r "${bishengVerFile}" ]; then
+      if [ "${BUILD_CONFIG[OPENJDK_CORE_VERSION]}" == "${JDK8_CORE_VERSION}" ]; then
+        local updateNum="$(cut -d'.' -f 2 <${bishengVerFile})"
+        local buildNum="$(cut -d'.' -f 5 <${bishengVerFile})"
+        version="jdk8u${updateNum}-b${buildNum}"
+      else
       local minorNum="$(cut -d'.' -f 2 <"${bishengVerFile}")"
       local updateNum="$(cut -d'.' -f 3 <"${bishengVerFile}")"
       local buildNum="$(cut -d'.' -f 5 <"${bishengVerFile}")"
-      version="jdk-11.${minorNum}.${updateNum}+${buildNum}"
+        version="jdk-11.${minorNum}.${updateNum}+${buildNum}"
+      fi
     else
       version=${BUILD_CONFIG[TAG]:-$(getFirstTagFromOpenJDKGitRepo)}
       version=$(echo "$version" | cut -d'-' -f 2 | cut -d'_' -f 1)
@@ -888,7 +894,7 @@ getFirstTagFromOpenJDKGitRepo() {
     TAG_SEARCH="dragonwell-*_jdk*"
   fi
 
-  if [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_BISHENG}" -a "${BUILD_CONFIG[OS_ARCHITECTORE]}" = "riscv64" ]; then
+  if [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_BISHENG}" -a "${BUILD_CONFIG[OS_ARCHITECTURE]}" = "riscv64" ]; then
     TAG_SEARCH="jdk-*+*bisheng_riscv"
   elif [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_BISHENG}" -a "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" == "8" ]; then
     # Bisheng's JDK8 tags follow the aarch64 convention

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -894,7 +894,7 @@ getFirstTagFromOpenJDKGitRepo() {
     TAG_SEARCH="dragonwell-*_jdk*"
   fi
 
-  if [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_BISHENG}" ] && [ "${BUILD_CONFIG[OS_ARCHITECTURE]}" = "riscv64" ]; then
+  if [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_BISHENG}" ] && [ "${BUILD_CONFIG[OS_ARCHITECTURE]}" == "riscv64" ]; then
     TAG_SEARCH="jdk-*+*bisheng_riscv"
   elif [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_BISHENG}" ] && [ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" == "8" ]; then
     # Bisheng's JDK8 tags follow the aarch64 convention

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -175,9 +175,9 @@ getOpenJdkVersion() {
         local buildNum="$(cut -d'.' -f 5 <"${bishengVerFile}")"
         version="jdk8u${updateNum}-b${buildNum}"
       else
-      local minorNum="$(cut -d'.' -f 2 <"${bishengVerFile}")"
-      local updateNum="$(cut -d'.' -f 3 <"${bishengVerFile}")"
-      local buildNum="$(cut -d'.' -f 5 <"${bishengVerFile}")"
+        local minorNum="$(cut -d'.' -f 2 <"${bishengVerFile}")"
+        local updateNum="$(cut -d'.' -f 3 <"${bishengVerFile}")"
+        local buildNum="$(cut -d'.' -f 5 <"${bishengVerFile}")"
         version="jdk-11.${minorNum}.${updateNum}+${buildNum}"
       fi
     else
@@ -894,9 +894,9 @@ getFirstTagFromOpenJDKGitRepo() {
     TAG_SEARCH="dragonwell-*_jdk*"
   fi
 
-  if [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_BISHENG}" -a "${BUILD_CONFIG[OS_ARCHITECTURE]}" = "riscv64" ]; then
+  if [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_BISHENG}" ] && [ "${BUILD_CONFIG[OS_ARCHITECTURE]}" = "riscv64" ]; then
     TAG_SEARCH="jdk-*+*bisheng_riscv"
-  elif [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_BISHENG}" -a "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" == "8" ]; then
+  elif [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_BISHENG}" ] && [ "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" == "8" ]; then
     # Bisheng's JDK8 tags follow the aarch64 convention
     TAG_SEARCH="aarch64-shenandoah-jdk8u*-b*"
   fi

--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -888,11 +888,8 @@ getFirstTagFromOpenJDKGitRepo() {
     TAG_SEARCH="dragonwell-*_jdk*"
   fi
 
-  if [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_BISHENG}" -a "${BUILD_CONFIG[OS_ARCHITECTORE]}" = "riscv64" ]; then
+  if [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_BISHENG}" ]; then
     TAG_SEARCH="jdk-*+*bisheng_riscv"
-  elif [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_BISHENG}" -a "${BUILD_CONFIG[OPENJDK_FEATURE_NUMBER]}" == "8" ]; then
-    # Bisheng's JDK8 tags follow the aarch64 convention
-    TAG_SEARCH="aarch64-shenandoah-jdk8u*-b*"
   fi
 
   # If openj9 and the closed/openjdk-tag.gmk file exists which specifies what level the openj9 jdk code is based upon...

--- a/sbin/common/config_init.sh
+++ b/sbin/common/config_init.sh
@@ -349,8 +349,10 @@ function setBranch() {
     branch="master";
   elif [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_CORRETTO}" ]; then
     branch="develop";
-  elif [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_BISHENG}" ]; then
-    branch="risc-v"
+  elif [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_BISHENG}" -a "${BUILD_CONFIG[OS_ARCHITECTURE]}" == "riscv64" ]; then
+      branch="risc-v"
+  elif [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_BISHENG}" -a "${BUILD_CONFIG[OS_ARCHITECTURE]}" != "riscv64" ]; then
+      branch="master"
   fi
 
   BUILD_CONFIG[BRANCH]=${BUILD_CONFIG[BRANCH]:-$branch}

--- a/sbin/common/config_init.sh
+++ b/sbin/common/config_init.sh
@@ -349,9 +349,9 @@ function setBranch() {
     branch="master";
   elif [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_CORRETTO}" ]; then
     branch="develop";
-  elif [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_BISHENG}" -a "${BUILD_CONFIG[OS_ARCHITECTURE]}" == "riscv64" ]; then
+  elif [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_BISHENG}" ] && [ "${BUILD_CONFIG[OS_ARCHITECTURE]}" == "riscv64" ]; then
       branch="risc-v"
-  elif [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_BISHENG}" -a "${BUILD_CONFIG[OS_ARCHITECTURE]}" != "riscv64" ]; then
+  elif [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_BISHENG}" ] && [ "${BUILD_CONFIG[OS_ARCHITECTURE]}" != "riscv64" ]; then
       branch="master"
   fi
 

--- a/sbin/common/config_init.sh
+++ b/sbin/common/config_init.sh
@@ -349,10 +349,8 @@ function setBranch() {
     branch="master";
   elif [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_CORRETTO}" ]; then
     branch="develop";
-  elif [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_BISHENG}" ] && [ "${BUILD_CONFIG[OS_ARCHITECTURE]}" == "riscv64" ]; then
-      branch="risc-v"
-  elif [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_BISHENG}" ] && [ "${BUILD_CONFIG[OS_ARCHITECTURE]}" != "riscv64" ]; then
-      branch="master"
+  elif [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_BISHENG}" ]; then
+    branch="risc-v"
   fi
 
   BUILD_CONFIG[BRANCH]=${BUILD_CONFIG[BRANCH]:-$branch}

--- a/sbin/common/config_init.sh
+++ b/sbin/common/config_init.sh
@@ -350,7 +350,11 @@ function setBranch() {
   elif [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_CORRETTO}" ]; then
     branch="develop";
   elif [ "${BUILD_CONFIG[BUILD_VARIANT]}" == "${BUILD_VARIANT_BISHENG}" ]; then
-    branch="risc-v"
+    if [ "${BUILD_CONFIG[OS_ARCHITECTURE]}" == "riscv64" ] ; then
+      branch="risc-v"
+    else
+      branch="master"
+    fi
   fi
 
   BUILD_CONFIG[BRANCH]=${BUILD_CONFIG[BRANCH]:-$branch}


### PR DESCRIPTION
Fixes https://github.com/AdoptOpenJDK/openjdk-build/issues/2531 - I've removed the processing of `version.txt` from this because Bisheng doesn't have a `version.txt` that I can see - perhaps that needs to chnage?

Tag processing will need extra work before this is finalised - specifically [this line](https://github.com/AdoptOpenJDK/openjdk-build/blob/bd103bb984217fe49082db2a843692cf7880d6cb/sbin/build.sh#L873):
```
TAG_SEARCH="jdk-*+*bisheng_riscv"
```

Signed-off-by: Stewart X Addison <sxa@redhat.com>