### PR TITLE
macOS: prevent m1 builds from cross compiling x64

### DIFF
--- a/build-farm/platform-specific-configurations/mac.sh
+++ b/build-farm/platform-specific-configurations/mac.sh
@@ -58,6 +58,8 @@ else
     if [ "${ARCHITECTURE}" == "x64" ]; then
       # We can only target 10.9 on intel macs
       export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --with-extra-cxxflags=-mmacosx-version-min=10.9"
+    elif [ "${ARCHITECTURE}" == "arm64" ]; then
+      export CONFIGURE_ARGS_FOR_ANY_PLATFORM="${CONFIGURE_ARGS_FOR_ANY_PLATFORM} --openjdk-target=aarch64-apple-darwin"
     fi
   fi
 fi


### PR DESCRIPTION
Fixes the bug reported in https://github.com/AdoptOpenJDK/openjdk-build/issues/1922#issuecomment-820747121

Essentially the arm64 macs were still cross-compiling for x64 rather than building on arm64

Confirmed to be fixed:

```bash
file java
java: Mach-O 64-bit executable arm64
```