### PR TITLE
Fix for BundledFreetypeTest on Windows

### DIFF
--- a/test/functional/buildAndPackage/src/net/adoptopenjdk/test/BundledFreetypeTest.java
+++ b/test/functional/buildAndPackage/src/net/adoptopenjdk/test/BundledFreetypeTest.java
@@ -30,17 +30,30 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 /**
- * Freetype needs to be bundled on Windows and macOS but should not be present on Linux or AIX.
+ * Freetype needs to be bundled on Windows and macOS
+ * but should not be present on Linux or AIX.
  *
- * @see <a href="https://github.com/AdoptOpenJDK/openjdk-build/issues/2133">AdoptOpenJDK enhancement request</a>
+ * @see <a href="https://github.com/AdoptOpenJDK/openjdk-build/issues/2133">
+ * AdoptOpenJDK enhancement request</a>
  */
 @Test(groups = {"level.extended"})
 public class BundledFreetypeTest {
 
-    private static final Logger LOGGER = Logger.getLogger(BundledFreetypeTest.class.getName());
+    /**
+     * Message logger for test debug output.
+     */
+    private static final Logger LOGGER
+        = Logger.getLogger(BundledFreetypeTest.class.getName());
 
+    /**
+     * This is used to identify the OS we're running on.
+     */
     private final JdkPlatform jdkPlatform = new JdkPlatform();
 
+    /**
+     * Test to ensure freetype is bundled with this build
+     * or not, depending on the platform.
+     */
     @Test
     public void freetypeOnlyBundledOnWindowsAndMacOS() throws IOException {
         String testJdkHome = System.getenv("TEST_JDK_HOME");
@@ -48,17 +61,24 @@ public class BundledFreetypeTest {
             throw new AssertionError("TEST_JDK_HOME is not set");
         }
 
-        Pattern freetypePattern = Pattern.compile("(.*)?freetype\\.(dll|dylib|so)$");
+        Pattern freetypePattern
+            = Pattern.compile("(.*)?freetype\\.(dll|dylib|so)$");
         Set<String> freetypeFiles = Files.walk(Paths.get(testJdkHome))
                 .map(Path::toString)
                 .filter(name -> freetypePattern.matcher(name).matches())
                 .collect(Collectors.toSet());
 
-        if (jdkPlatform.runsOn(OperatingSystem.MACOS) || jdkPlatform.runsOn(OperatingSystem.WINDOWS)) {
-            assertTrue(freetypeFiles.size() > 0, "Expected libfreetype to be bundled but is not.");
+        if (jdkPlatform.runsOn(OperatingSystem.MACOS)) {
+            assertTrue(freetypeFiles.size() > 0,
+              "Expected libfreetype.dylib to be bundled but it is not.");
+        } else if (jdkPlatform.runsOn(OperatingSystem.WINDOWS)) {
+            assertTrue(freetypeFiles.size() > 0,
+              "Expected freetype.dll to be bundled, but it is not.");
         } else {
-            LOGGER.info("Found freetype-related files: " + freetypeFiles.toString());
-            assertEquals(freetypeFiles.size(), 0, "Expected libfreetype not to be bundled but it is.");
+            LOGGER.info("Found freetype-related files: "
+                        + freetypeFiles.toString());
+            assertEquals(freetypeFiles.size(), 0,
+              "Expected libfreetype not to be bundled but it is.");
         }
     }
 }

--- a/test/functional/buildAndPackage/src/net/adoptopenjdk/test/BundledFreetypeTest.java
+++ b/test/functional/buildAndPackage/src/net/adoptopenjdk/test/BundledFreetypeTest.java
@@ -48,7 +48,7 @@ public class BundledFreetypeTest {
             throw new AssertionError("TEST_JDK_HOME is not set");
         }
 
-        Pattern freetypePattern = Pattern.compile("(.*)?libfreetype\\.(dll|dylib|so)$");
+        Pattern freetypePattern = Pattern.compile("(.*)?freetype\\.(dll|dylib|so)$");
         Set<String> freetypeFiles = Files.walk(Paths.get(testJdkHome))
                 .map(Path::toString)
                 .filter(name -> freetypePattern.matcher(name).matches())

--- a/test/functional/buildAndPackage/src/net/adoptopenjdk/test/package-info.java
+++ b/test/functional/buildAndPackage/src/net/adoptopenjdk/test/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This package contains a series of vendor-specific tests designed
+ * to verify various vendor-specific aspects of an openjdk build.
+ */
+
+package net.adoptopenjdk.test;


### PR DESCRIPTION
Currently, BundledFreetypeTest cannot find the freetype file it's
looking for on Windows, as that file is named "freetype.dll" (no lib).

Modifying the regex to match this, while still allowing
libfreetype.dylib (the macos file name).

Signed-off-by: Adam Farley <adfarley@redhat.com>