### PR TITLE
Remove quotes from BUILD_CONFIG[SHALLOW_CLONE_OPTION]

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -110,7 +110,8 @@ getOpenJDKUpdateAndBuildVersion() {
     echo "Pulling latest tags and getting the latest update version using git fetch -q --tags ${BUILD_CONFIG[SHALLOW_CLONE_OPTION]}"
     # shellcheck disable=SC2154
     echo "NOTE: This can take quite some time!  Please be patient"
-    git fetch -q --tags "${BUILD_CONFIG[SHALLOW_CLONE_OPTION]}"
+    # shellcheck disable=SC2086
+    git fetch -q --tags ${BUILD_CONFIG[SHALLOW_CLONE_OPTION]}
     local openJdkVersion=$(getOpenJdkVersion)
     if [[ "${openJdkVersion}" == "" ]]; then
       # shellcheck disable=SC2154

--- a/sbin/prepareWorkspace.sh
+++ b/sbin/prepareWorkspace.sh
@@ -171,7 +171,8 @@ checkoutRequiredCodeToBuild() {
     else
       git remote set-branches --add origin "${BUILD_CONFIG[BRANCH]}" || rc=$?
       if [ $rc -eq 0 ]; then
-        git fetch --all "${BUILD_CONFIG[SHALLOW_CLONE_OPTION]}" || rc=$?
+        # shellcheck disable=SC2086
+        git fetch --all ${BUILD_CONFIG[SHALLOW_CLONE_OPTION]} || rc=$?
         if [ $rc -eq 0 ]; then
           git reset --hard "origin/${BUILD_CONFIG[BRANCH]}" || rc=$?
           if [ $rc -eq 0 ]; then
@@ -253,8 +254,8 @@ checkoutRequiredCodeToBuild() {
 setGitCloneArguments() {
   cd "${BUILD_CONFIG[WORKSPACE_DIR]}"
   local git_remote_repo_address="${BUILD_CONFIG[REPOSITORY]}.git"
-
-  GIT_CLONE_ARGUMENTS=("${BUILD_CONFIG[SHALLOW_CLONE_OPTION]}" "$git_remote_repo_address" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}")
+  # shellcheck disable=SC2206
+  GIT_CLONE_ARGUMENTS=(${BUILD_CONFIG[SHALLOW_CLONE_OPTION]} "$git_remote_repo_address" "${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/${BUILD_CONFIG[OPENJDK_SOURCE_DIR]}")
 }
 
 updateOpenj9Sources() {


### PR DESCRIPTION
When this value is empty ("") it will cause git commands
to fail because "" will be picked up as an argument

Introduced by 962e6febfeb

Signed-off-by: Adam Brousseau <adam.brousseau88@gmail.com>