### PR TITLE
Shenandoah present on win32

### DIFF
--- a/test/functional/buildAndPackage/src/net/adoptopenjdk/test/FeatureTests.java
+++ b/test/functional/buildAndPackage/src/net/adoptopenjdk/test/FeatureTests.java
@@ -64,6 +64,7 @@ public class FeatureTests {
                     || jdkPlatform.runsOn(OperatingSystem.LINUX, Architecture.X64)
                     || jdkPlatform.runsOn(OperatingSystem.MACOS, Architecture.X64)
                     || jdkPlatform.runsOn(OperatingSystem.MACOS, Architecture.AARCH64)
+                    || jdkPlatform.runsOn(OperatingSystem.WINDOWS, Architecture.X86)
                     || jdkPlatform.runsOn(OperatingSystem.WINDOWS, Architecture.X64)
                     || jdkPlatform.runsOn(OperatingSystem.WINDOWS, Architecture.AARCH64)
             ) {


### PR DESCRIPTION
As per the Shenandoah project webpage, if shenandoah is set as a
with-jvm-features option during pre-build configuration (which Adopt
does), then we should expect Shenandoah to be both present and
functional in the build.

My assumption is that Windows 32bit was simply skipped during smoke
test pre-deployment testing, and this problem was simply not seen
as a result.

Signed-off-by: Adam Farley <adfarley@redhat.com>