### PR TITLE
Enable arch ppc64 for smoke tests

### DIFF
--- a/test/functional/buildAndPackage/playlist.xml
+++ b/test/functional/buildAndPackage/playlist.xml
@@ -33,6 +33,7 @@
         </impls>
          <vendors>
             <vendor>adoptopenjdk</vendor>
+            <vendor>alibaba</vendor>
         </vendors>
     </test>
     <test>

--- a/test/functional/buildAndPackage/playlist.xml
+++ b/test/functional/buildAndPackage/playlist.xml
@@ -33,7 +33,6 @@
         </impls>
          <vendors>
             <vendor>adoptopenjdk</vendor>
-            <vendor>alibaba</vendor>
         </vendors>
     </test>
     <test>

--- a/test/functional/buildAndPackage/src/net/adoptopenjdk/test/JdkPlatform.java
+++ b/test/functional/buildAndPackage/src/net/adoptopenjdk/test/JdkPlatform.java
@@ -62,6 +62,9 @@ public class JdkPlatform {
         if (arch.equals("aarch64")) {
             return Architecture.AARCH64;
         }
+        if (arch.equals("ppc64")) {
+            return Architecture.PPC64;
+        }
         if (arch.equals("ppc64le")) {
             return Architecture.PPC64LE;
         }
@@ -123,7 +126,7 @@ public class JdkPlatform {
     }
 
     enum Architecture {
-        ARM, AARCH64, PPC64LE, RISCV, RISCV64, SPARC32, SPARC64, S390X, X64, X86
+        ARM, AARCH64, PPC64, PPC64LE, RISCV, RISCV64, SPARC32, SPARC64, S390X, X64, X86
     }
 
     enum OperatingSystem {


### PR DESCRIPTION
Enable arch ppc64 for smoke tests

related https://github.com/adoptium/ci-jenkins-pipelines/issues/127

Signed-off-by: Sophia Guo <sophia.gwf@gmail.com>

