### PR TITLE
Remove JFR expectation on AIX

### DIFF
--- a/test/functional/buildAndPackage/src/net/adoptopenjdk/test/FeatureTests.java
+++ b/test/functional/buildAndPackage/src/net/adoptopenjdk/test/FeatureTests.java
@@ -160,7 +160,9 @@ public class FeatureTests {
         }
         boolean shouldBePresent = false;
         if (jdkVersion.isNewerOrEqual(11) || jdkVersion.isNewerOrEqualSameFeature(8, 0, 262)) {
-            shouldBePresent = true;
+            if (!jdkPlatform.runsOn(OperatingSystem.AIX)) {
+                shouldBePresent = true;
+            }
         }
         LOGGER.info(String.format("Detected %s on %s, expect JFR to be present: %s",
                 jdkVersion, jdkPlatform, shouldBePresent));


### PR DESCRIPTION
...because JFR is not supported on AIX.

Signed-off-by: Adam Farley <adfarley@redhat.com>