### PR TITLE
checks for processes on Linux/arm32 builds for scaleway

### DIFF
--- a/build-farm/platform-specific-configurations/linux.sh
+++ b/build-farm/platform-specific-configurations/linux.sh
@@ -88,6 +88,11 @@ then
   then
     export BUILD_ARGS="${BUILD_ARGS} --processors $NUM_PROCESSORS"
   fi
+  echo === START OF ARM32 STATUS CHECK
+  uptime
+  free
+  ps -fu jenkins
+  echo === END OF ARM32 STATUS CHECK
 fi
 
 BOOT_JDK_VERSION="$((JAVA_FEATURE_VERSION-1))"


### PR DESCRIPTION
We often have scaleway build machines offline - most recently [here](https://github.com/AdoptOpenJDK/openjdk-infrastructure/issues/2061) - this is to add some extra checks that will be performed on those systems before a build is executed to see if there are any obvious problems. I do not anticipate this being permanent.
