### PR TITLE
make-adopt-build-farm: Use arm instead of armv7l

### DIFF
--- a/build-farm/make-adopt-build-farm.sh
+++ b/build-farm/make-adopt-build-farm.sh
@@ -29,6 +29,7 @@ if [ -z "$ARCHITECTURE"  ]; then
    if [ "$ARCHITECTURE" = "i386"    ]; then ARCHITECTURE=x64;        fi # Solaris/x64
    if [ "$ARCHITECTURE" = "sparc"   ]; then ARCHITECTURE=sparcv9;    fi # Solaris/SPARC
    if [ "$ARCHITECTURE" = "powerpc" ]; then ARCHITECTURE=ppc64;      fi # AIX
+   if [ "$ARCHITECTURE" = "armv7l"  ]; then ARCHITECTURE=arm;        fi # Linux/arm32
    echo ARCHITECTURE not defined - assuming $ARCHITECTURE
    export ARCHITECTURE
 fi


### PR DESCRIPTION
Found while verifying https://github.com/AdoptOpenJDK/openjdk-build/pull/2539. Introduced with the new autodetection in https://github.com/AdoptOpenJDK/openjdk-build/commit/3ec1ae9aa9d66114ee07be15205a2b6064c85101 (which isn't used by our pipelines)

While we use `armv7l` for `OS_ARCHITECTURE`, the `ARCHITECTURE` variables should be `arm` for arm32 builds.

Signed-off-by: Stewart X Addison <sxa@redhat.com>