### PR TITLE
Update smoke test to work with openj9 jdk

### DIFF
--- a/test/functional/buildAndPackage/src/net/adoptopenjdk/test/CudaEnabledTest.java
+++ b/test/functional/buildAndPackage/src/net/adoptopenjdk/test/CudaEnabledTest.java
@@ -46,22 +46,18 @@ public class CudaEnabledTest {
         }
         if("Linux".contains(System.getProperty("os.name").split(" ")[0])) {
             if(getJDKVersion() == 8) {
-                prtLibDirectory += jreSubdir + "/lib/amd64/compressedrefs";
+                prtLibDirectory += jreSubdir + "/lib/amd64";
             } else {
-                prtLibDirectory += "/lib/compressedrefs";
+                prtLibDirectory += "/lib/default";
             }
         }
         //windows
         if("Windows".contains(System.getProperty("os.name").split(" ")[0])) {
             if(getJDKVersion() == 8) {
                 //jdk8 32: 
-                prtLibDirectory += jreSubdir + "/bin/compressedrefs";
-                if(!(new File(prtLibDirectory)).exists()) {
-                    //In case of a 32-bit build, or a non-cr build.
-                    prtLibDirectory = System.getProperty("java.home") + jreSubdir + "/bin/default";
-                }
+                prtLibDirectory += jreSubdir + "/bin/default";
             } else {
-                prtLibDirectory += "/bin/compressedrefs";
+                prtLibDirectory += "/bin/default";
             }
         }
 

--- a/test/functional/buildAndPackage/src/net/adoptopenjdk/test/VendorPropertiesTest.java
+++ b/test/functional/buildAndPackage/src/net/adoptopenjdk/test/VendorPropertiesTest.java
@@ -165,7 +165,7 @@ public class VendorPropertiesTest {
 
         @Override
         public void javaVmVendor(String value) {
-            assertEquals(value, "AdoptOpenJDK");
+            assertTrue(value.equals("AdoptOpenJDK") || value.equals("Eclipse OpenJ9"));
         }
 
         @Override


### PR DESCRIPTION
Update smoke test to work with openj9 jdk

Related: https://github.com/adoptium/ci-jenkins-pipelines/issues/127#issuecomment-819194309