### PR TITLE
Enable manual setting of freetype location on windows

### DIFF
--- a/sbin/build.sh
+++ b/sbin/build.sh
@@ -381,10 +381,10 @@ configureFreetypeLocation() {
         jdk8* | jdk9* | jdk10*) freetypeDir=${BUILD_CONFIG[FREETYPE_DIRECTORY]:-"${BUILD_CONFIG[WORKSPACE_DIR]}/${BUILD_CONFIG[WORKING_DIR]}/installedfreetype"} ;;
         *) freetypeDir=${BUILD_CONFIG[FREETYPE_DIRECTORY]:-bundled} ;;
         esac
-
-        echo "setting freetype dir to ${freetypeDir}"
-        addConfigureArg "--with-freetype=" "${freetypeDir}"
       fi
+
+      echo "setting freetype dir to ${freetypeDir}"
+      addConfigureArg "--with-freetype=" "${freetypeDir}"
     fi
   fi
 }


### PR DESCRIPTION
This change solves a bug preventing us from manually specifying
the location of freetype on Windows.

This change also adds the "--with-freetype=bundled" configure
option to windows builds where the user has not specified the
location of freetype. While this is not necessary, it does add
clarity and consistency.

Signed-off-by: Adam Farley <adfarley@redhat.com>